### PR TITLE
Create common helpers for visits comparison reducers

### DIFF
--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -29,6 +29,7 @@ type MainDeps = {
   Overview: FC,
   EditShortUrl: FC,
   ManageDomains: FC,
+  TagVisitsComparison: FC,
 };
 
 const Main: FCWithDeps<MainProps, MainDeps> = ({ createNotFound }) => {
@@ -44,6 +45,7 @@ const Main: FCWithDeps<MainProps, MainDeps> = ({ createNotFound }) => {
     Overview,
     EditShortUrl,
     ManageDomains,
+    TagVisitsComparison,
   } = useDependencies(Main);
   const location = useLocation();
   const routesPrefix = useRoutesPrefix();
@@ -74,6 +76,7 @@ const Main: FCWithDeps<MainProps, MainDeps> = ({ createNotFound }) => {
                 <Route path="/short-code/:shortCode/visits/*" element={<ShortUrlVisits />} />
                 <Route path="/short-code/:shortCode/edit" element={<EditShortUrl />} />
                 <Route path="/tag/:tag/visits/*" element={<TagVisits />} />
+                <Route path="/tags/compare-visits" element={<TagVisitsComparison />} />
                 {addDomainVisitsRoute && <Route path="/domain/:domain/visits/*" element={<DomainVisits />} />}
                 <Route path="/orphan-visits/*" element={<OrphanVisits />} />
                 <Route path="/non-orphan-visits/*" element={<NonOrphanVisits />} />
@@ -101,4 +104,5 @@ export const MainFactory = componentFactory(Main, [
   'Overview',
   'EditShortUrl',
   'ManageDomains',
+  'TagVisitsComparison',
 ]);

--- a/src/container/store.ts
+++ b/src/container/store.ts
@@ -17,8 +17,31 @@ import type { ShortUrlVisitsDeletion } from '../visits/reducers/shortUrlVisitsDe
 import type { TagVisits } from '../visits/reducers/tagVisits';
 import type { VisitsInfo } from '../visits/reducers/types';
 import type { VisitsOverview } from '../visits/reducers/visitsOverview';
+import type { VisitsComparisonInfo } from '../visits/visits-comparison/reducers/types';
 
 const isProduction = process.env.NODE_ENV === 'production';
+
+export type RootState = {
+  shortUrlsList: ShortUrlsList;
+  shortUrlCreation: ShortUrlCreation;
+  shortUrlDeletion: ShortUrlDeletion;
+  shortUrlEdition: ShortUrlEdition;
+  shortUrlVisits: ShortUrlVisits;
+  shortUrlVisitsDeletion: ShortUrlVisitsDeletion;
+  tagVisits: TagVisits;
+  tagVisitsComparison: VisitsComparisonInfo;
+  domainVisits: DomainVisits;
+  orphanVisits: VisitsInfo;
+  orphanVisitsDeletion: OrphanVisitsDeletion;
+  nonOrphanVisits: VisitsInfo;
+  shortUrlDetail: ShortUrlDetail;
+  tagsList: TagsList;
+  tagDelete: TagDeletion;
+  tagEdit: TagEdition;
+  mercureInfo: MercureInfo;
+  domainsList: DomainsList;
+  visitsOverview: VisitsOverview;
+};
 
 export const setUpStore = (container: IContainer) => configureStore({
   devTools: !isProduction,
@@ -32,6 +55,7 @@ export const setUpStore = (container: IContainer) => configureStore({
     shortUrlVisits: container.shortUrlVisitsReducer,
     shortUrlVisitsDeletion: container.shortUrlVisitsDeletionReducer,
     tagVisits: container.tagVisitsReducer,
+    tagVisitsComparison: container.tagVisitsComparisonReducer,
     domainVisits: container.domainVisitsReducer,
     orphanVisits: container.orphanVisitsReducer,
     orphanVisitsDeletion: container.orphanVisitsDeletionReducer,
@@ -41,31 +65,10 @@ export const setUpStore = (container: IContainer) => configureStore({
     tagEdit: container.tagEditReducer,
     domainsList: container.domainsListReducer,
     visitsOverview: container.visitsOverviewReducer,
-  }),
+  } satisfies RootState),
   middleware: (defaultMiddlewaresIncludingReduxThunk) => defaultMiddlewaresIncludingReduxThunk({
     // State is too big for these
     immutableCheck: false,
     serializableCheck: false,
   }),
 });
-
-export type RootState = {
-  shortUrlsList: ShortUrlsList;
-  shortUrlCreation: ShortUrlCreation;
-  shortUrlDeletion: ShortUrlDeletion;
-  shortUrlEdition: ShortUrlEdition;
-  shortUrlVisits: ShortUrlVisits;
-  shortUrlVisitsDeletion: ShortUrlVisitsDeletion;
-  tagVisits: TagVisits;
-  domainVisits: DomainVisits;
-  orphanVisits: VisitsInfo;
-  orphanVisitsDeletion: OrphanVisitsDeletion;
-  nonOrphanVisits: VisitsInfo;
-  shortUrlDetail: ShortUrlDetail;
-  tagsList: TagsList;
-  tagDelete: TagDeletion;
-  tagEdit: TagEdition;
-  mercureInfo: MercureInfo;
-  domainsList: DomainsList;
-  visitsOverview: VisitsOverview;
-};

--- a/src/visits/reducers/common/createLoadVisits.ts
+++ b/src/visits/reducers/common/createLoadVisits.ts
@@ -14,16 +14,16 @@ export type LastVisitLoader = (excludeBots?: boolean) => Promise<ShlinkVisit | u
 
 type CreateLoadVisitsOptions = {
   /** Used to load visits for a specific page and number of items */
-  visitsLoader: VisitsLoader,
+  visitsLoader: VisitsLoader;
   /** Invoked before loading a batch, can be used to stop loading more batches if it returns true */
-  shouldCancel: () => boolean,
+  shouldCancel: () => boolean;
   /**
    * When a lot of batches need to be loaded, this callback is invoked with a value from 0 to 100, so that callers know
    * the actual progress.
    */
-  progressChanged: (progress: number) => void,
+  progressChanged: (progress: number) => void;
   /** Max amount of parallel loadings in the same batch */
-  batchSize?: number,
+  batchSize?: number;
 };
 
 /**

--- a/src/visits/services/provideServices.ts
+++ b/src/visits/services/provideServices.ts
@@ -15,6 +15,11 @@ import { createNewVisits } from '../reducers/visitCreation';
 import { loadVisitsOverview, visitsOverviewReducerCreator } from '../reducers/visitsOverview';
 import { ShortUrlVisitsFactory } from '../ShortUrlVisits';
 import { TagVisitsFactory } from '../TagVisits';
+import {
+  getTagVisitsForComparison,
+  tagVisitsComparisonReducerCreator,
+} from '../visits-comparison/reducers/tagVisitsComparison';
+import { TagVisitsComparison } from '../visits-comparison/TagVisitsComparison';
 import * as visitsParser from './VisitsParser';
 
 export const provideServices = (bottle: Bottle, connect: ConnectDecorator) => {
@@ -40,6 +45,12 @@ export const provideServices = (bottle: Bottle, connect: ConnectDecorator) => {
   bottle.decorator('TagVisits', connect(
     ['tagVisits', 'mercureInfo'],
     ['getTagVisits', 'cancelGetTagVisits', 'createNewVisits', 'loadMercureInfo'],
+  ));
+
+  bottle.serviceFactory('TagVisitsComparison', () => TagVisitsComparison);
+  bottle.decorator('TagVisitsComparison', connect(
+    ['tagVisitsComparison', 'mercureInfo'],
+    ['getTagVisitsForComparison', 'cancelGetTagVisitsForComparison', 'createNewVisits', 'loadMercureInfo'],
   ));
 
   bottle.factory('DomainVisits', DomainVisitsFactory);
@@ -71,6 +82,13 @@ export const provideServices = (bottle: Bottle, connect: ConnectDecorator) => {
 
   bottle.serviceFactory('getTagVisits', getTagVisits, 'apiClientFactory');
   bottle.serviceFactory('cancelGetTagVisits', (obj) => obj.cancelGetVisits, 'tagVisitsReducerCreator');
+
+  bottle.serviceFactory('getTagVisitsForComparison', getTagVisitsForComparison, 'apiClientFactory');
+  bottle.serviceFactory(
+    'cancelGetTagVisitsForComparison',
+    (obj) => obj.cancelGetVisits,
+    'tagVisitsComparisonReducerCreator',
+  );
 
   bottle.serviceFactory('getDomainVisits', getDomainVisits, 'apiClientFactory');
   bottle.serviceFactory('cancelGetDomainVisits', (obj) => obj.cancelGetVisits, 'domainVisitsReducerCreator');
@@ -128,4 +146,11 @@ export const provideServices = (bottle: Bottle, connect: ConnectDecorator) => {
 
   bottle.serviceFactory('tagVisitsReducerCreator', tagVisitsReducerCreator, 'getTagVisits');
   bottle.serviceFactory('tagVisitsReducer', (obj) => obj.reducer, 'tagVisitsReducerCreator');
+
+  bottle.serviceFactory(
+    'tagVisitsComparisonReducerCreator',
+    tagVisitsComparisonReducerCreator,
+    'getTagVisitsForComparison',
+  );
+  bottle.serviceFactory('tagVisitsComparisonReducer', (obj) => obj.reducer, 'tagVisitsComparisonReducerCreator');
 };

--- a/src/visits/visits-comparison/TagVisitsComparison.tsx
+++ b/src/visits/visits-comparison/TagVisitsComparison.tsx
@@ -13,6 +13,7 @@ type TagVisitsComparisonProps = {
 // TODO
 //      * Bind to mercure for visits creation
 //      * Inject ColorGenerator so that chart lines use the tag color
+/* v8 ignore start */
 export const TagVisitsComparison: FC<TagVisitsComparisonProps> = (
   { getTagVisitsForComparison, tagVisitsComparison },
 ) => {
@@ -35,3 +36,4 @@ export const TagVisitsComparison: FC<TagVisitsComparisonProps> = (
     </ul>
   );
 };
+/* v8 ignore stop */

--- a/src/visits/visits-comparison/TagVisitsComparison.tsx
+++ b/src/visits/visits-comparison/TagVisitsComparison.tsx
@@ -1,0 +1,37 @@
+import { useParsedQuery } from '@shlinkio/shlink-frontend-kit';
+import type { FC } from 'react';
+import { useEffect } from 'react';
+import type { LoadTagVisitsForComparison } from './reducers/tagVisitsComparison';
+import type { VisitsComparisonInfo } from './reducers/types';
+
+type TagVisitsComparisonProps = {
+  getTagVisitsForComparison: (params: LoadTagVisitsForComparison) => void;
+  tagVisitsComparison: VisitsComparisonInfo;
+  cancelGetTagVisitsComparison: () => void;
+};
+
+// TODO
+//      * Bind to mercure for visits creation
+//      * Inject ColorGenerator so that chart lines use the tag color
+export const TagVisitsComparison: FC<TagVisitsComparisonProps> = (
+  { getTagVisitsForComparison, tagVisitsComparison },
+) => {
+  const { tags } = useParsedQuery<{ tags: string }>();
+  const { visitsGroups, loading } = tagVisitsComparison;
+
+  useEffect(() => {
+    getTagVisitsForComparison({ tags: tags.split(',') });
+  }, [getTagVisitsForComparison, tags]);
+
+  if (loading) {
+    return 'Loading...';
+  }
+
+  return (
+    <ul>
+      {Object.entries(visitsGroups).map(([tag, visits]) => (
+        <li key={tag}>{tag}: {visits.length}</li>
+      ))}
+    </ul>
+  );
+};

--- a/src/visits/visits-comparison/reducers/common/createLoadVisitsForComparison.ts
+++ b/src/visits/visits-comparison/reducers/common/createLoadVisitsForComparison.ts
@@ -1,0 +1,59 @@
+import type { ShlinkVisit } from '@shlinkio/shlink-js-sdk/api-contract';
+import type { VisitsLoader } from '../../../reducers/common';
+import { createLoadVisits } from '../../../reducers/common';
+
+type CreateLoadVisitsForComparisonOptions = {
+  /** Used to load visits for a specific page and number of items */
+  visitsLoaders: Record<string, VisitsLoader>;
+  /** Invoked before loading a batch, can be used to stop loading more batches if it returns true */
+  shouldCancel: () => boolean;
+  /**
+   * When a lot of batches need to be loaded, this callback is invoked with a value from 0 to 100, so that callers know
+   * the actual progress.
+   */
+  progressChanged: (progress: number) => void;
+};
+
+/**
+ * Creates a callback used to load visits in batches, using provided visits loader as the source of visits, and
+ * notifying progress changes when needed.
+ */
+export const createLoadVisitsForComparison = ({
+  visitsLoaders,
+  shouldCancel,
+  progressChanged,
+}: CreateLoadVisitsForComparisonOptions) => {
+  const keys = Object.keys(visitsLoaders);
+  const batchSize = Math.max(1, Math.round(4 / keys.length));
+  const progresses = Object.fromEntries(keys.map((key) => [key, 0]));
+  const computeProgress = (key: string, progress: number) => {
+    progresses[key] = progress;
+
+    const values = Object.values(progresses);
+    const sum = values.reduce((a, b) => a + b, 0);
+    progressChanged(sum / values.length);
+  };
+
+  const loadVisitsEntries = Object.entries(visitsLoaders).map(
+    ([key, visitsLoader]): [string, () => Promise<ShlinkVisit[]>] => [
+      key,
+      createLoadVisits({
+        visitsLoader,
+        batchSize,
+        shouldCancel,
+        progressChanged: (progress) => computeProgress(key, progress),
+      }),
+    ],
+  );
+
+  return async (): Promise<Record<string, ShlinkVisit[]>> => {
+    // TODO Every loadVisits has a built-in batching logic, which is more or less "optimized" here by provided batchSize
+    //      However, this Promise.all(...) may also need some batching if a large list of items is passed.
+    const visitsEntries = await Promise.all(loadVisitsEntries.map(async ([key, loadVisits]) => {
+      const visits = await loadVisits();
+      return [key, visits];
+    }));
+
+    return Object.fromEntries(visitsEntries);
+  };
+};

--- a/src/visits/visits-comparison/reducers/common/createVisitsComparisonAsyncThunk.ts
+++ b/src/visits/visits-comparison/reducers/common/createVisitsComparisonAsyncThunk.ts
@@ -5,19 +5,19 @@ import type { VisitsLoader } from '../../../reducers/common';
 import type { LoadVisitsForComparison, VisitsForComparisonLoaded } from '../types';
 import { createLoadVisitsForComparison } from './createLoadVisitsForComparison';
 
-interface VisitsComparisonAsyncThunkOptions {
+interface VisitsComparisonAsyncThunkOptions<CreateLoadersParam extends LoadVisitsForComparison> {
   typePrefix: string;
-  createLoaders: (params: LoadVisitsForComparison) => Record<string, VisitsLoader>;
+  createLoaders: (params: CreateLoadersParam) => Record<string, VisitsLoader>;
   shouldCancel: (getState: () => RootState) => boolean;
 }
 
-export const createVisitsComparisonAsyncThunk = (
-  { typePrefix, createLoaders, shouldCancel }: VisitsComparisonAsyncThunkOptions,
+export const createVisitsComparisonAsyncThunk = <CreateLoadersParam extends LoadVisitsForComparison>(
+  { typePrefix, createLoaders, shouldCancel }: VisitsComparisonAsyncThunkOptions<CreateLoadersParam>,
 ) => {
   const progressChanged = createAction<number>(`${typePrefix}/progressChanged`);
   const asyncThunk = createAsyncThunk(
     typePrefix,
-    async (params: LoadVisitsForComparison, { getState, dispatch }): Promise<VisitsForComparisonLoaded> => {
+    async (params: CreateLoadersParam, { getState, dispatch }): Promise<VisitsForComparisonLoaded> => {
       const visitsLoaders = createLoaders(params);
       const loadVisits = createLoadVisitsForComparison({
         visitsLoaders,

--- a/src/visits/visits-comparison/reducers/common/createVisitsComparisonAsyncThunk.ts
+++ b/src/visits/visits-comparison/reducers/common/createVisitsComparisonAsyncThunk.ts
@@ -1,0 +1,34 @@
+import { createAction } from '@reduxjs/toolkit';
+import type { RootState } from '../../../../container/store';
+import { createAsyncThunk } from '../../../../utils/redux';
+import type { VisitsLoader } from '../../../reducers/common';
+import type { LoadVisitsForComparison, VisitsForComparisonLoaded } from '../types';
+import { createLoadVisitsForComparison } from './createLoadVisitsForComparison';
+
+interface VisitsComparisonAsyncThunkOptions {
+  typePrefix: string;
+  createLoaders: (params: LoadVisitsForComparison) => Record<string, VisitsLoader>;
+  shouldCancel: (getState: () => RootState) => boolean;
+}
+
+export const createVisitsComparisonAsyncThunk = (
+  { typePrefix, createLoaders, shouldCancel }: VisitsComparisonAsyncThunkOptions,
+) => {
+  const progressChanged = createAction<number>(`${typePrefix}/progressChanged`);
+  const asyncThunk = createAsyncThunk(
+    typePrefix,
+    async (params: LoadVisitsForComparison, { getState, dispatch }): Promise<VisitsForComparisonLoaded> => {
+      const visitsLoaders = createLoaders(params);
+      const loadVisits = createLoadVisitsForComparison({
+        visitsLoaders,
+        shouldCancel: () => shouldCancel(getState),
+        progressChanged: (progress) => dispatch(progressChanged(progress)),
+      });
+      const visitsGroups = await loadVisits();
+
+      return { visitsGroups };
+    },
+  );
+
+  return Object.assign(asyncThunk, { progressChanged });
+};

--- a/src/visits/visits-comparison/reducers/common/createVisitsComparisonReducer.ts
+++ b/src/visits/visits-comparison/reducers/common/createVisitsComparisonReducer.ts
@@ -1,0 +1,54 @@
+import { createSlice } from '@reduxjs/toolkit';
+import { parseApiError } from '../../../../api-contract/utils';
+// import { createNewVisits } from '../../../reducers/visitCreation';
+import type { VisitsComparisonInfo } from '../types';
+import type { createVisitsComparisonAsyncThunk } from './createVisitsComparisonAsyncThunk';
+
+type VisitsReducerOptions<
+  State extends VisitsComparisonInfo,
+  AT extends ReturnType<typeof createVisitsComparisonAsyncThunk>,
+> = {
+  name: string;
+  asyncThunkCreator: AT;
+  initialState: State;
+  // filterCreatedVisits: (state: State, createdVisits: CreateVisit[]) => CreateVisit[];
+};
+
+export const createVisitsComparisonReducer = <
+  State extends VisitsComparisonInfo,
+  AT extends ReturnType<typeof createVisitsComparisonAsyncThunk>,
+>(
+    { name, asyncThunkCreator, initialState /* filterCreatedVisits, */ }: VisitsReducerOptions<State, AT>,
+  ) => {
+  const { pending, rejected, fulfilled, progressChanged } = asyncThunkCreator;
+  const { reducer, actions } = createSlice({
+    name,
+    initialState,
+    reducers: {
+      cancelGetVisits: (state) => ({ ...state, cancelLoad: true }),
+    },
+    extraReducers: (builder) => {
+      builder.addCase(pending, () => ({ ...initialState, loading: true }));
+      builder.addCase(rejected, (_, { error }) => (
+        { ...initialState, errorData: parseApiError(error) ?? null }
+      ));
+      builder.addCase(fulfilled, (state, { payload }) => (
+        { ...state, ...payload, loading: false, progress: null, errorData: null }
+      ));
+
+      builder.addCase(progressChanged, (state, { payload: progress }) => ({ ...state, progress }));
+
+      // TODO Handle visits creation
+      // builder.addCase(createNewVisits, (state, { payload }) => {
+      //   const { visits } = state;
+      //   // @ts-expect-error TODO Fix type inference
+      //   const newVisits = filterCreatedVisits(state, payload.createdVisits).map(({ visit }) => visit);
+      //
+      //   return !newVisits.length ? state : { ...state, visits: [...newVisits, ...visits] };
+      // });
+    },
+  });
+  const { cancelGetVisits } = actions;
+
+  return { reducer, cancelGetVisits };
+};

--- a/src/visits/visits-comparison/reducers/tagVisitsComparison.ts
+++ b/src/visits/visits-comparison/reducers/tagVisitsComparison.ts
@@ -1,0 +1,41 @@
+import type { ShlinkApiClient } from '../../../api-contract';
+import { createVisitsComparisonAsyncThunk } from './common/createVisitsComparisonAsyncThunk';
+import { createVisitsComparisonReducer } from './common/createVisitsComparisonReducer';
+import type { LoadVisitsForComparison, VisitsComparisonInfo } from './types';
+
+const REDUCER_PREFIX = 'shlink/tagVisitsComparison';
+
+export type LoadTagVisitsForComparison = LoadVisitsForComparison & { tags: string[]; };
+
+const initialState: VisitsComparisonInfo = {
+  visitsGroups: {},
+  loading: false,
+  cancelLoad: false,
+  errorData: null,
+  progress: null,
+};
+
+export const getTagVisitsForComparison = (apiClientFactory: () => ShlinkApiClient) => createVisitsComparisonAsyncThunk({
+  typePrefix: `${REDUCER_PREFIX}/getTagVisitsForComparison`,
+  createLoaders: ({ tags, query = {} }: LoadTagVisitsForComparison) => {
+    const apiClient = apiClientFactory();
+    const loaderEntries = tags.map((tag) => [
+      tag,
+      async (page: number, itemsPerPage: number) => apiClient.getTagVisits(
+        tag,
+        { ...query, page, itemsPerPage },
+      ),
+    ]);
+
+    return Object.fromEntries(loaderEntries);
+  },
+  shouldCancel: (getState) => getState().tagVisitsComparison.cancelLoad,
+});
+
+export const tagVisitsComparisonReducerCreator = (asyncThunkCreator: ReturnType<typeof getTagVisitsForComparison>) =>
+  createVisitsComparisonReducer({
+    name: REDUCER_PREFIX,
+    initialState,
+    // @ts-expect-error TODO Fix type inference
+    asyncThunkCreator,
+  });

--- a/src/visits/visits-comparison/reducers/types.ts
+++ b/src/visits/visits-comparison/reducers/types.ts
@@ -1,0 +1,11 @@
+import type { ShlinkVisit } from '../../../api-contract';
+import type { VisitsParams } from '../../types';
+
+export interface LoadVisitsForComparison {
+  query?: VisitsParams;
+}
+
+export type VisitsForComparisonLoaded<T = {}> = T & {
+  visitsGroups: Record<string, ShlinkVisit[]>;
+  query?: VisitsParams;
+};

--- a/src/visits/visits-comparison/reducers/types.ts
+++ b/src/visits/visits-comparison/reducers/types.ts
@@ -1,11 +1,20 @@
-import type { ShlinkVisit } from '../../../api-contract';
-import type { VisitsParams } from '../../types';
+import type { ShlinkVisitsParams } from '@shlinkio/shlink-js-sdk/api-contract';
+import type { ProblemDetailsError, ShlinkVisit } from '../../../api-contract';
 
-export interface LoadVisitsForComparison {
-  query?: VisitsParams;
-}
+export type VisitsComparisonInfo = {
+  visitsGroups: Record<string, ShlinkVisit[]>;
+  loading: boolean;
+  errorData: ProblemDetailsError | null;
+  progress: number | null;
+  cancelLoad: boolean;
+  query?: ShlinkVisitsParams;
+};
+
+export type LoadVisitsForComparison = {
+  query?: ShlinkVisitsParams;
+};
 
 export type VisitsForComparisonLoaded<T = {}> = T & {
   visitsGroups: Record<string, ShlinkVisit[]>;
-  query?: VisitsParams;
+  query?: ShlinkVisitsParams;
 };

--- a/test/Main.test.tsx
+++ b/test/Main.test.tsx
@@ -25,6 +25,7 @@ describe('<Main />', () => {
     Overview: () => <>OverviewRoute</>,
     EditShortUrl: () => <>EditShortUrl</>,
     ManageDomains: () => <>ManageDomains</>,
+    TagVisitsComparison: () => <>TagVisitsComparison</>,
   }));
   const setUp = ({ createNotFound, currentPath = '', domainVisitsSupported = true }: SetUpOptions) => render(
     <MemoryRouter initialEntries={[{ pathname: currentPath }]}>
@@ -48,6 +49,7 @@ describe('<Main />', () => {
     ['/domain/domain.com/visits/foo', 'DomainVisits'],
     ['/non-orphan-visits/foo', 'NonOrphanVisits'],
     ['/manage-domains', 'ManageDomains'],
+    ['/tags/compare-visits', 'TagVisitsComparison'],
   ])(
     'renders expected component based on location and server version',
     (currentPath, expectedContent) => {

--- a/test/visits/visits-comparison/reducers/tagVisitsComparison.test.ts
+++ b/test/visits/visits-comparison/reducers/tagVisitsComparison.test.ts
@@ -1,0 +1,101 @@
+import { fromPartial } from '@total-typescript/shoehorn';
+import type { ShlinkApiClient, ShlinkVisit } from '../../../../src/api-contract';
+import { rangeOf } from '../../../../src/utils/helpers';
+import {
+  getTagVisitsForComparison as getTagVisitsForComparisonCreator,
+  tagVisitsComparisonReducerCreator,
+} from '../../../../src/visits/visits-comparison/reducers/tagVisitsComparison';
+import { problemDetailsError } from '../../../__mocks__/ProblemDetailsError.mock';
+
+describe('tagVisitsComparisonReducer', () => {
+  const getTagVisitsCall = vi.fn();
+  const buildShlinkApiClientMock = () => fromPartial<ShlinkApiClient>({ getTagVisits: getTagVisitsCall });
+  const getTagVisitsForComparison = getTagVisitsForComparisonCreator(buildShlinkApiClientMock);
+  const { reducer, cancelGetVisits: cancelGetTagVisitsForComparison } = tagVisitsComparisonReducerCreator(
+    getTagVisitsForComparison,
+  );
+
+  describe('reducer', () => {
+    it('returns loading when pending', () => {
+      const action = getTagVisitsForComparison.pending('', { tags: [] }, undefined);
+      const { loading } = reducer(fromPartial({ loading: false }), action);
+
+      expect(loading).toEqual(true);
+    });
+
+    it('returns cancelLoad when load is cancelled', () => {
+      const { cancelLoad } = reducer(fromPartial({ cancelLoad: false }), cancelGetTagVisitsForComparison());
+      expect(cancelLoad).toEqual(true);
+    });
+
+    it('stops loading and returns error when rejected', () => {
+      const { loading, errorData } = reducer(
+        fromPartial({ loading: true, errorData: null }),
+        getTagVisitsForComparison.rejected(problemDetailsError, '', { tags: [] }, undefined, undefined),
+      );
+
+      expect(loading).toEqual(false);
+      expect(errorData).toEqual(problemDetailsError);
+    });
+
+    it('returns visits groups when fulfilled', () => {
+      const actionVisits: Record<string, ShlinkVisit[]> = {
+        foo: [fromPartial({}), fromPartial({})],
+        bar: [fromPartial({}), fromPartial({})],
+      };
+      const { loading, errorData, visitsGroups } = reducer(
+        fromPartial({ loading: true, errorData: null }),
+        getTagVisitsForComparison.fulfilled({ visitsGroups: actionVisits }, '', { tags: ['foo', 'bar'] }, undefined),
+      );
+
+      expect(loading).toEqual(false);
+      expect(errorData).toBeNull();
+      expect(visitsGroups).toEqual(actionVisits);
+    });
+
+    it('returns new progress when progress changes', () => {
+      const { progress } = reducer(undefined, getTagVisitsForComparison.progressChanged(85));
+      expect(progress).toEqual(85);
+    });
+  });
+
+  describe('getTagVisitsForComparison', () => {
+    const dispatch = vi.fn();
+    const getState = vi.fn().mockReturnValue({
+      tagVisitsComparison: { cancelLoad: false },
+    });
+    const visitsMocks = rangeOf(2, () => fromPartial<ShlinkVisit>({}));
+
+    it.each([
+      [undefined],
+      [{}],
+    ])('dispatches start and success when promise is resolved', async (query) => {
+      const visitsGroups = {
+        foo: visitsMocks,
+        bar: visitsMocks,
+        baz: visitsMocks,
+      };
+      const tags = Object.keys(visitsGroups);
+
+      getTagVisitsCall.mockResolvedValue({
+        data: visitsMocks,
+        pagination: {
+          currentPage: 1,
+          pagesCount: 1,
+          totalItems: 1,
+        },
+      });
+
+      await getTagVisitsForComparison({ tags, query })(dispatch, getState, {});
+
+      expect(dispatch).toHaveBeenCalledTimes(2);
+      expect(dispatch).toHaveBeenLastCalledWith(expect.objectContaining({
+        payload: { visitsGroups },
+      }));
+      expect(getTagVisitsCall).toHaveBeenCalledTimes(tags.length);
+      expect(getTagVisitsCall).toHaveBeenNthCalledWith(1, 'foo', expect.anything());
+      expect(getTagVisitsCall).toHaveBeenNthCalledWith(2, 'bar', expect.anything());
+      expect(getTagVisitsCall).toHaveBeenNthCalledWith(3, 'baz', expect.anything());
+    });
+  });
+});


### PR DESCRIPTION
Part of #7

This PR introduces a few common helpers used for visit comparison reducers. They are inspired in the common helpers for visits, and in some cases they wrap and enhance them.  