### PR TITLE
Add legend to visits comparisons charts

### DIFF
--- a/src/tags/helpers/TagBullet.tsx
+++ b/src/tags/helpers/TagBullet.tsx
@@ -1,5 +1,5 @@
+import { ColorBullet } from '../../utils/components/ColorBullet';
 import type { ColorGenerator } from '../../utils/services/ColorGenerator';
-import './TagBullet.scss';
 
 interface TagBulletProps {
   tag: string;
@@ -7,8 +7,5 @@ interface TagBulletProps {
 }
 
 export const TagBullet = ({ tag, colorGenerator }: TagBulletProps) => (
-  <div
-    style={{ backgroundColor: colorGenerator.getColorForKey(tag) }}
-    className="tag-bullet"
-  />
+  <ColorBullet color={colorGenerator.getColorForKey(tag)} />
 );

--- a/src/utils/components/ColorBullet.scss
+++ b/src/utils/components/ColorBullet.scss
@@ -1,4 +1,4 @@
-.tag-bullet {
+.color-bullet {
   $width: 20px;
 
   border-radius: 50%;

--- a/src/utils/components/ColorBullet.tsx
+++ b/src/utils/components/ColorBullet.tsx
@@ -1,0 +1,9 @@
+import './ColorBullet.scss';
+
+interface ColorBulletProps {
+  color: string;
+}
+
+export const ColorBullet = ({ color }: ColorBulletProps) => (
+  <div style={{ backgroundColor: color }} className="color-bullet" />
+);

--- a/src/visits/charts/LineChartLegend.tsx
+++ b/src/visits/charts/LineChartLegend.tsx
@@ -1,0 +1,30 @@
+import type { FC } from 'react';
+import { ColorBullet } from '../../utils/components/ColorBullet';
+import { prettify } from '../../utils/helpers/numbers';
+
+type ChartEntry = {
+  value: string;
+  color?: string;
+};
+
+export type LineChartLegendProps = {
+  visitsGroups: Record<string, unknown[]>;
+  entries?: ChartEntry[];
+};
+
+export const LineChartLegend: FC<LineChartLegendProps> = ({ entries = [], visitsGroups }) => {
+  if (entries.length === 0) {
+    return null;
+  }
+
+  return (
+    <ul className="list-unstyled mb-0 mt-2 d-flex flex-wrap justify-content-center gap-3">
+      {entries.map(({ value, color = '' }, index) => (
+        <li className="d-inline" key={`${value}${index}`}>
+          <ColorBullet color={color} />
+          <strong>{value} ({prettify(visitsGroups[value]?.length ?? 0)})</strong>
+        </li>
+      ))}
+    </ul>
+  );
+};

--- a/src/visits/visits-comparison/VisitsComparison.tsx
+++ b/src/visits/visits-comparison/VisitsComparison.tsx
@@ -103,7 +103,7 @@ export const VisitsComparison: FC<VisitsComparisonProps> = ({
         </div>
       </div>
       <VisitsLoadingFeedback info={visitsComparisonInfo} />
-      {!loading && <LineChartCard visitsGroups={normalizedVisitsGroups} />}
+      {!loading && <LineChartCard showLegend visitsGroups={normalizedVisitsGroups} />}
     </>
   );
 };

--- a/test/visits/charts/LineChartCard.test.tsx
+++ b/test/visits/charts/LineChartCard.test.tsx
@@ -7,10 +7,15 @@ import type { NormalizedVisit } from '../../../src/visits/types';
 import { checkAccessibility } from '../../__helpers__/accessibility';
 import { renderWithEvents } from '../../__helpers__/setUpTest';
 
+type SetUpOptions = {
+  visitsGroups?: Record<string, VisitsList>;
+  showLegend?: boolean;
+};
+
 describe('<LineChartCard />', () => {
   const dimensions = { width: 800, height: 400 };
-  const setUp = (visitsGroups: Record<string, VisitsList> = {}) => renderWithEvents(
-    <LineChartCard visitsGroups={visitsGroups} dimensions={dimensions} />,
+  const setUp = ({ visitsGroups = {}, showLegend = false }: SetUpOptions = {}) => renderWithEvents(
+    <LineChartCard visitsGroups={visitsGroups} showLegend={showLegend} dimensions={dimensions} />,
   );
   const asMainVisits = (visits: NormalizedVisit[]): VisitsList => Object.assign(visits, { type: 'main' as const });
   const asHighlightedVisits = (visits: NormalizedVisit[]): VisitsList => Object.assign(
@@ -33,7 +38,9 @@ describe('<LineChartCard />', () => {
     visits,
     expectedActiveIndex,
   ) => {
-    const { user } = setUp({ v: asMainVisits(visits.map((visit) => fromPartial(visit))) });
+    const { user } = setUp({
+      visitsGroups: { v: asMainVisits(visits.map((visit) => fromPartial(visit))) },
+    });
 
     await user.click(screen.getByRole('button', { name: /Group by/ }));
 
@@ -48,27 +55,34 @@ describe('<LineChartCard />', () => {
   });
 
   it.each([
-    [{}],
-    [{ v: asMainVisits([]), h: asHighlightedVisits([]) }],
-    [{ v: asMainVisits([fromPartial<NormalizedVisit>({ date: '2016-04-01' })]), h: asHighlightedVisits([]) }],
-    [{
-      v: asMainVisits([fromPartial<NormalizedVisit>({ date: '2016-04-01' })]),
-      h: asHighlightedVisits([fromPartial<NormalizedVisit>({ date: '2016-04-01' })]),
-    }],
-    [{
-      foo: asColoredVisits([
-        fromPartial<NormalizedVisit>({ date: '2023-04-01' }),
-        fromPartial<NormalizedVisit>({ date: '2023-04-02' }),
-        fromPartial<NormalizedVisit>({ date: '2023-04-03' }),
-      ], 'red'),
-      bar: asColoredVisits([
-        fromPartial<NormalizedVisit>({ date: '2024-04-01' }),
-        fromPartial<NormalizedVisit>({ date: '2024-04-03' }),
-        fromPartial<NormalizedVisit>({ date: '2024-04-05' }),
-      ], 'yellow'),
-    }],
-  ])('renders chart with expected data', (visitsGroups) => {
-    const { container } = setUp(visitsGroups);
+    [{}, false],
+    [{ v: asMainVisits([]), h: asHighlightedVisits([]) }, false],
+    [{ v: asMainVisits([fromPartial<NormalizedVisit>({ date: '2016-04-01' })]), h: asHighlightedVisits([]) }, false],
+    [
+      {
+        v: asMainVisits([fromPartial<NormalizedVisit>({ date: '2016-04-01' })]),
+        h: asHighlightedVisits([fromPartial<NormalizedVisit>({ date: '2016-04-01' })]),
+      },
+      false,
+    ],
+    [
+      {
+        foo: asColoredVisits([
+          fromPartial<NormalizedVisit>({ date: '2023-04-01' }),
+          fromPartial<NormalizedVisit>({ date: '2023-04-02' }),
+          fromPartial<NormalizedVisit>({ date: '2023-04-03' }),
+        ], 'red'),
+        bar: asColoredVisits([
+          fromPartial<NormalizedVisit>({ date: '2024-04-01' }),
+          fromPartial<NormalizedVisit>({ date: '2024-04-03' }),
+          fromPartial<NormalizedVisit>({ date: '2024-04-05' }),
+          fromPartial<NormalizedVisit>({ date: '2024-04-07' }),
+        ], 'yellow'),
+      },
+      true,
+    ],
+  ])('renders chart with expected data', (visitsGroups, showLegend) => {
+    const { container } = setUp({ visitsGroups, showLegend });
     expect(container).toMatchSnapshot();
   });
 });

--- a/test/visits/charts/LineChartLegend.test.tsx
+++ b/test/visits/charts/LineChartLegend.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react';
+import type { LineChartLegendProps } from '../../../src/visits/charts/LineChartLegend';
+import { LineChartLegend } from '../../../src/visits/charts/LineChartLegend';
+import { checkAccessibility } from '../../__helpers__/accessibility';
+
+describe('<LineChartLegend />', () => {
+  const setUp = ({ visitsGroups = {}, entries }: Partial<LineChartLegendProps> = {}) => render(
+    <LineChartLegend visitsGroups={visitsGroups} entries={entries} />,
+  );
+  const createEntries = (...values: string[]) => values.map((value) => ({ value, color: value }));
+
+  it('passes a11y checks', () => checkAccessibility(setUp({
+    entries: createEntries('red', 'green', 'blue'),
+  })));
+
+  it.each([
+    [undefined],
+    [[]],
+  ])('renders no list when entries are empty', (entries) => {
+    const { container } = setUp({ entries });
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders every entry with their corresponding amount', () => {
+    setUp({
+      entries: createEntries('red', 'green', 'blue', 'yellow'),
+      visitsGroups: {
+        red: [1, 2, 3],
+        green: [1, 2, 3, 4, 5],
+        blue: [],
+      },
+    });
+
+    expect(screen.getAllByRole('listitem')).toHaveLength(4);
+    expect(screen.queryByText(/^red/)).toHaveTextContent('red (3)');
+    expect(screen.queryByText(/^green/)).toHaveTextContent('green (5)');
+    expect(screen.queryByText(/^blue/)).toHaveTextContent('blue (0)');
+    expect(screen.queryByText(/^yellow/)).toHaveTextContent('yellow (0)');
+  });
+});

--- a/test/visits/charts/__snapshots__/LineChartCard.test.tsx.snap
+++ b/test/visits/charts/__snapshots__/LineChartCard.test.tsx.snap
@@ -9038,6 +9038,43 @@ exports[`<LineChartCard /> > renders chart with expected data 5`] = `
           </g>
         </svg>
         <div
+          class="recharts-legend-wrapper"
+          style="position: absolute; width: 790px; height: auto; left: 5px; bottom: 5px;"
+        >
+          <ul
+            class="list-unstyled mb-0 mt-2 d-flex flex-wrap justify-content-center gap-3"
+          >
+            <li
+              class="d-inline"
+            >
+              <div
+                class="color-bullet"
+                style="background-color: red;"
+              />
+              <strong>
+                foo
+                 (
+                3
+                )
+              </strong>
+            </li>
+            <li
+              class="d-inline"
+            >
+              <div
+                class="color-bullet"
+                style="background-color: yellow;"
+              />
+              <strong>
+                bar
+                 (
+                4
+                )
+              </strong>
+            </li>
+          </ul>
+        </div>
+        <div
           class="recharts-tooltip-wrapper"
           role="dialog"
           style="visibility: hidden; pointer-events: none; position: absolute; top: 0px; left: 0px;"


### PR DESCRIPTION
Closes #208 

Add a legend at the bottom of visits comparison line charts, showing the total amount of visits for every loaded item in active interval.

![image](https://github.com/shlinkio/shlink-web-component/assets/2719332/e3a3faca-4196-4367-a832-3064441a12a1)
