### PR TITLE
Add component to collect elements for visits comparison

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.4.2",
         "@fortawesome/react-fontawesome": "^0.2.0",
         "@reduxjs/toolkit": "^2.0.1",
-        "@shlinkio/shlink-frontend-kit": "^0.4.0",
+        "@shlinkio/shlink-frontend-kit": "^0.4.1",
         "@shlinkio/shlink-js-sdk": "^0.2.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -1747,12 +1747,12 @@
       }
     },
     "node_modules/@shlinkio/shlink-frontend-kit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@shlinkio/shlink-frontend-kit/-/shlink-frontend-kit-0.4.0.tgz",
-      "integrity": "sha512-Z9GqIqc6iHGMs9GHEQ+ERv5NfdvnoReHJbz5WPgXMlVT0s5ooL7s0hdsR/zgppLVF0r8HsKLXKlKR8bMY8B22g==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@shlinkio/shlink-frontend-kit/-/shlink-frontend-kit-0.4.1.tgz",
+      "integrity": "sha512-opmcapGLe6rkEbn+vucHzvduYU4gm8o62DdJEuMrXBPmE2DWqJnZ65xuDnqgmBOQw6LEH7j5wiBToYbhmwLReA==",
       "peer": true,
       "dependencies": {
-        "classnames": "^2.3.2",
+        "clsx": "^2.0.0",
         "qs": "^6.11.2",
         "uuid": "^9.0.1"
       },

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.4.2",
     "@fortawesome/react-fontawesome": "^0.2.0",
     "@reduxjs/toolkit": "^2.0.1",
-    "@shlinkio/shlink-frontend-kit": "^0.4.0",
+    "@shlinkio/shlink-frontend-kit": "^0.4.1",
     "@shlinkio/shlink-js-sdk": "^0.2.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/index.scss
+++ b/src/index.scss
@@ -6,3 +6,9 @@
 .input-group-text.input-group-text {
   border-color: var(--input-border-color);
 }
+
+.top-sticky {
+  position: sticky;
+  top: $headerHeight;
+  z-index: 10;
+}

--- a/src/short-urls/EditShortUrl.tsx
+++ b/src/short-urls/EditShortUrl.tsx
@@ -1,10 +1,9 @@
 import { faArrowLeft } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { Message, parseQuery, Result } from '@shlinkio/shlink-frontend-kit';
+import { Message, Result, useParsedQuery } from '@shlinkio/shlink-frontend-kit';
 import type { FC } from 'react';
 import { useEffect, useMemo } from 'react';
 import { ExternalLink } from 'react-external-link';
-import { useLocation } from 'react-router-dom';
 import { Button, Card } from 'reactstrap';
 import type { ShlinkEditShortUrlData } from '../api-contract';
 import { ShlinkApiError } from '../common/ShlinkApiError';
@@ -34,12 +33,11 @@ const EditShortUrl: FCWithDeps<EditShortUrlProps, EditShortUrlDeps> = (
   { shortUrlDetail, getShortUrlDetail, shortUrlEdition, editShortUrl },
 ) => {
   const { ShortUrlForm } = useDependencies(EditShortUrl);
-  const { search } = useLocation();
+  const { domain } = useParsedQuery<{ domain?: string }>();
   const shortCode = useDecodedShortCodeFromParams();
   const goBack = useGoBack();
   const { loading, error, errorData, shortUrl } = shortUrlDetail;
   const { saving, saved, error: savingError, errorData: savingErrorData } = shortUrlEdition;
-  const { domain } = parseQuery<{ domain?: string }>(search);
   const shortUrlCreationSettings = useSetting('shortUrlCreation');
   const initialState = useMemo(
     () => shortUrlDataFromShortUrl(shortUrl, shortUrlCreationSettings),

--- a/src/short-urls/ShortUrlsList.tsx
+++ b/src/short-urls/ShortUrlsList.tsx
@@ -13,6 +13,11 @@ import { Topics } from '../mercure/helpers/Topics';
 import { useFeature } from '../utils/features';
 import { useSettings } from '../utils/settings';
 import { TableOrderIcon } from '../utils/table/TableOrderIcon';
+import { VisitsComparisonCollector } from '../visits/visits-comparison/VisitsComparisonCollector';
+import {
+  useVisitsComparison,
+  VisitsComparisonProvider,
+} from '../visits/visits-comparison/VisitsComparisonContext';
 import type { ShortUrlsOrder, ShortUrlsOrderableFields } from './data';
 import { useShortUrlsQuery } from './helpers/hooks';
 import { Paginator } from './Paginator';
@@ -83,6 +88,7 @@ const ShortUrlsList: FCWithDeps<ShortUrlsListProps, ShortUrlsListDeps> = boundTo
 
     return { field, dir };
   }, [doExcludeBots, supportsExcludingBots]);
+  const visitsComparisonValue = useVisitsComparison();
 
   useEffect(() => {
     listShortUrls({
@@ -111,13 +117,14 @@ const ShortUrlsList: FCWithDeps<ShortUrlsListProps, ShortUrlsListDeps> = boundTo
   ]);
 
   return (
-    <>
+    <VisitsComparisonProvider value={visitsComparisonValue}>
       <ShortUrlsFilteringBar
         shortUrlsAmount={shortUrlsList.shortUrls?.pagination.totalItems}
         order={actualOrderBy}
         handleOrderBy={handleOrderBy}
         className="mb-3"
       />
+      <VisitsComparisonCollector type="short-urls" className="mb-3" />
       <Card body className="pb-0">
         <ShortUrlsTable
           shortUrlsList={shortUrlsList}
@@ -127,7 +134,8 @@ const ShortUrlsList: FCWithDeps<ShortUrlsListProps, ShortUrlsListDeps> = boundTo
         />
         <Paginator paginator={pagination} currentQueryString={location.search} />
       </Card>
-    </>
+    </VisitsComparisonProvider>
+
   );
 }, () => [Topics.visits]);
 

--- a/src/short-urls/helpers/ShortUrlsRowMenu.tsx
+++ b/src/short-urls/helpers/ShortUrlsRowMenu.tsx
@@ -42,8 +42,8 @@ const ShortUrlsRowMenu: FCWithDeps<ShortUrlsRowMenuProps, ShortUrlsRowMenuDeps> 
       {visitsComparison && (
         <>
           <DropdownItem
-            disabled={visitsComparison.visitsToCompare.some(({ name }) => name === shortUrl.shortUrl)}
-            onClick={() => visitsComparison.addVisitToCompare({
+            disabled={visitsComparison.itemsToCompare.some(({ name }) => name === shortUrl.shortUrl)}
+            onClick={() => visitsComparison.addItemToCompare({
               name: shortUrl.shortUrl,
               query: shortUrlToQuery(shortUrl),
             })}

--- a/src/short-urls/helpers/ShortUrlsRowMenu.tsx
+++ b/src/short-urls/helpers/ShortUrlsRowMenu.tsx
@@ -1,4 +1,5 @@
 import {
+  faChartLine as lineChartIcon,
   faChartPie as pieChartIcon,
   faEdit as editIcon,
   faMinusCircle as deleteIcon,
@@ -11,7 +12,9 @@ import { DropdownItem } from 'reactstrap';
 import type { ShlinkShortUrl } from '../../api-contract';
 import type { FCWithDeps } from '../../container/utils';
 import { componentFactory, useDependencies } from '../../container/utils';
+import { useVisitsToCompare } from '../../visits/visits-comparison/VisitsComparisonContext';
 import type { ShortUrlModalProps } from '../data';
+import { shortUrlToQuery } from './index';
 import { ShortUrlDetailLink } from './ShortUrlDetailLink';
 
 type ShortUrlsRowMenuProps = {
@@ -29,12 +32,29 @@ const ShortUrlsRowMenu: FCWithDeps<ShortUrlsRowMenuProps, ShortUrlsRowMenuDeps> 
   const { DeleteShortUrlModal, QrCodeModal } = useDependencies(ShortUrlsRowMenu);
   const [isQrModalOpen,, openQrCodeModal, closeQrCodeModal] = useToggle();
   const [isDeleteModalOpen,, openDeleteModal, closeDeleteModal] = useToggle();
+  const visitsComparison = useVisitsToCompare();
 
   return (
     <RowDropdownBtn minWidth={190}>
       <DropdownItem tag={ShortUrlDetailLink} shortUrl={shortUrl} suffix="visits" asLink>
         <FontAwesomeIcon icon={pieChartIcon} fixedWidth /> Visit stats
       </DropdownItem>
+      {visitsComparison && (
+        <>
+          <DropdownItem
+            disabled={visitsComparison.visitsToCompare.some(({ name }) => name === shortUrl.shortUrl)}
+            onClick={() => visitsComparison.addVisitToCompare({
+              name: shortUrl.shortUrl,
+              query: shortUrlToQuery(shortUrl),
+            })}
+            data-testid="add-visit-to-compare-button"
+          >
+            <FontAwesomeIcon icon={lineChartIcon} fixedWidth /> Compare visits
+          </DropdownItem>
+
+          <DropdownItem divider tag="hr" />
+        </>
+      )}
 
       <DropdownItem tag={ShortUrlDetailLink} shortUrl={shortUrl} suffix="edit" asLink>
         <FontAwesomeIcon icon={editIcon} fixedWidth /> Edit short URL

--- a/src/short-urls/helpers/hooks.ts
+++ b/src/short-urls/helpers/hooks.ts
@@ -1,10 +1,9 @@
-import { orderToString, stringifyQuery, stringToOrder } from '@shlinkio/shlink-frontend-kit';
+import { orderToString, stringifyQuery, stringToOrder, useParsedQuery } from '@shlinkio/shlink-frontend-kit';
 import { useCallback, useMemo } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import type { TagsFilteringMode } from '../../api-contract';
 import type { BooleanString } from '../../utils/helpers';
 import { parseOptionalBooleanToString } from '../../utils/helpers';
-import { useParsedQuery } from '../../utils/helpers/hooks';
 import { useRoutesPrefix } from '../../utils/routesPrefix';
 import type { ShortUrlsOrder, ShortUrlsOrderableFields } from '../data';
 import { urlDecodeShortCode } from './index';

--- a/src/short-urls/helpers/index.ts
+++ b/src/short-urls/helpers/index.ts
@@ -2,6 +2,7 @@ import type { ShlinkCreateShortUrlData, ShlinkShortUrl } from '../../api-contrac
 import type { OptionalString } from '../../utils/helpers';
 import type { ShortUrlCreationSettings } from '../../utils/settings';
 import { DEFAULT_DOMAIN } from '../../visits/reducers/domainVisits';
+import type { ShortUrlIdentifier } from '../data';
 
 export const shortUrlMatches = (shortUrl: ShlinkShortUrl, shortCode: string, domain: OptionalString): boolean => {
   if (domain === undefined || domain === null) {
@@ -49,8 +50,31 @@ export const shortUrlDataFromShortUrl = (
   };
 };
 
-const MULTI_SEGMENT_SEPARATOR = '__';
+/**
+ * Converts a short code into a valid URL param, replacing bars from multi-segment slugs with double underscore
+ */
+export const urlEncodeShortCode = (shortCode: string): string => shortCode.replaceAll('/', '__');
 
-export const urlEncodeShortCode = (shortCode: string): string => shortCode.replaceAll('/', MULTI_SEGMENT_SEPARATOR);
+/**
+ * Converts a URL param representing a short code into its corresponding short code, by replacing double underscores
+ * (if any) with bars, which means it's a multi-segment slug
+ */
+export const urlDecodeShortCode = (shortCode: string): string => shortCode.replaceAll('__', '/');
 
-export const urlDecodeShortCode = (shortCode: string): string => shortCode.replaceAll(MULTI_SEGMENT_SEPARATOR, '/');
+/**
+ * String representation of a short URL, so that it can be used as query param
+ */
+export const shortUrlToQuery = ({ domain, shortCode }: ShortUrlIdentifier): string =>
+  `${domain ?? DEFAULT_DOMAIN}__${shortCode}`;
+
+/**
+ * String representation of a short URL, so that it can be used as query param
+ */
+export const queryToShortUrl = (shortUrlQuery: string): ShortUrlIdentifier => {
+  const [domain, shortCode] = shortUrlQuery.split('__');
+  if (!shortCode) {
+    throw new Error(`It was not possible to parse domain and short code from "${shortUrlQuery}"`);
+  }
+
+  return { domain: domain === DEFAULT_DOMAIN ? null : domain, shortCode };
+};

--- a/src/tags/TagsTable.tsx
+++ b/src/tags/TagsTable.tsx
@@ -1,8 +1,7 @@
 import { splitEvery } from '@shlinkio/data-manipulation';
-import { parseQuery, SimpleCard } from '@shlinkio/shlink-frontend-kit';
+import { SimpleCard, useParsedQuery } from '@shlinkio/shlink-frontend-kit';
 import type { FC } from 'react';
 import { useEffect, useRef } from 'react';
-import { useLocation } from 'react-router-dom';
 import type { FCWithDeps } from '../container/utils';
 import { componentFactory, useDependencies } from '../container/utils';
 import { SimplePaginator } from '../utils/components/SimplePaginator';
@@ -26,8 +25,7 @@ const TAGS_PER_PAGE = 20; // TODO Allow customizing this value in settings
 const TagsTable: FCWithDeps<TagsTableProps, TagsTableDeps> = ({ sortedTags, orderByColumn, currentOrder }) => {
   const { TagsTableRow } = useDependencies(TagsTable);
   const isFirstLoad = useRef(true);
-  const { search } = useLocation();
-  const { page: pageFromQuery = 1 } = parseQuery<{ page?: number | string }>(search);
+  const { page: pageFromQuery = 1 } = useParsedQuery<{ page?: number | string }>();
   const [page, setPage] = useQueryState<number>('page', Number(pageFromQuery));
   const pages = splitEvery(sortedTags, TAGS_PER_PAGE);
   const showPaginator = pages.length > 1;

--- a/src/tags/helpers/Tag.tsx
+++ b/src/tags/helpers/Tag.tsx
@@ -41,7 +41,8 @@ export const Tag: FC<TagProps> = (props) => {
             'tag--light-bg': isLightColor,
           })}
           onClick={props.onClose}
-        >&times;
+        >
+          &times;
         </UnstyledButton>
       )}
     </Wrapper>

--- a/src/utils/components/UnstyledButton.tsx
+++ b/src/utils/components/UnstyledButton.tsx
@@ -5,7 +5,7 @@ export const UnstyledButton: FC<Omit<HTMLProps<HTMLButtonElement>, 'type'>> = ({
   <button
     type="button"
     className={clsx('border-0', className)}
-    style={{ backgroundColor: 'inherit', fontWeight: 'inherit', ...style }}
+    style={{ backgroundColor: 'inherit', fontWeight: 'inherit', color: 'inherit', ...style }}
     {...rest}
   />
 );

--- a/src/utils/helpers/hooks.ts
+++ b/src/utils/helpers/hooks.ts
@@ -1,7 +1,7 @@
 import { parseQuery, stringifyQuery } from '@shlinkio/shlink-frontend-kit';
 import type { DependencyList, EffectCallback } from 'react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useSwipeable as useReactSwipeable } from 'react-swipeable';
 import type { MediaMatcher } from '../types';
 
@@ -55,11 +55,6 @@ export const useEffectExceptFirstTime = (callback: EffectCallback, deps: Depende
 export const useGoBack = () => {
   const navigate = useNavigate();
   return useCallback(() => navigate(-1), [navigate]);
-};
-
-export const useParsedQuery = <T>(): T => {
-  const { search } = useLocation();
-  return useMemo(() => parseQuery<T>(search), [search]);
 };
 
 export const useMaxResolution = (maxResolution: number, matchMedia: MediaMatcher) => {

--- a/src/visits/ShortUrlVisits.tsx
+++ b/src/visits/ShortUrlVisits.tsx
@@ -1,6 +1,5 @@
-import { parseQuery } from '@shlinkio/shlink-frontend-kit';
+import { useParsedQuery } from '@shlinkio/shlink-frontend-kit';
 import { useCallback, useEffect, useMemo } from 'react';
-import { useLocation } from 'react-router-dom';
 import type { FCWithDeps } from '../container/utils';
 import { componentFactory, useDependencies } from '../container/utils';
 import type { MercureBoundProps } from '../mercure/helpers/boundToMercureHub';
@@ -46,9 +45,8 @@ const ShortUrlVisits: FCWithDeps<MercureBoundProps & ShortUrlVisitsProps, ShortU
   const supportsShortUrlVisitsDeletion = useFeature('shortUrlVisitsDeletion');
   const { ReportExporter: reportExporter } = useDependencies(ShortUrlVisits);
   const shortCode = useDecodedShortCodeFromParams();
-  const { search } = useLocation();
   const goBack = useGoBack();
-  const { domain } = parseQuery<{ domain?: string }>(search);
+  const { domain } = useParsedQuery<{ domain?: string }>();
   const loadVisits = useCallback((params: VisitsParams, doIntervalFallback?: boolean) => getShortUrlVisits({
     shortCode,
     query: { ...toApiParams(params), domain },

--- a/src/visits/VisitsStats.tsx
+++ b/src/visits/VisitsStats.tsx
@@ -95,7 +95,7 @@ export const VisitsStats: FC<VisitsStatsProps> = (props) => {
   const isFirstLoad = useRef(true);
   const { search } = useLocation();
 
-  const buildSectionUrl = (subPath?: string) => (!subPath ? search : `${subPath}${search}`);
+  const buildSectionUrl = useCallback((subPath?: string) => (!subPath ? search : `${subPath}${search}`), [search]);
   const normalizedVisits = useMemo(() => normalizeVisits(visits), [visits]);
   const { os, browsers, referrers, countries, cities, citiesForMap, visitedUrls } = useMemo(
     () => processStatsFromVisits(normalizedVisits),

--- a/src/visits/helpers/hooks.ts
+++ b/src/visits/helpers/hooks.ts
@@ -1,5 +1,5 @@
 import { mergeDeepRight } from '@shlinkio/data-manipulation';
-import { stringifyQuery } from '@shlinkio/shlink-frontend-kit';
+import { stringifyQuery, useParsedQuery } from '@shlinkio/shlink-frontend-kit';
 import { useCallback, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import type { ShlinkOrphanVisitType } from '../../api-contract';
@@ -8,7 +8,6 @@ import type { DateRange } from '../../utils/dates/helpers/dateIntervals';
 import { datesToDateRange } from '../../utils/dates/helpers/dateIntervals';
 import type { BooleanString } from '../../utils/helpers';
 import { parseBooleanToString } from '../../utils/helpers';
-import { useParsedQuery } from '../../utils/helpers/hooks';
 import type { DeepPartial } from '../../utils/types';
 import type { VisitsFilter } from '../types';
 

--- a/src/visits/visits-comparison/VisitsComparison.tsx
+++ b/src/visits/visits-comparison/VisitsComparison.tsx
@@ -1,0 +1,3 @@
+import type { FC } from 'react';
+
+export const VisitsComparison: FC = () => null;

--- a/src/visits/visits-comparison/VisitsComparisonCollector.tsx
+++ b/src/visits/visits-comparison/VisitsComparisonCollector.tsx
@@ -1,0 +1,71 @@
+import { faChartLine as lineChartIcon } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { SimpleCard } from '@shlinkio/shlink-frontend-kit';
+import { clsx } from 'clsx';
+import type { FC } from 'react';
+import { useMemo } from 'react';
+import { Link } from 'react-router-dom';
+import { Button } from 'reactstrap';
+import { UnstyledButton } from '../../utils/components/UnstyledButton';
+import { useRoutesPrefix } from '../../utils/routesPrefix';
+import { useVisitsToCompare } from './VisitsComparisonContext';
+
+type VisitsComparisonCollectorProps = {
+  className?: string;
+  type: 'short-urls' | 'tags' | 'domains';
+};
+
+export const VisitsComparisonCollector: FC<VisitsComparisonCollectorProps> = ({ className, type }) => {
+  const routesPrefix = useRoutesPrefix();
+  const context = useVisitsToCompare();
+  const query = useMemo(
+    () => (!context ? '' : encodeURIComponent(context.visitsToCompare.map((visit) => visit.query).join(','))),
+    [context],
+  );
+
+  if (!context?.visitsToCompare.length) {
+    return null;
+  }
+
+  return (
+    <div className={clsx('top-sticky', className)}>
+      <SimpleCard bodyClassName="d-flex gap-3 align-items-center">
+        <div className="d-flex flex-wrap gap-1 flex-grow-1">
+          {context.visitsToCompare.map((item, index) => (
+            <span key={`${item.name}_${index}`} className="badge bg-secondary pe-1">
+              {item.name}
+              <UnstyledButton
+                aria-label={`Remove ${item.name}`}
+                className="fw-bold fs-6"
+                onClick={() => context.removeVisitToCompare(item)}
+              >
+                &times;
+              </UnstyledButton>
+            </span>
+          ))}
+        </div>
+        <div>
+          <Button
+            outline
+            color="primary"
+            disabled={context.visitsToCompare.length < 2}
+            tag={Link}
+            to={`${routesPrefix}/${type}/compare-visits?${type}=${query}`}
+          >
+            <FontAwesomeIcon icon={lineChartIcon} fixedWidth className="me-1" />
+            Compare &raquo;
+          </Button>
+          <Button
+            aria-label="Close compare"
+            outline
+            color="secondary"
+            className="ms-2 fw-bold"
+            onClick={context.clearVisitsToCompare}
+          >
+            &times;
+          </Button>
+        </div>
+      </SimpleCard>
+    </div>
+  );
+};

--- a/src/visits/visits-comparison/VisitsComparisonCollector.tsx
+++ b/src/visits/visits-comparison/VisitsComparisonCollector.tsx
@@ -11,15 +11,15 @@ import { useRoutesPrefix } from '../../utils/routesPrefix';
 import { useVisitsToCompare } from './VisitsComparisonContext';
 
 type VisitsComparisonCollectorProps = {
-  className?: string;
   type: 'short-urls' | 'tags' | 'domains';
+  className?: string;
 };
 
 export const VisitsComparisonCollector: FC<VisitsComparisonCollectorProps> = ({ className, type }) => {
   const routesPrefix = useRoutesPrefix();
   const context = useVisitsToCompare();
   const query = useMemo(
-    () => (!context ? '' : encodeURIComponent(context.itemsToCompare.map((visit) => visit.query).join(','))),
+    () => (!context ? '' : encodeURIComponent(context.itemsToCompare.map((item) => item.query).join(','))),
     [context],
   );
 
@@ -30,9 +30,9 @@ export const VisitsComparisonCollector: FC<VisitsComparisonCollectorProps> = ({ 
   return (
     <div className={clsx('top-sticky', className)}>
       <SimpleCard bodyClassName="d-flex gap-3 align-items-center">
-        <div className="d-flex flex-wrap gap-1 flex-grow-1">
+        <ul className="d-flex flex-wrap gap-1 flex-grow-1 p-0 m-0">
           {context.itemsToCompare.map((item, index) => (
-            <span key={`${item.name}_${index}`} className="badge bg-secondary pe-1">
+            <li key={`${item.name}_${index}`} className="badge bg-secondary pe-1">
               {item.name}
               <UnstyledButton
                 aria-label={`Remove ${item.name}`}
@@ -41,10 +41,10 @@ export const VisitsComparisonCollector: FC<VisitsComparisonCollectorProps> = ({ 
               >
                 &times;
               </UnstyledButton>
-            </span>
+            </li>
           ))}
-        </div>
-        <div>
+        </ul>
+        <div className="indivisible">
           <Button
             outline
             color="primary"

--- a/src/visits/visits-comparison/VisitsComparisonCollector.tsx
+++ b/src/visits/visits-comparison/VisitsComparisonCollector.tsx
@@ -19,11 +19,11 @@ export const VisitsComparisonCollector: FC<VisitsComparisonCollectorProps> = ({ 
   const routesPrefix = useRoutesPrefix();
   const context = useVisitsToCompare();
   const query = useMemo(
-    () => (!context ? '' : encodeURIComponent(context.visitsToCompare.map((visit) => visit.query).join(','))),
+    () => (!context ? '' : encodeURIComponent(context.itemsToCompare.map((visit) => visit.query).join(','))),
     [context],
   );
 
-  if (!context?.visitsToCompare.length) {
+  if (!context || context.itemsToCompare.length === 0) {
     return null;
   }
 
@@ -31,13 +31,13 @@ export const VisitsComparisonCollector: FC<VisitsComparisonCollectorProps> = ({ 
     <div className={clsx('top-sticky', className)}>
       <SimpleCard bodyClassName="d-flex gap-3 align-items-center">
         <div className="d-flex flex-wrap gap-1 flex-grow-1">
-          {context.visitsToCompare.map((item, index) => (
+          {context.itemsToCompare.map((item, index) => (
             <span key={`${item.name}_${index}`} className="badge bg-secondary pe-1">
               {item.name}
               <UnstyledButton
                 aria-label={`Remove ${item.name}`}
                 className="fw-bold fs-6"
-                onClick={() => context.removeVisitToCompare(item)}
+                onClick={() => context.removeItemToCompare(item)}
               >
                 &times;
               </UnstyledButton>
@@ -48,7 +48,7 @@ export const VisitsComparisonCollector: FC<VisitsComparisonCollectorProps> = ({ 
           <Button
             outline
             color="primary"
-            disabled={context.visitsToCompare.length < 2}
+            disabled={context.itemsToCompare.length < 2}
             tag={Link}
             to={`${routesPrefix}/${type}/compare-visits?${type}=${query}`}
           >
@@ -60,7 +60,7 @@ export const VisitsComparisonCollector: FC<VisitsComparisonCollectorProps> = ({ 
             outline
             color="secondary"
             className="ms-2 fw-bold"
-            onClick={context.clearVisitsToCompare}
+            onClick={context.clearItemsToCompare}
           >
             &times;
           </Button>

--- a/src/visits/visits-comparison/VisitsComparisonContext.ts
+++ b/src/visits/visits-comparison/VisitsComparisonContext.ts
@@ -1,0 +1,37 @@
+import { createContext, useCallback, useContext, useState } from 'react';
+
+export type VisitsComparisonItem = {
+  name: string;
+  query: string;
+};
+
+export type VisitsComparison = {
+  visitsToCompare: VisitsComparisonItem[];
+  addVisitToCompare: (item: VisitsComparisonItem) => void;
+  removeVisitToCompare: (item: VisitsComparisonItem) => void;
+  clearVisitsToCompare: () => void;
+};
+
+const VisitsComparisonContext = createContext<VisitsComparison | undefined>(undefined);
+
+export const { Provider: VisitsComparisonProvider } = VisitsComparisonContext;
+
+export const useVisitsToCompare = (): VisitsComparison | undefined => {
+  const context = useContext(VisitsComparisonContext);
+  return context as VisitsComparison | undefined;
+};
+
+export const useVisitsComparison = (): VisitsComparison => {
+  const [visitsToCompare, setVisitsToCompare] = useState<VisitsComparisonItem[]>([]);
+  const addVisitToCompare = useCallback(
+    (item: VisitsComparisonItem) => setVisitsToCompare((prev) => [...prev, item]),
+    [],
+  );
+  const removeVisitToCompare = useCallback(
+    (item: VisitsComparisonItem) => setVisitsToCompare((prev) => prev.filter((i) => i !== item)),
+    [],
+  );
+  const clearVisitsToCompare = useCallback(() => setVisitsToCompare([]), []);
+
+  return { visitsToCompare, addVisitToCompare, removeVisitToCompare, clearVisitsToCompare };
+};

--- a/src/visits/visits-comparison/VisitsComparisonContext.ts
+++ b/src/visits/visits-comparison/VisitsComparisonContext.ts
@@ -22,16 +22,16 @@ export const useVisitsToCompare = (): VisitsComparison | undefined => {
 };
 
 export const useVisitsComparison = (): VisitsComparison => {
-  const [itemsToCompare, setItemToCompare] = useState<VisitsComparisonItem[]>([]);
+  const [itemsToCompare, setItemsToCompare] = useState<VisitsComparisonItem[]>([]);
   const addItemToCompare = useCallback(
-    (item: VisitsComparisonItem) => setItemToCompare((prev) => [...prev, item]),
+    (item: VisitsComparisonItem) => setItemsToCompare((prev) => [...prev, item]),
     [],
   );
   const removeItemToCompare = useCallback(
-    (item: VisitsComparisonItem) => setItemToCompare((prev) => prev.filter((i) => i !== item)),
+    (item: VisitsComparisonItem) => setItemsToCompare((prev) => prev.filter((i) => i !== item)),
     [],
   );
-  const clearItemsToCompare = useCallback(() => setItemToCompare([]), []);
+  const clearItemsToCompare = useCallback(() => setItemsToCompare([]), []);
 
   return { itemsToCompare, addItemToCompare, removeItemToCompare, clearItemsToCompare };
 };

--- a/src/visits/visits-comparison/VisitsComparisonContext.ts
+++ b/src/visits/visits-comparison/VisitsComparisonContext.ts
@@ -6,10 +6,10 @@ export type VisitsComparisonItem = {
 };
 
 export type VisitsComparison = {
-  visitsToCompare: VisitsComparisonItem[];
-  addVisitToCompare: (item: VisitsComparisonItem) => void;
-  removeVisitToCompare: (item: VisitsComparisonItem) => void;
-  clearVisitsToCompare: () => void;
+  itemsToCompare: VisitsComparisonItem[];
+  addItemToCompare: (item: VisitsComparisonItem) => void;
+  removeItemToCompare: (item: VisitsComparisonItem) => void;
+  clearItemsToCompare: () => void;
 };
 
 const VisitsComparisonContext = createContext<VisitsComparison | undefined>(undefined);
@@ -22,16 +22,16 @@ export const useVisitsToCompare = (): VisitsComparison | undefined => {
 };
 
 export const useVisitsComparison = (): VisitsComparison => {
-  const [visitsToCompare, setVisitsToCompare] = useState<VisitsComparisonItem[]>([]);
-  const addVisitToCompare = useCallback(
-    (item: VisitsComparisonItem) => setVisitsToCompare((prev) => [...prev, item]),
+  const [itemsToCompare, setItemToCompare] = useState<VisitsComparisonItem[]>([]);
+  const addItemToCompare = useCallback(
+    (item: VisitsComparisonItem) => setItemToCompare((prev) => [...prev, item]),
     [],
   );
-  const removeVisitToCompare = useCallback(
-    (item: VisitsComparisonItem) => setVisitsToCompare((prev) => prev.filter((i) => i !== item)),
+  const removeItemToCompare = useCallback(
+    (item: VisitsComparisonItem) => setItemToCompare((prev) => prev.filter((i) => i !== item)),
     [],
   );
-  const clearVisitsToCompare = useCallback(() => setVisitsToCompare([]), []);
+  const clearItemsToCompare = useCallback(() => setItemToCompare([]), []);
 
-  return { visitsToCompare, addVisitToCompare, removeVisitToCompare, clearVisitsToCompare };
+  return { itemsToCompare, addItemToCompare, removeItemToCompare, clearItemsToCompare };
 };

--- a/test/short-urls/ShortUrlsFilteringBar.test.tsx
+++ b/test/short-urls/ShortUrlsFilteringBar.test.tsx
@@ -1,7 +1,8 @@
 import { screen, waitFor } from '@testing-library/react';
 import { fromPartial } from '@total-typescript/shoehorn';
 import { endOfDay, formatISO, startOfDay } from 'date-fns';
-import { MemoryRouter, useLocation, useNavigate } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
+import { Router, useNavigate } from 'react-router-dom';
 import { ShortUrlsFilteringBarFactory } from '../../src/short-urls/ShortUrlsFilteringBar';
 import { formatIsoDate } from '../../src/utils/dates/helpers/date';
 import type { DateRange } from '../../src/utils/dates/helpers/dateIntervals';
@@ -15,7 +16,6 @@ vi.mock('react-router-dom', async () => ({
   ...(await vi.importActual<any>('react-router-dom')),
   useParams: vi.fn().mockReturnValue({ serverId: '1' }),
   useNavigate: vi.fn(),
-  useLocation: vi.fn().mockReturnValue({}),
 }));
 
 describe('<ShortUrlsFilteringBar />', () => {
@@ -26,12 +26,12 @@ describe('<ShortUrlsFilteringBar />', () => {
   const navigate = vi.fn();
   const handleOrderBy = vi.fn();
   const now = new Date();
-  const setUp = (search = '', filterDisabledUrls = true) => {
-    (useLocation as any).mockReturnValue({ search });
+  const setUp = (search: string | undefined = undefined, filterDisabledUrls = true) => {
     (useNavigate as any).mockReturnValue(navigate);
+    const history = createMemoryHistory({ initialEntries: search ? [{ search }] : undefined });
 
     return renderWithEvents(
-      <MemoryRouter>
+      <Router location={history.location} navigator={history}>
         <SettingsProvider value={fromPartial({ visits: {} })}>
           <FeaturesProvider value={fromPartial({ filterDisabledUrls })}>
             <RoutesPrefixProvider value="/server/1">
@@ -39,7 +39,7 @@ describe('<ShortUrlsFilteringBar />', () => {
             </RoutesPrefixProvider>
           </FeaturesProvider>
         </SettingsProvider>
-      </MemoryRouter>,
+      </Router>,
     );
   };
 

--- a/test/short-urls/helpers/ShortUrlsRowMenu.test.tsx
+++ b/test/short-urls/helpers/ShortUrlsRowMenu.test.tsx
@@ -36,7 +36,7 @@ describe('<ShortUrlsRowMenu />', () => {
   it.each([
     [setUp],
     [setUpAndOpen],
-    [() => setUpAndOpen(fromPartial({ visitsToCompare: [] }))],
+    [() => setUpAndOpen(fromPartial({ itemsToCompare: [] }))],
   ])('passes a11y checks', (setUp) => checkAccessibility(setUp()));
 
   it('renders modal windows', () => {
@@ -48,7 +48,7 @@ describe('<ShortUrlsRowMenu />', () => {
 
   it.each([
     [undefined, 4],
-    [fromPartial<VisitsComparison>({ visitsToCompare: [] }), 5],
+    [fromPartial<VisitsComparison>({ itemsToCompare: [] }), 5],
   ])('renders correct amount of menu items', async (visitsComparison, expectedMenuItems) => {
     await setUpAndOpen(visitsComparison);
     expect(screen.getAllByRole('menuitem')).toHaveLength(expectedMenuItems);
@@ -59,7 +59,7 @@ describe('<ShortUrlsRowMenu />', () => {
     [fromPartial<VisitsComparisonItem>({ name: 'something else' }), false],
   ])('disables visits comparison menu if short URL is already selected', async (visitToCompare, hasAttribute) => {
     await setUpAndOpen(fromPartial({
-      visitsToCompare: [visitToCompare],
+      itemsToCompare: [visitToCompare],
     }));
     const button = screen.getByTestId('add-visit-to-compare-button');
 
@@ -73,8 +73,8 @@ describe('<ShortUrlsRowMenu />', () => {
   it('adds visit to compare when clicked', async () => {
     const addVisitToCompare = vi.fn();
     const { user } = await setUpAndOpen(fromPartial({
-      visitsToCompare: [],
-      addVisitToCompare,
+      itemsToCompare: [],
+      addItemToCompare: addVisitToCompare,
     }));
 
     await user.click(screen.getByTestId('add-visit-to-compare-button'));

--- a/test/short-urls/helpers/ShortUrlsRowMenu.test.tsx
+++ b/test/short-urls/helpers/ShortUrlsRowMenu.test.tsx
@@ -1,9 +1,12 @@
 import { screen } from '@testing-library/react';
-import type { UserEvent } from '@testing-library/user-event';
 import { fromPartial } from '@total-typescript/shoehorn';
 import { MemoryRouter } from 'react-router-dom';
 import type { ShlinkShortUrl } from '../../../src/api-contract';
 import { ShortUrlsRowMenuFactory } from '../../../src/short-urls/helpers/ShortUrlsRowMenu';
+import type { VisitsComparison, VisitsComparisonItem,
+} from '../../../src/visits/visits-comparison/VisitsComparisonContext';
+import {
+  VisitsComparisonProvider } from '../../../src/visits/visits-comparison/VisitsComparisonContext';
 import { checkAccessibility } from '../../__helpers__/accessibility';
 import { renderWithEvents } from '../../__helpers__/setUpTest';
 
@@ -16,21 +19,24 @@ describe('<ShortUrlsRowMenu />', () => {
     shortCode: 'abc123',
     shortUrl: 'https://s.test/abc123',
   });
-  const setUp = () => renderWithEvents(
+  const setUp = (visitsComparison?: VisitsComparison) => renderWithEvents(
     <MemoryRouter>
-      <ShortUrlsRowMenu shortUrl={shortUrl} />
+      <VisitsComparisonProvider value={visitsComparison}>
+        <ShortUrlsRowMenu shortUrl={shortUrl} />
+      </VisitsComparisonProvider>
     </MemoryRouter>,
   );
-  const openMenu = (user: UserEvent) => user.click(screen.getByRole('button'));
+  const setUpAndOpen = async (visitsComparison?: VisitsComparison) => {
+    const result = setUp(visitsComparison);
+    await result.user.click(screen.getByRole('button'));
+
+    return result;
+  };
 
   it.each([
     [setUp],
-    [async () => {
-      const { user, container } = setUp();
-      await openMenu(user);
-
-      return { container };
-    }],
+    [setUpAndOpen],
+    [() => setUpAndOpen(fromPartial({ visitsToCompare: [] }))],
   ])('passes a11y checks', (setUp) => checkAccessibility(setUp()));
 
   it('renders modal windows', () => {
@@ -40,10 +46,41 @@ describe('<ShortUrlsRowMenu />', () => {
     expect(screen.getByText('QrCodeModal')).toBeInTheDocument();
   });
 
-  it('renders correct amount of menu items', async () => {
-    const { user } = setUp();
+  it.each([
+    [undefined, 4],
+    [fromPartial<VisitsComparison>({ visitsToCompare: [] }), 5],
+  ])('renders correct amount of menu items', async (visitsComparison, expectedMenuItems) => {
+    await setUpAndOpen(visitsComparison);
+    expect(screen.getAllByRole('menuitem')).toHaveLength(expectedMenuItems);
+  });
 
-    await openMenu(user);
-    expect(screen.getAllByRole('menuitem')).toHaveLength(4);
+  it.each([
+    [fromPartial<VisitsComparisonItem>({ name: shortUrl.shortUrl }), true],
+    [fromPartial<VisitsComparisonItem>({ name: 'something else' }), false],
+  ])('disables visits comparison menu if short URL is already selected', async (visitToCompare, hasAttribute) => {
+    await setUpAndOpen(fromPartial({
+      visitsToCompare: [visitToCompare],
+    }));
+    const button = screen.getByTestId('add-visit-to-compare-button');
+
+    if (hasAttribute) {
+      expect(button).toHaveAttribute('disabled');
+    } else {
+      expect(button).not.toHaveAttribute('disabled');
+    }
+  });
+
+  it('adds visit to compare when clicked', async () => {
+    const addVisitToCompare = vi.fn();
+    const { user } = await setUpAndOpen(fromPartial({
+      visitsToCompare: [],
+      addVisitToCompare,
+    }));
+
+    await user.click(screen.getByTestId('add-visit-to-compare-button'));
+    expect(addVisitToCompare).toHaveBeenCalledWith({
+      name: shortUrl.shortUrl,
+      query: expect.stringContaining('abc123'),
+    });
   });
 });

--- a/test/short-urls/helpers/index.test.ts
+++ b/test/short-urls/helpers/index.test.ts
@@ -1,6 +1,13 @@
 import { fromPartial } from '@total-typescript/shoehorn';
 import type { ShlinkShortUrl } from '../../../src/api-contract';
-import { shortUrlDataFromShortUrl, urlDecodeShortCode, urlEncodeShortCode } from '../../../src/short-urls/helpers';
+import {
+  queryToShortUrl,
+  shortUrlDataFromShortUrl,
+  shortUrlToQuery,
+  urlDecodeShortCode,
+  urlEncodeShortCode,
+} from '../../../src/short-urls/helpers';
+import { DEFAULT_DOMAIN } from '../../../src/visits/reducers/domainVisits';
 
 describe('helpers', () => {
   describe('shortUrlDataFromShortUrl', () => {
@@ -43,6 +50,31 @@ describe('helpers', () => {
       ['foo__bar__baz', 'foo/bar/baz'],
     ])('parses shortCode as expected', (shortCode, result) => {
       expect(urlDecodeShortCode(shortCode)).toEqual(result);
+    });
+  });
+
+  describe('shortUrlToQuery', () => {
+    it.each([
+      [{ domain: null, shortCode: 'foo' }, `${DEFAULT_DOMAIN}__foo`],
+      [{ domain: 's.test', shortCode: 'bar' }, 's.test__bar'],
+    ])('generates expected pattern', (shortUrl, expectedResult) => {
+      expect(shortUrlToQuery(shortUrl)).toEqual(expectedResult);
+    });
+  });
+
+  describe('queryToShortUrl', () => {
+    it.each([
+      [`${DEFAULT_DOMAIN}__foo`, { domain: null, shortCode: 'foo' }],
+      ['s.test__bar', { domain: 's.test', shortCode: 'bar' }],
+      ['s.test__baz__ignored', { domain: 's.test', shortCode: 'baz' }],
+    ])('generates expected pattern', (query, expectedShortUrl) => {
+      expect(queryToShortUrl(query)).toEqual(expectedShortUrl);
+    });
+
+    it('throws error when provided value is un-parseable', () => {
+      expect(() => queryToShortUrl('foo')).toThrowError(
+        'It was not possible to parse domain and short code from "foo"',
+      );
     });
   });
 });

--- a/test/tags/TagsTable.test.tsx
+++ b/test/tags/TagsTable.test.tsx
@@ -1,6 +1,6 @@
 import { screen } from '@testing-library/react';
 import { fromPartial } from '@total-typescript/shoehorn';
-import { useLocation } from 'react-router-dom';
+import { MemoryRouter, useLocation } from 'react-router-dom';
 import { TagsTableFactory } from '../../src/tags/TagsTable';
 import type { TagsTableRowProps } from '../../src/tags/TagsTableRow';
 import { rangeOf } from '../../src/utils/helpers';
@@ -21,11 +21,13 @@ describe('<TagsTable />', () => {
   const setUp = (sortedTags: string[] = [], search = '') => {
     (useLocation as any).mockReturnValue({ search });
     return renderWithEvents(
-      <TagsTable
-        sortedTags={sortedTags.map((tag) => fromPartial({ tag }))}
-        currentOrder={{}}
-        orderByColumn={() => orderByColumn}
-      />,
+      <MemoryRouter>
+        <TagsTable
+          sortedTags={sortedTags.map((tag) => fromPartial({ tag }))}
+          currentOrder={{}}
+          orderByColumn={() => orderByColumn}
+        />
+      </MemoryRouter>,
     );
   };
 

--- a/test/tags/TagsTable.test.tsx
+++ b/test/tags/TagsTable.test.tsx
@@ -1,16 +1,12 @@
 import { screen } from '@testing-library/react';
 import { fromPartial } from '@total-typescript/shoehorn';
-import { MemoryRouter, useLocation } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
+import { Router } from 'react-router-dom';
 import { TagsTableFactory } from '../../src/tags/TagsTable';
 import type { TagsTableRowProps } from '../../src/tags/TagsTableRow';
 import { rangeOf } from '../../src/utils/helpers';
 import { checkAccessibility } from '../__helpers__/accessibility';
 import { renderWithEvents } from '../__helpers__/setUpTest';
-
-vi.mock('react-router-dom', async () => ({
-  ...(await vi.importActual<any>('react-router-dom')),
-  useLocation: vi.fn(),
-}));
 
 describe('<TagsTable />', () => {
   const orderByColumn = vi.fn();
@@ -19,15 +15,15 @@ describe('<TagsTable />', () => {
   }));
   const tags = (amount: number) => rangeOf(amount, (i) => `tag_${i}`);
   const setUp = (sortedTags: string[] = [], search = '') => {
-    (useLocation as any).mockReturnValue({ search });
+    const history = createMemoryHistory({ initialEntries: search ? [{ search }] : undefined });
     return renderWithEvents(
-      <MemoryRouter>
+      <Router location={history.location} navigator={history}>
         <TagsTable
           sortedTags={sortedTags.map((tag) => fromPartial({ tag }))}
           currentOrder={{}}
           orderByColumn={() => orderByColumn}
         />
-      </MemoryRouter>,
+      </Router>,
     );
   };
 

--- a/test/visits/visits-comparison/VisitsComparisonCollector.test.tsx
+++ b/test/visits/visits-comparison/VisitsComparisonCollector.test.tsx
@@ -1,0 +1,79 @@
+import { screen } from '@testing-library/react';
+import { fromPartial } from '@total-typescript/shoehorn';
+import { MemoryRouter } from 'react-router-dom';
+import { rangeOf } from '../../../src/utils/helpers';
+import { VisitsComparisonCollector } from '../../../src/visits/visits-comparison/VisitsComparisonCollector';
+import type { VisitsComparison } from '../../../src/visits/visits-comparison/VisitsComparisonContext';
+import { VisitsComparisonProvider } from '../../../src/visits/visits-comparison/VisitsComparisonContext';
+import { checkAccessibility } from '../../__helpers__/accessibility';
+import { renderWithEvents } from '../../__helpers__/setUpTest';
+
+describe('<VisitsComparisonCollector />', () => {
+  const clearItemsToCompare = vi.fn();
+  const removeItemToCompare = vi.fn();
+  const createVisitsComparison = (itemsAmount = 1): VisitsComparison => fromPartial({
+    itemsToCompare: rangeOf(itemsAmount, (index) => ({ name: `foo${index}`, query: `bar${index}` })),
+    clearItemsToCompare,
+    removeItemToCompare,
+  });
+  const setUp = (visitsComparison?: VisitsComparison, type: 'short-urls' | 'tags' | 'domains' = 'short-urls') =>
+    renderWithEvents(
+      <MemoryRouter>
+        <VisitsComparisonProvider value={visitsComparison}>
+          <VisitsComparisonCollector type={type} />
+        </VisitsComparisonProvider>
+      </MemoryRouter>,
+    );
+
+  it('passes a11y checks', () => checkAccessibility(setUp(createVisitsComparison())));
+
+  it.each([
+    [undefined],
+    [fromPartial<VisitsComparison>({ itemsToCompare: [] })],
+  ])('does not render when no context or no items are defined', (visitsComparison) => {
+    const { container } = setUp(visitsComparison);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it.each([
+    [1, true],
+    [2, false],
+    [5, false],
+  ])('disables compare button when there is only one selected item', (itemsAmount, isDisabled) => {
+    setUp(createVisitsComparison(itemsAmount));
+    const compareButton = screen.getByText(/^Compare/);
+
+    expect(screen.getAllByRole('listitem')).toHaveLength(itemsAmount);
+    if (isDisabled) {
+      expect(compareButton).toHaveAttribute('disabled');
+    } else {
+      expect(compareButton).not.toHaveAttribute('disabled');
+    }
+  });
+
+  it('can clear selected items', async () => {
+    const { user } = setUp(createVisitsComparison(5));
+
+    await user.click(screen.getByLabelText('Close compare'));
+    expect(clearItemsToCompare).toHaveBeenCalled();
+  });
+
+  it.each([[1], [2], [4]])('can remove individual items', async (index) => {
+    const { user } = setUp(createVisitsComparison(5));
+
+    await user.click(screen.getByLabelText(`Remove foo${index}`));
+    expect(removeItemToCompare).toHaveBeenCalledWith({ name: `foo${index}`, query: `bar${index}` });
+  });
+
+  it.each([
+    ['short-urls' as const],
+    ['tags' as const],
+    ['domains' as const],
+  ])('redirects comparison to expected location', (type) => {
+    setUp(createVisitsComparison(3), type);
+    expect(screen.getByText(/^Compare/)).toHaveAttribute(
+      'href',
+      `/${type}/compare-visits?${type}=${encodeURIComponent('bar1,bar2,bar3')}`,
+    );
+  });
+});

--- a/test/visits/visits-comparison/VisitsComparisonContext.test.tsx
+++ b/test/visits/visits-comparison/VisitsComparisonContext.test.tsx
@@ -1,0 +1,58 @@
+import { screen } from '@testing-library/react';
+import { useVisitsComparison } from '../../../src/visits/visits-comparison/VisitsComparisonContext';
+import { renderWithEvents } from '../../__helpers__/setUpTest';
+
+describe('useVisitsComparison', () => {
+  const FakeComponent = () => {
+    const { itemsToCompare, clearItemsToCompare, removeItemToCompare, addItemToCompare } = useVisitsComparison();
+
+    return (
+      <>
+        <ul>
+          {itemsToCompare.map((item, index) => (
+            <li key={`${item.name}_${index}`}>{item.name} {item.query}</li>
+          ))}
+        </ul>
+        <button
+          type="button"
+          data-testid="add-button"
+          onClick={() => addItemToCompare({ name: `${Math.random()}`, query: `${Math.random()}` })}
+        >
+          Add
+        </button>
+        <button
+          type="button"
+          data-testid="remove-button"
+          onClick={() => itemsToCompare[0] && removeItemToCompare(itemsToCompare[0])}
+        >
+          Remove first
+        </button>
+        <button type="button" data-testid="clear-button" onClick={clearItemsToCompare}>Clear</button>
+      </>
+    );
+  };
+  const setUp = () => renderWithEvents(<FakeComponent />);
+
+  it('can handle items to compare', async () => {
+    const { user } = setUp();
+
+    expect(screen.queryByRole('listitem')).not.toBeInTheDocument();
+
+    // Can add items
+    await user.click(screen.getByTestId('add-button'));
+    await user.click(screen.getByTestId('add-button'));
+    await user.click(screen.getByTestId('add-button'));
+    await user.click(screen.getByTestId('add-button'));
+    await user.click(screen.getByTestId('add-button'));
+    expect(screen.getAllByRole('listitem')).toHaveLength(5);
+
+    // Can remove items
+    await user.click(screen.getByTestId('remove-button'));
+    await user.click(screen.getByTestId('remove-button'));
+    expect(screen.getAllByRole('listitem')).toHaveLength(3);
+
+    // Can clear all items
+    await user.click(screen.getByTestId('clear-button'));
+    expect(screen.queryByRole('listitem')).not.toBeInTheDocument();
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -33,6 +33,7 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
+    allowOnly: true,
     setupFiles: './test/setup.ts',
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
Add a `<VisitsComparisonCollector />` component that can be used to collect short URLs, tags or domains which visits we want to collect.

The component sticks to the top when scrolling down, making sure it is always visible, and keeps its state even when filtering or paginating the list it is rendered next to.

This PR adds that component to the short URLs list as a proof of concept.

[Grabación de pantalla desde 2023-12-16 09-03-42.webm](https://github.com/shlinkio/shlink-web-component/assets/2719332/9e301e17-ac8a-4abc-8c5e-93eb6262162c)

Part of #7