### PR TITLE
Subscribe visits comparisons components to mercure hub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [Unreleased]
+### Added
+* [#7](https://github.com/shlinkio/shlink-web-component/issues/7) Allow comparing visits for multiple short URLs, tags or domains.
+
+  When in the tags, domains or short URLs tables, you can now pick up to 5 items to compare their visits. Once selected, you are taken to a section displaying a comparative line chart, which supports all regular visits filtering capabilities.
+
+### Changed
+* *Nothing*
+
+### Deprecated
+* *Nothing*
+
+### Removed
+* *Nothing*
+
+### Fixed
+* *Nothing*
+
+
 ## [0.4.1] - 2023-12-09
 ### Added
 * [#117](https://github.com/shlinkio/shlink-web-component/issues/117) Migrate charts from Chart.JS to Recharts.

--- a/src/visits/reducers/domainVisits.ts
+++ b/src/visits/reducers/domainVisits.ts
@@ -1,6 +1,5 @@
 import type { ShlinkApiClient } from '../../api-contract';
-import { domainMatches } from '../../short-urls/helpers';
-import { isBetween } from '../../utils/dates/helpers/date';
+import { filterCreatedVisitsByDomain } from '../types/helpers';
 import { createVisitsAsyncThunk, createVisitsReducer, lastVisitLoaderForLoader } from './common';
 import type { LoadVisits, VisitsInfo } from './types';
 
@@ -51,11 +50,9 @@ export const domainVisitsReducerCreator = (
   initialState,
   // @ts-expect-error TODO Fix type inference
   asyncThunkCreator,
-  filterCreatedVisits: ({ domain, query = {} }, createdVisits) => {
-    const { startDate, endDate } = query;
-    return createdVisits.filter(
-      ({ shortUrl, visit }) =>
-        shortUrl && domainMatches(shortUrl, domain) && isBetween(visit.date, startDate, endDate),
-    );
-  },
+  filterCreatedVisits: ({ domain, query = {} }, createdVisits) => filterCreatedVisitsByDomain(
+    createdVisits,
+    domain,
+    query,
+  ),
 });

--- a/src/visits/reducers/shortUrlVisits.ts
+++ b/src/visits/reducers/shortUrlVisits.ts
@@ -1,6 +1,5 @@
 import type { ShlinkApiClient, ShlinkVisitsParams } from '../../api-contract';
-import { shortUrlMatches } from '../../short-urls/helpers';
-import { isBetween } from '../../utils/dates/helpers/date';
+import { filterCreatedVisitsByShortUrl } from '../types/helpers';
 import { createVisitsAsyncThunk, createVisitsReducer, lastVisitLoaderForLoader } from './common';
 import type { deleteShortUrlVisits } from './shortUrlVisitsDeletion';
 import type { LoadVisits, VisitsInfo } from './types';
@@ -63,10 +62,7 @@ export const shortUrlVisitsReducerCreator = (
     });
   },
   filterCreatedVisits: ({ shortCode, query = {} }: ShortUrlVisits, createdVisits) => {
-    const { startDate, endDate, domain } = query;
-    return createdVisits.filter(
-      ({ shortUrl, visit }) =>
-        shortUrl && shortUrlMatches(shortUrl, shortCode, domain) && isBetween(visit.date, startDate, endDate),
-    );
+    const { domain, ...restOfQuery } = query;
+    return filterCreatedVisitsByShortUrl(createdVisits, { shortCode, domain }, restOfQuery);
   },
 });

--- a/src/visits/reducers/tagVisits.ts
+++ b/src/visits/reducers/tagVisits.ts
@@ -1,5 +1,5 @@
 import type { ShlinkApiClient } from '../../api-contract';
-import { isBetween } from '../../utils/dates/helpers/date';
+import { filterCreatedVisitsByTag } from '../types/helpers';
 import { createVisitsAsyncThunk, createVisitsReducer, lastVisitLoaderForLoader } from './common';
 import type { LoadVisits, VisitsInfo } from './types';
 
@@ -46,10 +46,9 @@ export const tagVisitsReducerCreator = (asyncThunkCreator: ReturnType<typeof get
   initialState,
   // @ts-expect-error TODO Fix type inference
   asyncThunkCreator,
-  filterCreatedVisits: ({ tag, query = {} }: TagVisits, createdVisits) => {
-    const { startDate, endDate } = query;
-    return createdVisits.filter(
-      ({ shortUrl, visit }) => shortUrl?.tags.includes(tag) && isBetween(visit.date, startDate, endDate),
-    );
-  },
+  filterCreatedVisits: ({ tag, query = {} }: TagVisits, createdVisits) => filterCreatedVisitsByTag(
+    createdVisits,
+    tag,
+    query,
+  ),
 });

--- a/src/visits/reducers/types/index.ts
+++ b/src/visits/reducers/types/index.ts
@@ -1,7 +1,6 @@
-import type { ProblemDetailsError, ShlinkVisit, ShlinkVisitsParams } from '../../../api-contract';
+import type { ProblemDetailsError, ShlinkVisit } from '../../../api-contract';
 import type { DateInterval } from '../../../utils/dates/helpers/dateIntervals';
-
-type VisitsParams = Omit<Omit<ShlinkVisitsParams, 'page' | 'itemsPerPage'>, 'domain'>;
+import type { VisitsQueryParams } from '../../types';
 
 export type VisitsLoadingInfo = {
   loading: boolean;
@@ -9,19 +8,19 @@ export type VisitsLoadingInfo = {
   progress: number | null;
 };
 
-export interface VisitsInfo<QueryType extends VisitsParams = VisitsParams> extends VisitsLoadingInfo {
+export interface VisitsInfo<QueryType extends VisitsQueryParams = VisitsQueryParams> extends VisitsLoadingInfo {
   visits: ShlinkVisit[];
   cancelLoad: boolean;
   query?: QueryType;
   fallbackInterval?: DateInterval;
 }
 
-export interface LoadVisits<QueryType extends VisitsParams = VisitsParams> {
+export interface LoadVisits<QueryType extends VisitsQueryParams = VisitsQueryParams> {
   query?: QueryType;
   doIntervalFallback?: boolean;
 }
 
-export type VisitsLoaded<QueryType extends VisitsParams = VisitsParams, T = {}> = T & {
+export type VisitsLoaded<QueryType extends VisitsQueryParams = VisitsQueryParams, T = {}> = T & {
   visits: ShlinkVisit[];
   query?: QueryType;
 };

--- a/src/visits/services/provideServices.ts
+++ b/src/visits/services/provideServices.ts
@@ -33,6 +33,11 @@ import { TagVisitsComparisonFactory } from '../visits-comparison/TagVisitsCompar
 import * as visitsParser from './VisitsParser';
 
 export const provideServices = (bottle: Bottle, connect: ConnectDecorator) => {
+  const connectWithMercure = (props: string[], actions: string[]) => connect(
+    [...props, 'mercureInfo'],
+    [...actions, 'createNewVisits', 'loadMercureInfo'],
+  );
+
   // Components
   bottle.serviceFactory('MapModal', () => MapModal);
 
@@ -52,51 +57,43 @@ export const provideServices = (bottle: Bottle, connect: ConnectDecorator) => {
   ]));
 
   bottle.factory('TagVisits', TagVisitsFactory);
-  bottle.decorator('TagVisits', connect(
-    ['tagVisits', 'mercureInfo'],
-    ['getTagVisits', 'cancelGetTagVisits', 'createNewVisits', 'loadMercureInfo'],
-  ));
+  bottle.decorator('TagVisits', connectWithMercure(['tagVisits'], ['getTagVisits', 'cancelGetTagVisits']));
 
   bottle.factory('TagVisitsComparison', TagVisitsComparisonFactory);
-  bottle.decorator('TagVisitsComparison', connect(
-    ['tagVisitsComparison', 'mercureInfo'],
-    ['getTagVisitsForComparison', 'cancelGetTagVisitsForComparison', 'createNewVisits', 'loadMercureInfo'],
+  bottle.decorator('TagVisitsComparison', connectWithMercure(
+    ['tagVisitsComparison'],
+    ['getTagVisitsForComparison', 'cancelGetTagVisitsForComparison'],
   ));
 
   bottle.serviceFactory('DomainVisitsComparison', () => DomainVisitsComparison);
-  bottle.decorator('DomainVisitsComparison', connect(
-    ['domainVisitsComparison', 'mercureInfo'],
-    ['getDomainVisitsForComparison', 'cancelGetDomainVisitsForComparison', 'createNewVisits', 'loadMercureInfo'],
+  bottle.decorator('DomainVisitsComparison', connectWithMercure(
+    ['domainVisitsComparison'],
+    ['getDomainVisitsForComparison', 'cancelGetDomainVisitsForComparison'],
   ));
 
   bottle.serviceFactory('ShortUrlVisitsComparison', () => ShortUrlVisitsComparison);
-  bottle.decorator('ShortUrlVisitsComparison', connect(
-    ['shortUrlVisitsComparison', 'shortUrlsDetails', 'mercureInfo'],
+  bottle.decorator('ShortUrlVisitsComparison', connectWithMercure(
+    ['shortUrlVisitsComparison', 'shortUrlsDetails'],
     [
       'getShortUrlVisitsForComparison',
       'cancelGetShortUrlVisitsForComparison',
       'getShortUrlsDetails',
-      'createNewVisits',
-      'loadMercureInfo',
     ],
   ));
 
   bottle.factory('DomainVisits', DomainVisitsFactory);
-  bottle.decorator('DomainVisits', connect(
-    ['domainVisits', 'mercureInfo'],
-    ['getDomainVisits', 'cancelGetDomainVisits', 'createNewVisits', 'loadMercureInfo'],
-  ));
+  bottle.decorator('DomainVisits', connectWithMercure(['domainVisits'], ['getDomainVisits', 'cancelGetDomainVisits']));
 
   bottle.factory('OrphanVisits', OrphanVisitsFactory);
-  bottle.decorator('OrphanVisits', connect(
-    ['orphanVisits', 'mercureInfo', 'orphanVisitsDeletion'],
-    ['getOrphanVisits', 'cancelGetOrphanVisits', 'createNewVisits', 'loadMercureInfo', 'deleteOrphanVisits'],
+  bottle.decorator('OrphanVisits', connectWithMercure(
+    ['orphanVisits', 'orphanVisitsDeletion'],
+    ['getOrphanVisits', 'cancelGetOrphanVisits', 'deleteOrphanVisits'],
   ));
 
   bottle.factory('NonOrphanVisits', NonOrphanVisitsFactory);
-  bottle.decorator('NonOrphanVisits', connect(
-    ['nonOrphanVisits', 'mercureInfo'],
-    ['getNonOrphanVisits', 'cancelGetNonOrphanVisits', 'createNewVisits', 'loadMercureInfo'],
+  bottle.decorator('NonOrphanVisits', connectWithMercure(
+    ['nonOrphanVisits'],
+    ['getNonOrphanVisits', 'cancelGetNonOrphanVisits'],
   ));
 
   // Services

--- a/src/visits/types/helpers.ts
+++ b/src/visits/types/helpers.ts
@@ -1,7 +1,18 @@
 import { countBy, groupBy } from '@shlinkio/data-manipulation';
 import type { ShlinkOrphanVisit, ShlinkVisit, ShlinkVisitsParams } from '../../api-contract';
-import { formatIsoDate } from '../../utils/dates/helpers/date';
-import type { CreateVisit, NormalizedOrphanVisit, NormalizedVisit, Stats, VisitsParams } from './index';
+import type { ShortUrlIdentifier } from '../../short-urls/data';
+import { domainMatches, shortUrlMatches } from '../../short-urls/helpers';
+import { formatIsoDate, isBetween } from '../../utils/dates/helpers/date';
+import type {
+  CreateVisit,
+  NormalizedOrphanVisit,
+  NormalizedVisit,
+  Stats,
+  VisitsParams,
+  VisitsQueryParams,
+} from './index';
+
+// FIXME This file should be in visits/helpers, not in visits/types
 
 export const isOrphanVisit = (visit: ShlinkVisit): visit is ShlinkOrphanVisit =>
   (visit as ShlinkOrphanVisit).visitedUrl !== undefined;
@@ -21,6 +32,40 @@ export const groupNewVisitsByType = (createdVisits: CreateVisit[]): GroupedNewVi
   );
   return { orphanVisits: [], nonOrphanVisits: [], ...groupedVisits };
 };
+
+/**
+ * Filters provided created visits by those matching a short URL and query
+ */
+export const filterCreatedVisitsByShortUrl = (
+  createdVisits: CreateVisit[],
+  { shortCode, domain }: ShortUrlIdentifier,
+  { endDate, startDate }: VisitsQueryParams,
+): CreateVisit[] => createdVisits.filter(
+  ({ shortUrl, visit }) =>
+    shortUrl && shortUrlMatches(shortUrl, shortCode, domain) && isBetween(visit.date, startDate, endDate),
+);
+
+/**
+ * Filters provided created visits by those matching a domain and query
+ */
+export const filterCreatedVisitsByDomain = (
+  createdVisits: CreateVisit[],
+  domain: string,
+  { endDate, startDate }: VisitsQueryParams,
+): CreateVisit[] => createdVisits.filter(
+  ({ shortUrl, visit }) => shortUrl && domainMatches(shortUrl, domain) && isBetween(visit.date, startDate, endDate),
+);
+
+/**
+ * Filters provided created visits by those matching a domain and query
+ */
+export const filterCreatedVisitsByTag = (
+  createdVisits: CreateVisit[],
+  tag: string,
+  { endDate, startDate }: VisitsQueryParams,
+): CreateVisit[] => createdVisits.filter(
+  ({ shortUrl, visit }) => shortUrl?.tags.includes(tag) && isBetween(visit.date, startDate, endDate),
+);
 
 export type HighlightableProps<T extends NormalizedVisit> = T extends NormalizedOrphanVisit
   ? ('referer' | 'country' | 'city' | 'visitedUrl')

--- a/src/visits/types/index.ts
+++ b/src/visits/types/index.ts
@@ -1,4 +1,4 @@
-import type { ShlinkOrphanVisitType, ShlinkShortUrl, ShlinkVisit } from '../../api-contract';
+import type { ShlinkOrphanVisitType, ShlinkShortUrl, ShlinkVisit, ShlinkVisitsParams } from '../../api-contract';
 import type { DateRange } from '../../utils/dates/helpers/dateIntervals';
 
 export interface UserAgent {
@@ -59,3 +59,5 @@ export interface VisitsParams {
   dateRange?: DateRange;
   filter?: VisitsFilter;
 }
+
+export type VisitsQueryParams = Omit<ShlinkVisitsParams, 'page' | 'itemsPerPage' | 'domain'>;

--- a/src/visits/visits-comparison/DomainVisitsComparison.tsx
+++ b/src/visits/visits-comparison/DomainVisitsComparison.tsx
@@ -1,18 +1,19 @@
 import type { FC } from 'react';
 import { useCallback } from 'react';
+import { boundToMercureHub, type MercureBoundProps } from '../../mercure/helpers/boundToMercureHub';
+import { Topics } from '../../mercure/helpers/Topics';
 import { useArrayQueryParam } from '../../utils/helpers/hooks';
 import type { LoadDomainVisitsForComparison } from './reducers/domainVisitsComparison';
 import type { LoadVisitsForComparison, VisitsComparisonInfo } from './reducers/types';
 import { VisitsComparison } from './VisitsComparison';
 
-type DomainVisitsComparisonProps = {
+type DomainVisitsComparisonProps = MercureBoundProps & {
   getDomainVisitsForComparison: (params: LoadDomainVisitsForComparison) => void;
   domainVisitsComparison: VisitsComparisonInfo;
   cancelGetDomainVisitsComparison: () => void;
 };
 
-// TODO Bind to mercure for visits creation
-export const DomainVisitsComparison: FC<DomainVisitsComparisonProps> = (
+export const DomainVisitsComparison: FC<DomainVisitsComparisonProps> = boundToMercureHub((
   { getDomainVisitsForComparison, domainVisitsComparison, cancelGetDomainVisitsComparison },
 ) => {
   const domains = useArrayQueryParam('domains');
@@ -29,4 +30,4 @@ export const DomainVisitsComparison: FC<DomainVisitsComparisonProps> = (
       cancelGetVisitsComparison={cancelGetDomainVisitsComparison}
     />
   );
-};
+}, () => [Topics.visits]);

--- a/src/visits/visits-comparison/ShortUrlVisitsComparison.tsx
+++ b/src/visits/visits-comparison/ShortUrlVisitsComparison.tsx
@@ -1,6 +1,9 @@
 import type { ShlinkVisit } from '@shlinkio/shlink-js-sdk/api-contract';
 import type { FC } from 'react';
 import { useCallback, useEffect, useMemo } from 'react';
+import type { MercureBoundProps } from '../../mercure/helpers/boundToMercureHub';
+import { boundToMercureHub } from '../../mercure/helpers/boundToMercureHub';
+import { Topics } from '../../mercure/helpers/Topics';
 import type { ShortUrlIdentifier } from '../../short-urls/data';
 import { queryToShortUrl, shortUrlToQuery } from '../../short-urls/helpers';
 import type { ShortUrlsDetails } from '../../short-urls/reducers/shortUrlsDetails';
@@ -9,7 +12,7 @@ import type { LoadShortUrlVisitsForComparison } from './reducers/shortUrlVisitsC
 import type { LoadVisitsForComparison, VisitsComparisonInfo } from './reducers/types';
 import { VisitsComparison } from './VisitsComparison';
 
-type ShortUrlVisitsComparisonProps = {
+type ShortUrlVisitsComparisonProps = MercureBoundProps & {
   getShortUrlVisitsForComparison: (params: LoadShortUrlVisitsForComparison) => void;
   shortUrlVisitsComparison: VisitsComparisonInfo;
   cancelGetShortUrlVisitsComparison: () => void;
@@ -17,8 +20,7 @@ type ShortUrlVisitsComparisonProps = {
   getShortUrlsDetails: (identifiers: ShortUrlIdentifier[]) => void;
 };
 
-// TODO Bind to mercure for visits creation
-export const ShortUrlVisitsComparison: FC<ShortUrlVisitsComparisonProps> = ({
+export const ShortUrlVisitsComparison: FC<ShortUrlVisitsComparisonProps> = boundToMercureHub(({
   getShortUrlVisitsForComparison,
   shortUrlVisitsComparison,
   cancelGetShortUrlVisitsComparison,
@@ -64,4 +66,4 @@ export const ShortUrlVisitsComparison: FC<ShortUrlVisitsComparisonProps> = ({
       cancelGetVisitsComparison={cancelGetShortUrlVisitsComparison}
     />
   );
-};
+}, () => [Topics.visits]);

--- a/src/visits/visits-comparison/TagVisitsComparison.tsx
+++ b/src/visits/visits-comparison/TagVisitsComparison.tsx
@@ -1,6 +1,9 @@
 import { useCallback, useMemo } from 'react';
 import type { FCWithDeps } from '../../container/utils';
 import { componentFactory, useDependencies } from '../../container/utils';
+import type { MercureBoundProps } from '../../mercure/helpers/boundToMercureHub';
+import { boundToMercureHub } from '../../mercure/helpers/boundToMercureHub';
+import { Topics } from '../../mercure/helpers/Topics';
 import { Tag } from '../../tags/helpers/Tag';
 import { useArrayQueryParam } from '../../utils/helpers/hooks';
 import type { ColorGenerator } from '../../utils/services/ColorGenerator';
@@ -8,7 +11,7 @@ import type { LoadTagVisitsForComparison } from './reducers/tagVisitsComparison'
 import type { LoadVisitsForComparison, VisitsComparisonInfo } from './reducers/types';
 import { VisitsComparison } from './VisitsComparison';
 
-type TagVisitsComparisonProps = {
+type TagVisitsComparisonProps = MercureBoundProps & {
   getTagVisitsForComparison: (params: LoadTagVisitsForComparison) => void;
   tagVisitsComparison: VisitsComparisonInfo;
   cancelGetTagVisitsComparison: () => void;
@@ -18,8 +21,7 @@ type TagVisitsComparisonDeps = {
   ColorGenerator: ColorGenerator;
 };
 
-// TODO Bind to mercure for visits creation
-const TagVisitsComparison: FCWithDeps<TagVisitsComparisonProps, TagVisitsComparisonDeps> = (
+const TagVisitsComparison: FCWithDeps<TagVisitsComparisonProps, TagVisitsComparisonDeps> = boundToMercureHub((
   { getTagVisitsForComparison, tagVisitsComparison, cancelGetTagVisitsComparison },
 ) => {
   const { ColorGenerator: colorGenerator } = useDependencies(TagVisitsComparison);
@@ -46,6 +48,6 @@ const TagVisitsComparison: FCWithDeps<TagVisitsComparisonProps, TagVisitsCompari
       colors={colors}
     />
   );
-};
+}, () => [Topics.visits]);
 
 export const TagVisitsComparisonFactory = componentFactory(TagVisitsComparison, ['ColorGenerator']);

--- a/src/visits/visits-comparison/reducers/common/createVisitsComparisonAsyncThunk.ts
+++ b/src/visits/visits-comparison/reducers/common/createVisitsComparisonAsyncThunk.ts
@@ -7,7 +7,7 @@ import { createLoadVisitsForComparison } from './createLoadVisitsForComparison';
 
 interface VisitsComparisonAsyncThunkOptions<CreateLoadersParam extends LoadVisitsForComparison> {
   typePrefix: string;
-  createLoaders: (params: CreateLoadersParam) => Record<string, VisitsLoader>;
+  createLoaders: (options: CreateLoadersParam) => Record<string, VisitsLoader>;
   shouldCancel: (getState: () => RootState) => boolean;
 }
 
@@ -17,8 +17,8 @@ export const createVisitsComparisonAsyncThunk = <CreateLoadersParam extends Load
   const progressChanged = createAction<number>(`${typePrefix}/progressChanged`);
   const asyncThunk = createAsyncThunk(
     typePrefix,
-    async (params: CreateLoadersParam, { getState, dispatch }): Promise<VisitsForComparisonLoaded> => {
-      const visitsLoaders = createLoaders(params);
+    async (options: CreateLoadersParam, { getState, dispatch }): Promise<VisitsForComparisonLoaded> => {
+      const visitsLoaders = createLoaders(options);
       const loadVisits = createLoadVisitsForComparison({
         visitsLoaders,
         shouldCancel: () => shouldCancel(getState),
@@ -26,7 +26,7 @@ export const createVisitsComparisonAsyncThunk = <CreateLoadersParam extends Load
       });
       const visitsGroups = await loadVisits();
 
-      return { visitsGroups };
+      return { visitsGroups, query: options.query };
     },
   );
 

--- a/src/visits/visits-comparison/reducers/common/createVisitsComparisonReducer.ts
+++ b/src/visits/visits-comparison/reducers/common/createVisitsComparisonReducer.ts
@@ -38,16 +38,17 @@ export const createVisitsComparisonReducer = <AT extends ReturnType<typeof creat
 
       builder.addCase(createNewVisits, (state, { payload }) => {
         const { visitsGroups, ...rest } = state;
-        const enhancedVisitsGroups = Object.keys(visitsGroups).reduce((acc, groupKey) => {
+        const newVisitGroupsPairs = Object.keys(visitsGroups).map((groupKey) => {
           const newVisits = filterCreatedVisitsForGroup(
             { ...rest, groupKey },
             payload.createdVisits,
           ).map(({ visit }) => visit);
-          acc[groupKey] = [...acc[groupKey], ...newVisits];
-          return acc;
-        }, { ...visitsGroups });
 
-        return { ...state, visitsGroups: enhancedVisitsGroups };
+          return [groupKey, [...newVisits, ...visitsGroups[groupKey]]];
+        });
+        const enhancedVisitsGroups = Object.fromEntries(newVisitGroupsPairs);
+
+        return { ...rest, visitsGroups: enhancedVisitsGroups };
       });
     },
   });

--- a/src/visits/visits-comparison/reducers/common/createVisitsComparisonReducer.ts
+++ b/src/visits/visits-comparison/reducers/common/createVisitsComparisonReducer.ts
@@ -1,25 +1,23 @@
 import { createSlice } from '@reduxjs/toolkit';
 import { parseApiError } from '../../../../api-contract/utils';
-// import { createNewVisits } from '../../../reducers/visitCreation';
+import { createNewVisits } from '../../../reducers/visitCreation';
+import type { CreateVisit } from '../../../types';
 import type { VisitsComparisonInfo } from '../types';
 import type { createVisitsComparisonAsyncThunk } from './createVisitsComparisonAsyncThunk';
 
-type VisitsReducerOptions<
-  State extends VisitsComparisonInfo,
-  AT extends ReturnType<typeof createVisitsComparisonAsyncThunk>,
-> = {
+type VisitsReducerOptions<AT extends ReturnType<typeof createVisitsComparisonAsyncThunk>> = {
   name: string;
   asyncThunkCreator: AT;
-  initialState: State;
-  // filterCreatedVisits: (state: State, createdVisits: CreateVisit[]) => CreateVisit[];
+  initialState: VisitsComparisonInfo;
+  filterCreatedVisitsForGroup: (
+    state: Omit<VisitsComparisonInfo, 'visitsGroups'> & { groupKey: string },
+    createdVisits: CreateVisit[]
+  ) => CreateVisit[];
 };
 
-export const createVisitsComparisonReducer = <
-  State extends VisitsComparisonInfo,
-  AT extends ReturnType<typeof createVisitsComparisonAsyncThunk>,
->(
-    { name, asyncThunkCreator, initialState /* filterCreatedVisits, */ }: VisitsReducerOptions<State, AT>,
-  ) => {
+export const createVisitsComparisonReducer = <AT extends ReturnType<typeof createVisitsComparisonAsyncThunk>>(
+  { name, asyncThunkCreator, initialState, filterCreatedVisitsForGroup }: VisitsReducerOptions<AT>,
+) => {
   const { pending, rejected, fulfilled, progressChanged } = asyncThunkCreator;
   const { reducer, actions } = createSlice({
     name,
@@ -38,14 +36,19 @@ export const createVisitsComparisonReducer = <
 
       builder.addCase(progressChanged, (state, { payload: progress }) => ({ ...state, progress }));
 
-      // TODO Handle visits creation
-      // builder.addCase(createNewVisits, (state, { payload }) => {
-      //   const { visits } = state;
-      //   // @ts-expect-error TODO Fix type inference
-      //   const newVisits = filterCreatedVisits(state, payload.createdVisits).map(({ visit }) => visit);
-      //
-      //   return !newVisits.length ? state : { ...state, visits: [...newVisits, ...visits] };
-      // });
+      builder.addCase(createNewVisits, (state, { payload }) => {
+        const { visitsGroups, ...rest } = state;
+        const enhancedVisitsGroups = Object.keys(visitsGroups).reduce((acc, groupKey) => {
+          const newVisits = filterCreatedVisitsForGroup(
+            { ...rest, groupKey },
+            payload.createdVisits,
+          ).map(({ visit }) => visit);
+          acc[groupKey] = [...acc[groupKey], ...newVisits];
+          return acc;
+        }, { ...visitsGroups });
+
+        return { ...state, visitsGroups: enhancedVisitsGroups };
+      });
     },
   });
   const { cancelGetVisits } = actions;

--- a/src/visits/visits-comparison/reducers/domainVisitsComparison.ts
+++ b/src/visits/visits-comparison/reducers/domainVisitsComparison.ts
@@ -1,6 +1,5 @@
 import type { ShlinkApiClient } from '../../../api-contract';
-import { domainMatches } from '../../../short-urls/helpers';
-import { isBetween } from '../../../utils/dates/helpers/date';
+import { filterCreatedVisitsByDomain } from '../../types/helpers';
 import { createVisitsComparisonAsyncThunk } from './common/createVisitsComparisonAsyncThunk';
 import { createVisitsComparisonReducer } from './common/createVisitsComparisonReducer';
 import type { LoadVisitsForComparison, VisitsComparisonInfo } from './types';
@@ -42,11 +41,9 @@ export const domainVisitsComparisonReducerCreator = (
   initialState,
   // @ts-expect-error TODO Fix type inference
   asyncThunkCreator,
-  filterCreatedVisitsForGroup: ({ groupKey: domain, query = {} }, createdVisits) => {
-    const { startDate, endDate } = query;
-    return createdVisits.filter(
-      ({ shortUrl, visit }) =>
-        shortUrl && domainMatches(shortUrl, domain) && isBetween(visit.date, startDate, endDate),
-    );
-  },
+  filterCreatedVisitsForGroup: ({ groupKey: domain, query = {} }, createdVisits) => filterCreatedVisitsByDomain(
+    createdVisits,
+    domain,
+    query,
+  ),
 });

--- a/src/visits/visits-comparison/reducers/domainVisitsComparison.ts
+++ b/src/visits/visits-comparison/reducers/domainVisitsComparison.ts
@@ -1,4 +1,6 @@
 import type { ShlinkApiClient } from '../../../api-contract';
+import { domainMatches } from '../../../short-urls/helpers';
+import { isBetween } from '../../../utils/dates/helpers/date';
 import { createVisitsComparisonAsyncThunk } from './common/createVisitsComparisonAsyncThunk';
 import { createVisitsComparisonReducer } from './common/createVisitsComparisonReducer';
 import type { LoadVisitsForComparison, VisitsComparisonInfo } from './types';
@@ -40,4 +42,11 @@ export const domainVisitsComparisonReducerCreator = (
   initialState,
   // @ts-expect-error TODO Fix type inference
   asyncThunkCreator,
+  filterCreatedVisitsForGroup: ({ groupKey: domain, query = {} }, createdVisits) => {
+    const { startDate, endDate } = query;
+    return createdVisits.filter(
+      ({ shortUrl, visit }) =>
+        shortUrl && domainMatches(shortUrl, domain) && isBetween(visit.date, startDate, endDate),
+    );
+  },
 });

--- a/src/visits/visits-comparison/reducers/shortUrlVisitsComparison.ts
+++ b/src/visits/visits-comparison/reducers/shortUrlVisitsComparison.ts
@@ -1,6 +1,7 @@
 import type { ShlinkApiClient } from '../../../api-contract';
 import type { ShortUrlIdentifier } from '../../../short-urls/data';
-import { shortUrlToQuery } from '../../../short-urls/helpers';
+import { queryToShortUrl, shortUrlMatches, shortUrlToQuery } from '../../../short-urls/helpers';
+import { isBetween } from '../../../utils/dates/helpers/date';
 import { createVisitsComparisonAsyncThunk } from './common/createVisitsComparisonAsyncThunk';
 import { createVisitsComparisonReducer } from './common/createVisitsComparisonReducer';
 import type { LoadVisitsForComparison, VisitsComparisonInfo } from './types';
@@ -42,4 +43,12 @@ export const shortUrlVisitsComparisonReducerCreator = (
   initialState,
   // @ts-expect-error TODO Fix type inference
   asyncThunkCreator,
+  filterCreatedVisitsForGroup: ({ groupKey, query = {} }, createdVisits) => {
+    const { shortCode, domain } = queryToShortUrl(groupKey);
+    const { endDate, startDate } = query;
+    return createdVisits.filter(
+      ({ shortUrl, visit }) =>
+        shortUrl && shortUrlMatches(shortUrl, shortCode, domain) && isBetween(visit.date, startDate, endDate),
+    );
+  },
 });

--- a/src/visits/visits-comparison/reducers/shortUrlVisitsComparison.ts
+++ b/src/visits/visits-comparison/reducers/shortUrlVisitsComparison.ts
@@ -1,7 +1,7 @@
 import type { ShlinkApiClient } from '../../../api-contract';
 import type { ShortUrlIdentifier } from '../../../short-urls/data';
-import { queryToShortUrl, shortUrlMatches, shortUrlToQuery } from '../../../short-urls/helpers';
-import { isBetween } from '../../../utils/dates/helpers/date';
+import { queryToShortUrl, shortUrlToQuery } from '../../../short-urls/helpers';
+import { filterCreatedVisitsByShortUrl } from '../../types/helpers';
 import { createVisitsComparisonAsyncThunk } from './common/createVisitsComparisonAsyncThunk';
 import { createVisitsComparisonReducer } from './common/createVisitsComparisonReducer';
 import type { LoadVisitsForComparison, VisitsComparisonInfo } from './types';
@@ -43,12 +43,9 @@ export const shortUrlVisitsComparisonReducerCreator = (
   initialState,
   // @ts-expect-error TODO Fix type inference
   asyncThunkCreator,
-  filterCreatedVisitsForGroup: ({ groupKey, query = {} }, createdVisits) => {
-    const { shortCode, domain } = queryToShortUrl(groupKey);
-    const { endDate, startDate } = query;
-    return createdVisits.filter(
-      ({ shortUrl, visit }) =>
-        shortUrl && shortUrlMatches(shortUrl, shortCode, domain) && isBetween(visit.date, startDate, endDate),
-    );
-  },
+  filterCreatedVisitsForGroup: ({ groupKey, query = {} }, createdVisits) => filterCreatedVisitsByShortUrl(
+    createdVisits,
+    queryToShortUrl(groupKey),
+    query,
+  ),
 });

--- a/src/visits/visits-comparison/reducers/tagVisitsComparison.ts
+++ b/src/visits/visits-comparison/reducers/tagVisitsComparison.ts
@@ -1,5 +1,5 @@
 import type { ShlinkApiClient } from '../../../api-contract';
-import { isBetween } from '../../../utils/dates/helpers/date';
+import { filterCreatedVisitsByTag } from '../../types/helpers';
 import { createVisitsComparisonAsyncThunk } from './common/createVisitsComparisonAsyncThunk';
 import { createVisitsComparisonReducer } from './common/createVisitsComparisonReducer';
 import type { LoadVisitsForComparison, VisitsComparisonInfo } from './types';
@@ -39,10 +39,9 @@ export const tagVisitsComparisonReducerCreator = (asyncThunkCreator: ReturnType<
     initialState,
     // @ts-expect-error TODO Fix type inference
     asyncThunkCreator,
-    filterCreatedVisitsForGroup: ({ groupKey: tag, query = {} }, createdVisits) => {
-      const { startDate, endDate } = query;
-      return createdVisits.filter(
-        ({ shortUrl, visit }) => shortUrl?.tags.includes(tag) && isBetween(visit.date, startDate, endDate),
-      );
-    },
+    filterCreatedVisitsForGroup: ({ groupKey: tag, query = {} }, createdVisits) => filterCreatedVisitsByTag(
+      createdVisits,
+      tag,
+      query,
+    ),
   });

--- a/src/visits/visits-comparison/reducers/tagVisitsComparison.ts
+++ b/src/visits/visits-comparison/reducers/tagVisitsComparison.ts
@@ -1,4 +1,5 @@
 import type { ShlinkApiClient } from '../../../api-contract';
+import { isBetween } from '../../../utils/dates/helpers/date';
 import { createVisitsComparisonAsyncThunk } from './common/createVisitsComparisonAsyncThunk';
 import { createVisitsComparisonReducer } from './common/createVisitsComparisonReducer';
 import type { LoadVisitsForComparison, VisitsComparisonInfo } from './types';
@@ -38,4 +39,10 @@ export const tagVisitsComparisonReducerCreator = (asyncThunkCreator: ReturnType<
     initialState,
     // @ts-expect-error TODO Fix type inference
     asyncThunkCreator,
+    filterCreatedVisitsForGroup: ({ groupKey: tag, query = {} }, createdVisits) => {
+      const { startDate, endDate } = query;
+      return createdVisits.filter(
+        ({ shortUrl, visit }) => shortUrl?.tags.includes(tag) && isBetween(visit.date, startDate, endDate),
+      );
+    },
   });

--- a/src/visits/visits-comparison/reducers/types.ts
+++ b/src/visits/visits-comparison/reducers/types.ts
@@ -1,20 +1,18 @@
-import type { ShlinkVisitsParams } from '@shlinkio/shlink-js-sdk/api-contract';
 import type { ShlinkVisit } from '../../../api-contract';
 import type { VisitsLoadingInfo } from '../../reducers/types';
-
-type VisitsParams = Omit<ShlinkVisitsParams, 'page' | 'itemsPerPage' | 'domain'>;
+import type { VisitsQueryParams } from '../../types';
 
 export type VisitsComparisonInfo = VisitsLoadingInfo & {
   visitsGroups: Record<string, ShlinkVisit[]>;
   cancelLoad: boolean;
-  query?: VisitsParams;
+  query?: VisitsQueryParams;
 };
 
 export type LoadVisitsForComparison = {
-  query?: VisitsParams;
+  query?: VisitsQueryParams;
 };
 
 export type VisitsForComparisonLoaded<T = {}> = T & {
   visitsGroups: Record<string, ShlinkVisit[]>;
-  query?: VisitsParams;
+  query?: VisitsQueryParams;
 };

--- a/test/visits/visits-comparison/DomainVisitsComparison.test.tsx
+++ b/test/visits/visits-comparison/DomainVisitsComparison.test.tsx
@@ -1,6 +1,7 @@
 import { cleanup, render, screen } from '@testing-library/react';
 import { fromPartial } from '@total-typescript/shoehorn';
 import { MemoryRouter } from 'react-router-dom';
+import type { MercureInfo } from '../../../src/mercure/reducers/mercureInfo';
 import { DomainVisitsComparison } from '../../../src/visits/visits-comparison/DomainVisitsComparison';
 import { checkAccessibility } from '../../__helpers__/accessibility';
 
@@ -15,6 +16,9 @@ describe('<DomainVisitsComparison />', () => {
         domainVisitsComparison={fromPartial({
           visitsGroups: Object.fromEntries(domains.map((domain) => [domain, []])),
         })}
+        createNewVisits={vi.fn()}
+        loadMercureInfo={vi.fn()}
+        mercureInfo={fromPartial<MercureInfo>({})}
       />
     </MemoryRouter>,
   );

--- a/test/visits/visits-comparison/ShortUrlVisitsComparison.test.tsx
+++ b/test/visits/visits-comparison/ShortUrlVisitsComparison.test.tsx
@@ -1,6 +1,7 @@
 import { cleanup, render, screen } from '@testing-library/react';
 import { fromPartial } from '@total-typescript/shoehorn';
 import { MemoryRouter } from 'react-router-dom';
+import type { MercureInfo } from '../../../src/mercure/reducers/mercureInfo';
 import type { ShortUrlIdentifier } from '../../../src/short-urls/data';
 import { queryToShortUrl, shortUrlToQuery } from '../../../src/short-urls/helpers';
 import { DEFAULT_DOMAIN } from '../../../src/visits/reducers/domainVisits';
@@ -34,6 +35,9 @@ describe('<ShortUrlVisitsComparison />', () => {
           )),
           loading: loadingDetails,
         })}
+        createNewVisits={vi.fn()}
+        loadMercureInfo={vi.fn()}
+        mercureInfo={fromPartial<MercureInfo>({})}
       />
     </MemoryRouter>,
   );

--- a/test/visits/visits-comparison/TagVisitsComparison.test.tsx
+++ b/test/visits/visits-comparison/TagVisitsComparison.test.tsx
@@ -1,6 +1,7 @@
 import { cleanup, render, screen } from '@testing-library/react';
 import { fromPartial } from '@total-typescript/shoehorn';
 import { MemoryRouter } from 'react-router-dom';
+import type { MercureInfo } from '../../../src/mercure/reducers/mercureInfo';
 import { TagVisitsComparisonFactory } from '../../../src/visits/visits-comparison/TagVisitsComparison';
 import { checkAccessibility } from '../../__helpers__/accessibility';
 import { colorGeneratorMock, getColorForKey } from '../../utils/services/__mocks__/ColorGenerator.mock';
@@ -19,6 +20,9 @@ describe('<TagVisitsComparison />', () => {
         tagVisitsComparison={fromPartial({
           visitsGroups: Object.fromEntries(tags.map((tag) => [tag, []])),
         })}
+        createNewVisits={vi.fn()}
+        loadMercureInfo={vi.fn()}
+        mercureInfo={fromPartial<MercureInfo>({})}
       />
     </MemoryRouter>,
   );

--- a/test/visits/visits-comparison/reducers/domainVisitsComparison.test.ts
+++ b/test/visits/visits-comparison/reducers/domainVisitsComparison.test.ts
@@ -1,6 +1,9 @@
 import { fromPartial } from '@total-typescript/shoehorn';
-import type { ShlinkApiClient, ShlinkVisit } from '../../../../src/api-contract';
+import { addDays, subDays } from 'date-fns';
+import type { ShlinkApiClient, ShlinkShortUrl, ShlinkVisit } from '../../../../src/api-contract';
+import { formatIsoDate } from '../../../../src/utils/dates/helpers/date';
 import { rangeOf } from '../../../../src/utils/helpers';
+import { createNewVisits } from '../../../../src/visits/reducers/visitCreation';
 import {
   domainVisitsComparisonReducerCreator,
   getDomainVisitsForComparison as getDomainVisitsForComparisonCreator,
@@ -8,6 +11,8 @@ import {
 import { problemDetailsError } from '../../../__mocks__/ProblemDetailsError.mock';
 
 describe('domainVisitsComparisonReducer', () => {
+  const now = new Date();
+  const visitsMocks = rangeOf(2, () => fromPartial<ShlinkVisit>({}));
   const getDomainVisitsCall = vi.fn();
   const buildShlinkApiClientMock = () => fromPartial<ShlinkApiClient>({ getDomainVisits: getDomainVisitsCall });
   const getDomainVisitsForComparison = getDomainVisitsForComparisonCreator(buildShlinkApiClientMock);
@@ -40,15 +45,15 @@ describe('domainVisitsComparisonReducer', () => {
 
     it('returns visits groups when fulfilled', () => {
       const actionVisits: Record<string, ShlinkVisit[]> = {
-        foo: [fromPartial({}), fromPartial({})],
-        bar: [fromPartial({}), fromPartial({})],
+        'foo.com': visitsMocks,
+        'bar.com': visitsMocks,
       };
       const { loading, errorData, visitsGroups } = reducer(
         fromPartial({ loading: true, errorData: null }),
         getDomainVisitsForComparison.fulfilled(
           { visitsGroups: actionVisits },
           '',
-          { domains: ['foo', 'bar'] },
+          { domains: ['foo.com', 'bar.com'] },
           undefined,
         ),
       );
@@ -62,6 +67,71 @@ describe('domainVisitsComparisonReducer', () => {
       const { progress } = reducer(undefined, getDomainVisitsForComparison.progressChanged(85));
       expect(progress).toEqual(85);
     });
+
+    it.each([
+      // No query. Domain matches foo. Visits prepended to foo
+      [{}, 'foo.com', visitsMocks.length + 1, visitsMocks.length],
+      // No query. Domain matches bar. Visits prepended to bar
+      [{}, 'bar.com', visitsMocks.length, visitsMocks.length + 1],
+      // No query. No domain match. No new visits prepended
+      [{}, 'baz.com', visitsMocks.length, visitsMocks.length],
+      // Query filter in the past. Domain matches foo. No new visits prepended
+      [{ endDate: formatIsoDate(subDays(now, 1)) ?? undefined }, 'foo.com', visitsMocks.length, visitsMocks.length],
+      // Query filter in the future. Domain matches foo. No new visits prepended
+      [{ startDate: formatIsoDate(addDays(now, 1)) ?? undefined }, 'foo.com', visitsMocks.length, visitsMocks.length],
+      // Query filter with start and end in the past. Domain matches foo. No new visits prepended
+      [
+        {
+          startDate: formatIsoDate(subDays(now, 5)) ?? undefined,
+          endDate: formatIsoDate(subDays(now, 2)) ?? undefined,
+        },
+        'foo.com',
+        visitsMocks.length,
+        visitsMocks.length,
+      ],
+      // Query filter with start and end in the present. Domain matches foo. Visits prepended to foo
+      [
+        {
+          startDate: formatIsoDate(subDays(now, 5)) ?? undefined,
+          endDate: formatIsoDate(addDays(now, 3)) ?? undefined,
+        },
+        'foo.com',
+        visitsMocks.length + 1,
+        visitsMocks.length,
+      ],
+      // Query filter with start and end in the present. Domain matches bar. Visits prepended to bar
+      [
+        {
+          startDate: formatIsoDate(subDays(now, 5)) ?? undefined,
+          endDate: formatIsoDate(addDays(now, 3)) ?? undefined,
+        },
+        'bar.com',
+        visitsMocks.length,
+        visitsMocks.length + 1,
+      ],
+      // Query filter with start and end in the present. No domain match. No new visits prepended
+      [
+        {
+          startDate: formatIsoDate(subDays(now, 5)) ?? undefined,
+          endDate: formatIsoDate(addDays(now, 3)) ?? undefined,
+        },
+        'baz.com',
+        visitsMocks.length,
+        visitsMocks.length,
+      ],
+    ])('prepends new visits when visits are created', (query, shortUrlDomain, expectedFooVisits, expectedBarVisits) => {
+      const actionVisits: Record<string, ShlinkVisit[]> = {
+        'foo.com': visitsMocks,
+        'bar.com': visitsMocks,
+      };
+      const shortUrl = fromPartial<ShlinkShortUrl>({ domain: shortUrlDomain });
+      const { visitsGroups } = reducer(fromPartial({ visitsGroups: actionVisits, query }), createNewVisits([
+        fromPartial({ shortUrl, visit: { date: formatIsoDate(now) ?? undefined } }),
+      ]));
+
+      expect(visitsGroups['foo.com']).toHaveLength(expectedFooVisits);
+      expect(visitsGroups['bar.com']).toHaveLength(expectedBarVisits);
+    });
   });
 
   describe('getDomainVisitsForComparison', () => {
@@ -69,7 +139,6 @@ describe('domainVisitsComparisonReducer', () => {
     const getState = vi.fn().mockReturnValue({
       domainVisitsComparison: { cancelLoad: false },
     });
-    const visitsMocks = rangeOf(2, () => fromPartial<ShlinkVisit>({}));
 
     it.each([
       [undefined],

--- a/test/visits/visits-comparison/reducers/domainVisitsComparison.test.ts
+++ b/test/visits/visits-comparison/reducers/domainVisitsComparison.test.ts
@@ -95,7 +95,7 @@ describe('domainVisitsComparisonReducer', () => {
 
       expect(dispatch).toHaveBeenCalledTimes(2);
       expect(dispatch).toHaveBeenLastCalledWith(expect.objectContaining({
-        payload: { visitsGroups },
+        payload: { visitsGroups, query },
       }));
       expect(getDomainVisitsCall).toHaveBeenCalledTimes(domains.length);
       expect(getDomainVisitsCall).toHaveBeenNthCalledWith(1, 'foo', expect.anything());

--- a/test/visits/visits-comparison/reducers/shortUrlVisitsComparison.test.ts
+++ b/test/visits/visits-comparison/reducers/shortUrlVisitsComparison.test.ts
@@ -96,7 +96,7 @@ describe('shortUrlVisitsComparisonReducer', () => {
 
       expect(dispatch).toHaveBeenCalledTimes(2);
       expect(dispatch).toHaveBeenLastCalledWith(expect.objectContaining({
-        payload: { visitsGroups },
+        payload: { visitsGroups, query },
       }));
       expect(getShortUrlVisitsCall).toHaveBeenCalledTimes(shortUrls.length);
       expect(getShortUrlVisitsCall).toHaveBeenNthCalledWith(1, 'foo', expect.anything());

--- a/test/visits/visits-comparison/reducers/shortUrlVisitsComparison.test.ts
+++ b/test/visits/visits-comparison/reducers/shortUrlVisitsComparison.test.ts
@@ -1,7 +1,10 @@
 import { fromPartial } from '@total-typescript/shoehorn';
-import type { ShlinkApiClient, ShlinkVisit } from '../../../../src/api-contract';
+import { addDays, subDays } from 'date-fns';
+import type { ShlinkApiClient, ShlinkShortUrl, ShlinkVisit } from '../../../../src/api-contract';
 import { queryToShortUrl } from '../../../../src/short-urls/helpers';
+import { formatIsoDate } from '../../../../src/utils/dates/helpers/date';
 import { rangeOf } from '../../../../src/utils/helpers';
+import { createNewVisits } from '../../../../src/visits/reducers/visitCreation';
 import {
   getShortUrlVisitsForComparison as getShortUrlVisitsForComparisonCreator,
   shortUrlVisitsComparisonReducerCreator,
@@ -9,6 +12,8 @@ import {
 import { problemDetailsError } from '../../../__mocks__/ProblemDetailsError.mock';
 
 describe('shortUrlVisitsComparisonReducer', () => {
+  const now = new Date();
+  const visitsMocks = rangeOf(2, () => fromPartial<ShlinkVisit>({}));
   const getShortUrlVisitsCall = vi.fn();
   const buildShlinkApiClientMock = () => fromPartial<ShlinkApiClient>({ getShortUrlVisits: getShortUrlVisitsCall });
   const getShortUrlVisitsForComparison = getShortUrlVisitsForComparisonCreator(buildShlinkApiClientMock);
@@ -41,8 +46,8 @@ describe('shortUrlVisitsComparisonReducer', () => {
 
     it('returns visits groups when fulfilled', () => {
       const actionVisits: Record<string, ShlinkVisit[]> = {
-        DEFAULT__foo: [fromPartial({}), fromPartial({})],
-        's.test__bar': [fromPartial({}), fromPartial({})],
+        DEFAULT__foo: visitsMocks,
+        's.test__bar': visitsMocks,
       };
       const { loading, errorData, visitsGroups } = reducer(
         fromPartial({ loading: true, errorData: null }),
@@ -63,6 +68,81 @@ describe('shortUrlVisitsComparisonReducer', () => {
       const { progress } = reducer(undefined, getShortUrlVisitsForComparison.progressChanged(85));
       expect(progress).toEqual(85);
     });
+
+    it.each([
+      // No query. Short URL matches foo. Visits prepended to foo
+      [{}, { shortCode: 'foo' }, visitsMocks.length + 1, visitsMocks.length],
+      // No query. Short URL matches bar. Visits prepended to bar
+      [{}, { shortCode: 'bar', domain: 's.test' }, visitsMocks.length, visitsMocks.length + 1],
+      // // No query. No short URL match. No new visits prepended
+      [{}, { shortCode: 'baz' }, visitsMocks.length, visitsMocks.length],
+      // Query filter in the past. Short URL matches foo. No new visits prepended
+      [
+        { endDate: formatIsoDate(subDays(now, 1)) ?? undefined },
+        { shortCode: 'foo' },
+        visitsMocks.length,
+        visitsMocks.length,
+      ],
+      // Query filter in the future. Short URL matches foo. No new visits prepended
+      [
+        { startDate: formatIsoDate(addDays(now, 1)) ?? undefined },
+        { shortCode: 'foo' },
+        visitsMocks.length,
+        visitsMocks.length,
+      ],
+      // Query filter with start and end in the past. Short URL matches foo. No new visits prepended
+      [
+        {
+          startDate: formatIsoDate(subDays(now, 5)) ?? undefined,
+          endDate: formatIsoDate(subDays(now, 2)) ?? undefined,
+        },
+        { shortCode: 'foo' },
+        visitsMocks.length,
+        visitsMocks.length,
+      ],
+      // Query filter with start and end in the present. Short URL matches foo. Visits prepended to foo
+      [
+        {
+          startDate: formatIsoDate(subDays(now, 5)) ?? undefined,
+          endDate: formatIsoDate(addDays(now, 3)) ?? undefined,
+        },
+        { shortCode: 'foo' },
+        visitsMocks.length + 1,
+        visitsMocks.length,
+      ],
+      // Query filter with start and end in the present. Short URL matches bar. Visits prepended to bar
+      [
+        {
+          startDate: formatIsoDate(subDays(now, 5)) ?? undefined,
+          endDate: formatIsoDate(addDays(now, 3)) ?? undefined,
+        },
+        { shortCode: 'bar', domain: 's.test' },
+        visitsMocks.length,
+        visitsMocks.length + 1,
+      ],
+      // Query filter with start and end in the present. No short URL match. No new visits prepended
+      [
+        {
+          startDate: formatIsoDate(subDays(now, 5)) ?? undefined,
+          endDate: formatIsoDate(addDays(now, 3)) ?? undefined,
+        },
+        { shortCode: 'foo', domain: 's.test' },
+        visitsMocks.length,
+        visitsMocks.length,
+      ],
+    ])('prepends new visits when visits are created', (query, shortUrlId, expectedFooVisits, expectedBarVisits) => {
+      const actionVisits: Record<string, ShlinkVisit[]> = {
+        DEFAULT__foo: visitsMocks,
+        's.test__bar': visitsMocks,
+      };
+      const shortUrl = fromPartial<ShlinkShortUrl>(shortUrlId);
+      const { visitsGroups } = reducer(fromPartial({ visitsGroups: actionVisits, query }), createNewVisits([
+        fromPartial({ shortUrl, visit: { date: formatIsoDate(now) ?? undefined } }),
+      ]));
+
+      expect(visitsGroups.DEFAULT__foo).toHaveLength(expectedFooVisits);
+      expect(visitsGroups['s.test__bar']).toHaveLength(expectedBarVisits);
+    });
   });
 
   describe('getShortUrlVisitsForComparison', () => {
@@ -70,7 +150,6 @@ describe('shortUrlVisitsComparisonReducer', () => {
     const getState = vi.fn().mockReturnValue({
       shortUrlVisitsComparison: { cancelLoad: false },
     });
-    const visitsMocks = rangeOf(2, () => fromPartial<ShlinkVisit>({}));
 
     it.each([
       [undefined],

--- a/test/visits/visits-comparison/reducers/tagVisitsComparison.test.ts
+++ b/test/visits/visits-comparison/reducers/tagVisitsComparison.test.ts
@@ -90,7 +90,7 @@ describe('tagVisitsComparisonReducer', () => {
 
       expect(dispatch).toHaveBeenCalledTimes(2);
       expect(dispatch).toHaveBeenLastCalledWith(expect.objectContaining({
-        payload: { visitsGroups },
+        payload: { visitsGroups, query },
       }));
       expect(getTagVisitsCall).toHaveBeenCalledTimes(tags.length);
       expect(getTagVisitsCall).toHaveBeenNthCalledWith(1, 'foo', expect.anything());

--- a/test/visits/visits-comparison/reducers/tagVisitsComparison.test.ts
+++ b/test/visits/visits-comparison/reducers/tagVisitsComparison.test.ts
@@ -1,6 +1,9 @@
 import { fromPartial } from '@total-typescript/shoehorn';
-import type { ShlinkApiClient, ShlinkVisit } from '../../../../src/api-contract';
+import { addDays, subDays } from 'date-fns';
+import type { ShlinkApiClient, ShlinkShortUrl, ShlinkVisit } from '../../../../src/api-contract';
+import { formatIsoDate } from '../../../../src/utils/dates/helpers/date';
 import { rangeOf } from '../../../../src/utils/helpers';
+import { createNewVisits } from '../../../../src/visits/reducers/visitCreation';
 import {
   getTagVisitsForComparison as getTagVisitsForComparisonCreator,
   tagVisitsComparisonReducerCreator,
@@ -8,6 +11,8 @@ import {
 import { problemDetailsError } from '../../../__mocks__/ProblemDetailsError.mock';
 
 describe('tagVisitsComparisonReducer', () => {
+  const now = new Date();
+  const visitsMocks = rangeOf(2, () => fromPartial<ShlinkVisit>({}));
   const getTagVisitsCall = vi.fn();
   const buildShlinkApiClientMock = () => fromPartial<ShlinkApiClient>({ getTagVisits: getTagVisitsCall });
   const getTagVisitsForComparison = getTagVisitsForComparisonCreator(buildShlinkApiClientMock);
@@ -40,8 +45,8 @@ describe('tagVisitsComparisonReducer', () => {
 
     it('returns visits groups when fulfilled', () => {
       const actionVisits: Record<string, ShlinkVisit[]> = {
-        foo: [fromPartial({}), fromPartial({})],
-        bar: [fromPartial({}), fromPartial({})],
+        foo: visitsMocks,
+        bar: visitsMocks,
       };
       const { loading, errorData, visitsGroups } = reducer(
         fromPartial({ loading: true, errorData: null }),
@@ -57,6 +62,71 @@ describe('tagVisitsComparisonReducer', () => {
       const { progress } = reducer(undefined, getTagVisitsForComparison.progressChanged(85));
       expect(progress).toEqual(85);
     });
+
+    it.each([
+      // No query. Tag matches foo. Visits prepended to foo
+      [{}, 'foo', visitsMocks.length + 1, visitsMocks.length],
+      // No query. Tag matches bar. Visits prepended to bar
+      [{}, 'bar', visitsMocks.length, visitsMocks.length + 1],
+      // No query. No tag match. No new visits prepended
+      [{}, 'baz', visitsMocks.length, visitsMocks.length],
+      // Query filter in the past. Tag matches foo. No new visits prepended
+      [{ endDate: formatIsoDate(subDays(now, 1)) ?? undefined }, 'foo', visitsMocks.length, visitsMocks.length],
+      // Query filter in the future. Tag matches foo. No new visits prepended
+      [{ startDate: formatIsoDate(addDays(now, 1)) ?? undefined }, 'foo', visitsMocks.length, visitsMocks.length],
+      // Query filter with start and end in the past. Tag matches foo. No new visits prepended
+      [
+        {
+          startDate: formatIsoDate(subDays(now, 5)) ?? undefined,
+          endDate: formatIsoDate(subDays(now, 2)) ?? undefined,
+        },
+        'foo',
+        visitsMocks.length,
+        visitsMocks.length,
+      ],
+      // Query filter with start and end in the present. Tag matches foo. Visits prepended to foo
+      [
+        {
+          startDate: formatIsoDate(subDays(now, 5)) ?? undefined,
+          endDate: formatIsoDate(addDays(now, 3)) ?? undefined,
+        },
+        'foo',
+        visitsMocks.length + 1,
+        visitsMocks.length,
+      ],
+      // Query filter with start and end in the present. Tag matches bar. Visits prepended to bar
+      [
+        {
+          startDate: formatIsoDate(subDays(now, 5)) ?? undefined,
+          endDate: formatIsoDate(addDays(now, 3)) ?? undefined,
+        },
+        'bar',
+        visitsMocks.length,
+        visitsMocks.length + 1,
+      ],
+      // Query filter with start and end in the present. No tag match. No new visits prepended
+      [
+        {
+          startDate: formatIsoDate(subDays(now, 5)) ?? undefined,
+          endDate: formatIsoDate(addDays(now, 3)) ?? undefined,
+        },
+        'baz',
+        visitsMocks.length,
+        visitsMocks.length,
+      ],
+    ])('prepends new visits when visits are created', (query, shortUrlTag, expectedFooVisits, expectedBarVisits) => {
+      const actionVisits: Record<string, ShlinkVisit[]> = {
+        foo: visitsMocks,
+        bar: visitsMocks,
+      };
+      const shortUrl = fromPartial<ShlinkShortUrl>({ tags: [shortUrlTag] });
+      const { visitsGroups } = reducer(fromPartial({ visitsGroups: actionVisits, query }), createNewVisits([
+        fromPartial({ shortUrl, visit: { date: formatIsoDate(now) ?? undefined } }),
+      ]));
+
+      expect(visitsGroups.foo).toHaveLength(expectedFooVisits);
+      expect(visitsGroups.bar).toHaveLength(expectedBarVisits);
+    });
   });
 
   describe('getTagVisitsForComparison', () => {
@@ -64,7 +134,6 @@ describe('tagVisitsComparisonReducer', () => {
     const getState = vi.fn().mockReturnValue({
       tagVisitsComparison: { cancelLoad: false },
     });
-    const visitsMocks = rangeOf(2, () => fromPartial<ShlinkVisit>({}));
 
     it.each([
       [undefined],


### PR DESCRIPTION
Closes #7 

Make all visits-comparison components subscribe to the visits mercure topic, and their reducers enhance visits groups via createNewVisits action.