### PR TITLE
Feature/visits prev period

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
         "@fortawesome/react-fontawesome": "^0.2.0",
         "@reduxjs/toolkit": "^2.0.1",
         "@shlinkio/shlink-frontend-kit": "^0.4.2",
-        "@shlinkio/shlink-js-sdk": "^0.2.0",
+        "@shlinkio/shlink-js-sdk": "^0.2.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-redux": "^9.0.1",
@@ -1765,9 +1765,9 @@
       }
     },
     "node_modules/@shlinkio/shlink-js-sdk": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@shlinkio/shlink-js-sdk/-/shlink-js-sdk-0.2.0.tgz",
-      "integrity": "sha512-onOJiPEaMuKzhGT/f+TbqnARnTowqf3xIxkyOzetYmN3ajcCdknoeEjb7A0fouuJWI0eBJTg9TtELv0+akl5kQ==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@shlinkio/shlink-js-sdk/-/shlink-js-sdk-0.2.2.tgz",
+      "integrity": "sha512-gY9EiaULbEwmrTsnXk0MQUG/3bOvhxHQNOU35psFX2NbB8OzdfoE1iiT/Sez3awmmxz+/p8d6aULBt/ywxukIQ==",
       "optional": true,
       "peer": true
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.4.2",
         "@fortawesome/react-fontawesome": "^0.2.0",
         "@reduxjs/toolkit": "^2.0.1",
-        "@shlinkio/shlink-frontend-kit": "^0.4.1",
+        "@shlinkio/shlink-frontend-kit": "^0.4.2",
         "@shlinkio/shlink-js-sdk": "^0.2.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -1745,12 +1745,12 @@
       }
     },
     "node_modules/@shlinkio/shlink-frontend-kit": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@shlinkio/shlink-frontend-kit/-/shlink-frontend-kit-0.4.1.tgz",
-      "integrity": "sha512-opmcapGLe6rkEbn+vucHzvduYU4gm8o62DdJEuMrXBPmE2DWqJnZ65xuDnqgmBOQw6LEH7j5wiBToYbhmwLReA==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@shlinkio/shlink-frontend-kit/-/shlink-frontend-kit-0.4.2.tgz",
+      "integrity": "sha512-saJyAgmYwRBn0N2wXbUM/zYfYnVE/aKPubQpUetBZUKw5aTFd53XWeRnwnCICk8J9LDc9VeZ6ageOyjmP0z8Dg==",
       "peer": true,
       "dependencies": {
-        "clsx": "^2.0.0",
+        "clsx": "^2.1.0",
         "qs": "^6.11.2",
         "uuid": "^9.0.1"
       },

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.4.2",
     "@fortawesome/react-fontawesome": "^0.2.0",
     "@reduxjs/toolkit": "^2.0.1",
-    "@shlinkio/shlink-frontend-kit": "^0.4.1",
+    "@shlinkio/shlink-frontend-kit": "^0.4.2",
     "@shlinkio/shlink-js-sdk": "^0.2.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@fortawesome/react-fontawesome": "^0.2.0",
     "@reduxjs/toolkit": "^2.0.1",
     "@shlinkio/shlink-frontend-kit": "^0.4.2",
-    "@shlinkio/shlink-js-sdk": "^0.2.0",
+    "@shlinkio/shlink-js-sdk": "^0.2.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-redux": "^9.0.1",

--- a/src/utils/dates/helpers/date.ts
+++ b/src/utils/dates/helpers/date.ts
@@ -39,7 +39,7 @@ export const parseDate = (date: string, theFormat: string) => parse(date, theFor
 
 export const parseISO = (date: DateOrString): Date => (isDateObject(date) ? date : stdParseISO(date));
 
-export const isBetween = (date: DateOrString, start?: DateOrString, end?: DateOrString): boolean => {
+export const isBetween = (date: DateOrString, start?: NullableDate, end?: NullableDate): boolean => {
   const parsedDate = parseISO(date);
   const parsedStart = start && parseISO(start);
   const parsedEnd = end && parseISO(end);

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -29,6 +29,7 @@ export interface ShortUrlCreationSettings {
 export interface VisitsSettings {
   defaultInterval: DateInterval;
   excludeBots?: boolean;
+  loadPrevInterval?: boolean;
 }
 
 export interface TagsSettings {

--- a/src/visits/DomainVisits.tsx
+++ b/src/visits/DomainVisits.tsx
@@ -6,10 +6,10 @@ import type { MercureBoundProps } from '../mercure/helpers/boundToMercureHub';
 import { boundToMercureHub } from '../mercure/helpers/boundToMercureHub';
 import { Topics } from '../mercure/helpers/Topics';
 import type { ReportExporter } from '../utils/services/ReportExporter';
+import { toApiParams } from './helpers';
 import type { DomainVisits as DomainVisitsState, LoadDomainVisits } from './reducers/domainVisits';
 import type { GetVisitsOptions } from './reducers/types';
 import type { NormalizedVisit, VisitsParams } from './types';
-import { toApiParams } from './types/helpers';
 import { VisitsHeader } from './VisitsHeader';
 import { VisitsStats } from './VisitsStats';
 

--- a/src/visits/DomainVisits.tsx
+++ b/src/visits/DomainVisits.tsx
@@ -1,6 +1,5 @@
 import { useCallback } from 'react';
 import { useParams } from 'react-router-dom';
-import type { ShlinkVisitsParams } from '../api-contract';
 import type { FCWithDeps } from '../container/utils';
 import { componentFactory, useDependencies } from '../container/utils';
 import type { MercureBoundProps } from '../mercure/helpers/boundToMercureHub';
@@ -8,7 +7,8 @@ import { boundToMercureHub } from '../mercure/helpers/boundToMercureHub';
 import { Topics } from '../mercure/helpers/Topics';
 import type { ReportExporter } from '../utils/services/ReportExporter';
 import type { DomainVisits as DomainVisitsState, LoadDomainVisits } from './reducers/domainVisits';
-import type { NormalizedVisit } from './types';
+import type { GetVisitsOptions } from './reducers/types';
+import type { NormalizedVisit, VisitsParams } from './types';
 import { toApiParams } from './types/helpers';
 import { VisitsHeader } from './VisitsHeader';
 import { VisitsStats } from './VisitsStats';
@@ -30,8 +30,11 @@ const DomainVisits: FCWithDeps<MercureBoundProps & DomainVisitsProps, DomainVisi
   const { domain = '' } = useParams();
   const [authority, domainId = authority] = domain.split('_');
   const loadVisits = useCallback(
-    (params: ShlinkVisitsParams, doIntervalFallback?: boolean) =>
-      getDomainVisits({ domain: domainId, query: toApiParams(params), doIntervalFallback }),
+    (params: VisitsParams, options: GetVisitsOptions) => getDomainVisits({
+      ...options,
+      domain: domainId,
+      query: toApiParams(params),
+    }),
     [domainId, getDomainVisits],
   );
   const exportCsv = useCallback(

--- a/src/visits/DomainVisits.tsx
+++ b/src/visits/DomainVisits.tsx
@@ -6,7 +6,6 @@ import type { MercureBoundProps } from '../mercure/helpers/boundToMercureHub';
 import { boundToMercureHub } from '../mercure/helpers/boundToMercureHub';
 import { Topics } from '../mercure/helpers/Topics';
 import type { ReportExporter } from '../utils/services/ReportExporter';
-import { toApiParams } from './helpers';
 import type { DomainVisits as DomainVisitsState, LoadDomainVisits } from './reducers/domainVisits';
 import type { GetVisitsOptions } from './reducers/types';
 import type { NormalizedVisit, VisitsParams } from './types';
@@ -31,9 +30,9 @@ const DomainVisits: FCWithDeps<MercureBoundProps & DomainVisitsProps, DomainVisi
   const [authority, domainId = authority] = domain.split('_');
   const loadVisits = useCallback(
     (params: VisitsParams, options: GetVisitsOptions) => getDomainVisits({
-      ...options,
       domain: domainId,
-      query: toApiParams(params),
+      options,
+      params,
     }),
     [domainId, getDomainVisits],
   );

--- a/src/visits/NonOrphanVisits.tsx
+++ b/src/visits/NonOrphanVisits.tsx
@@ -5,7 +5,6 @@ import type { MercureBoundProps } from '../mercure/helpers/boundToMercureHub';
 import { boundToMercureHub } from '../mercure/helpers/boundToMercureHub';
 import { Topics } from '../mercure/helpers/Topics';
 import type { ReportExporter } from '../utils/services/ReportExporter';
-import { toApiParams } from './helpers';
 import type { GetVisitsOptions, LoadVisits, VisitsInfo } from './reducers/types';
 import type { NormalizedVisit, VisitsParams } from './types';
 import { VisitsHeader } from './VisitsHeader';
@@ -30,7 +29,7 @@ const NonOrphanVisits: FCWithDeps<MercureBoundProps & NonOrphanVisitsProps, NonO
     [reportExporter],
   );
   const loadVisits = useCallback(
-    (params: VisitsParams, options: GetVisitsOptions) => getNonOrphanVisits({ ...options, query: toApiParams(params) }),
+    (params: VisitsParams, options: GetVisitsOptions) => getNonOrphanVisits({ options, params }),
     [getNonOrphanVisits],
   );
 

--- a/src/visits/NonOrphanVisits.tsx
+++ b/src/visits/NonOrphanVisits.tsx
@@ -5,9 +5,9 @@ import type { MercureBoundProps } from '../mercure/helpers/boundToMercureHub';
 import { boundToMercureHub } from '../mercure/helpers/boundToMercureHub';
 import { Topics } from '../mercure/helpers/Topics';
 import type { ReportExporter } from '../utils/services/ReportExporter';
+import { toApiParams } from './helpers';
 import type { GetVisitsOptions, LoadVisits, VisitsInfo } from './reducers/types';
 import type { NormalizedVisit, VisitsParams } from './types';
-import { toApiParams } from './types/helpers';
 import { VisitsHeader } from './VisitsHeader';
 import { VisitsStats } from './VisitsStats';
 

--- a/src/visits/NonOrphanVisits.tsx
+++ b/src/visits/NonOrphanVisits.tsx
@@ -5,7 +5,7 @@ import type { MercureBoundProps } from '../mercure/helpers/boundToMercureHub';
 import { boundToMercureHub } from '../mercure/helpers/boundToMercureHub';
 import { Topics } from '../mercure/helpers/Topics';
 import type { ReportExporter } from '../utils/services/ReportExporter';
-import type { LoadVisits, VisitsInfo } from './reducers/types';
+import type { GetVisitsOptions, LoadVisits, VisitsInfo } from './reducers/types';
 import type { NormalizedVisit, VisitsParams } from './types';
 import { toApiParams } from './types/helpers';
 import { VisitsHeader } from './VisitsHeader';
@@ -30,8 +30,7 @@ const NonOrphanVisits: FCWithDeps<MercureBoundProps & NonOrphanVisitsProps, NonO
     [reportExporter],
   );
   const loadVisits = useCallback(
-    (params: VisitsParams, doIntervalFallback?: boolean) =>
-      getNonOrphanVisits({ query: toApiParams(params), doIntervalFallback }),
+    (params: VisitsParams, options: GetVisitsOptions) => getNonOrphanVisits({ ...options, query: toApiParams(params) }),
     [getNonOrphanVisits],
   );
 

--- a/src/visits/OrphanVisits.tsx
+++ b/src/visits/OrphanVisits.tsx
@@ -8,7 +8,7 @@ import { useFeature } from '../utils/features';
 import type { ReportExporter } from '../utils/services/ReportExporter';
 import type { LoadOrphanVisits } from './reducers/orphanVisits';
 import type { OrphanVisitsDeletion } from './reducers/orphanVisitsDeletion';
-import type { VisitsInfo } from './reducers/types';
+import type { GetVisitsOptions, VisitsInfo } from './reducers/types';
 import type { NormalizedVisit, VisitsParams } from './types';
 import { toApiParams } from './types/helpers';
 import { VisitsHeader } from './VisitsHeader';
@@ -35,9 +35,14 @@ const OrphanVisits: FCWithDeps<MercureBoundProps & OrphanVisitsProps, OrphanVisi
     (visits: NormalizedVisit[]) => reportExporter.exportVisits('orphan_visits.csv', visits),
     [reportExporter],
   );
-  const loadVisits = useCallback((params: VisitsParams, doIntervalFallback?: boolean) => getOrphanVisits(
-    { query: toApiParams(params), orphanVisitsType: params.filter?.orphanVisitsType, doIntervalFallback },
-  ), [getOrphanVisits]);
+  const loadVisits = useCallback(
+    (params: VisitsParams, options: GetVisitsOptions) => getOrphanVisits({
+      ...options,
+      query: toApiParams(params),
+      orphanVisitsType: params.filter?.orphanVisitsType,
+    }),
+    [getOrphanVisits],
+  );
   const deletion = useMemo(() => (
     !supportsOrphanVisitsDeletion
       ? undefined

--- a/src/visits/OrphanVisits.tsx
+++ b/src/visits/OrphanVisits.tsx
@@ -6,11 +6,11 @@ import { boundToMercureHub } from '../mercure/helpers/boundToMercureHub';
 import { Topics } from '../mercure/helpers/Topics';
 import { useFeature } from '../utils/features';
 import type { ReportExporter } from '../utils/services/ReportExporter';
+import { toApiParams } from './helpers';
 import type { LoadOrphanVisits } from './reducers/orphanVisits';
 import type { OrphanVisitsDeletion } from './reducers/orphanVisitsDeletion';
 import type { GetVisitsOptions, VisitsInfo } from './reducers/types';
 import type { NormalizedVisit, VisitsParams } from './types';
-import { toApiParams } from './types/helpers';
 import { VisitsHeader } from './VisitsHeader';
 import { VisitsStats } from './VisitsStats';
 

--- a/src/visits/OrphanVisits.tsx
+++ b/src/visits/OrphanVisits.tsx
@@ -6,7 +6,6 @@ import { boundToMercureHub } from '../mercure/helpers/boundToMercureHub';
 import { Topics } from '../mercure/helpers/Topics';
 import { useFeature } from '../utils/features';
 import type { ReportExporter } from '../utils/services/ReportExporter';
-import { toApiParams } from './helpers';
 import type { LoadOrphanVisits } from './reducers/orphanVisits';
 import type { OrphanVisitsDeletion } from './reducers/orphanVisitsDeletion';
 import type { GetVisitsOptions, VisitsInfo } from './reducers/types';
@@ -37,8 +36,8 @@ const OrphanVisits: FCWithDeps<MercureBoundProps & OrphanVisitsProps, OrphanVisi
   );
   const loadVisits = useCallback(
     (params: VisitsParams, options: GetVisitsOptions) => getOrphanVisits({
-      ...options,
-      query: toApiParams(params),
+      options,
+      params,
       orphanVisitsType: params.filter?.orphanVisitsType,
     }),
     [getOrphanVisits],

--- a/src/visits/ShortUrlVisits.tsx
+++ b/src/visits/ShortUrlVisits.tsx
@@ -11,7 +11,6 @@ import { useDecodedShortCodeFromParams } from '../short-urls/helpers/hooks';
 import type { ShortUrlsDetails } from '../short-urls/reducers/shortUrlsDetails';
 import { useFeature } from '../utils/features';
 import type { ReportExporter } from '../utils/services/ReportExporter';
-import { toApiParams } from './helpers';
 import type { LoadShortUrlVisits, ShortUrlVisits as ShortUrlVisitsState } from './reducers/shortUrlVisits';
 import type { ShortUrlVisitsDeletion } from './reducers/shortUrlVisitsDeletion';
 import type { GetVisitsOptions } from './reducers/types';
@@ -51,11 +50,11 @@ const ShortUrlVisits: FCWithDeps<MercureBoundProps & ShortUrlVisitsProps, ShortU
 
   const loadVisits = useCallback(
     (params: VisitsParams, options: GetVisitsOptions) => getShortUrlVisits({
-      ...options,
-      shortCode,
-      query: { ...toApiParams(params), domain },
+      ...identifier,
+      options,
+      params,
     }),
-    [domain, getShortUrlVisits, shortCode],
+    [getShortUrlVisits, identifier],
   );
   const exportCsv = useCallback((visits: NormalizedVisit[]) => reportExporter.exportVisits(
     `short-url_${shortUrl?.shortUrl.replace(/https?:\/\//g, '')}_visits.csv`,

--- a/src/visits/ShortUrlVisits.tsx
+++ b/src/visits/ShortUrlVisits.tsx
@@ -13,6 +13,7 @@ import { useFeature } from '../utils/features';
 import type { ReportExporter } from '../utils/services/ReportExporter';
 import type { LoadShortUrlVisits, ShortUrlVisits as ShortUrlVisitsState } from './reducers/shortUrlVisits';
 import type { ShortUrlVisitsDeletion } from './reducers/shortUrlVisitsDeletion';
+import type { GetVisitsOptions } from './reducers/types';
 import { ShortUrlVisitsHeader } from './ShortUrlVisitsHeader';
 import type { NormalizedVisit, VisitsParams } from './types';
 import { toApiParams } from './types/helpers';
@@ -48,11 +49,14 @@ const ShortUrlVisits: FCWithDeps<MercureBoundProps & ShortUrlVisitsProps, ShortU
   const identifier = useMemo(() => ({ shortCode, domain }), [domain, shortCode]);
   const shortUrl = useMemo(() => shortUrlsDetails.shortUrls?.get(identifier), [identifier, shortUrlsDetails.shortUrls]);
 
-  const loadVisits = useCallback((params: VisitsParams, doIntervalFallback?: boolean) => getShortUrlVisits({
-    shortCode,
-    query: { ...toApiParams(params), domain },
-    doIntervalFallback,
-  }), [domain, getShortUrlVisits, shortCode]);
+  const loadVisits = useCallback(
+    (params: VisitsParams, options: GetVisitsOptions) => getShortUrlVisits({
+      ...options,
+      shortCode,
+      query: { ...toApiParams(params), domain },
+    }),
+    [domain, getShortUrlVisits, shortCode],
+  );
   const exportCsv = useCallback((visits: NormalizedVisit[]) => reportExporter.exportVisits(
     `short-url_${shortUrl?.shortUrl.replace(/https?:\/\//g, '')}_visits.csv`,
     visits,

--- a/src/visits/ShortUrlVisits.tsx
+++ b/src/visits/ShortUrlVisits.tsx
@@ -11,12 +11,12 @@ import { useDecodedShortCodeFromParams } from '../short-urls/helpers/hooks';
 import type { ShortUrlsDetails } from '../short-urls/reducers/shortUrlsDetails';
 import { useFeature } from '../utils/features';
 import type { ReportExporter } from '../utils/services/ReportExporter';
+import { toApiParams } from './helpers';
 import type { LoadShortUrlVisits, ShortUrlVisits as ShortUrlVisitsState } from './reducers/shortUrlVisits';
 import type { ShortUrlVisitsDeletion } from './reducers/shortUrlVisitsDeletion';
 import type { GetVisitsOptions } from './reducers/types';
 import { ShortUrlVisitsHeader } from './ShortUrlVisitsHeader';
 import type { NormalizedVisit, VisitsParams } from './types';
-import { toApiParams } from './types/helpers';
 import { VisitsStats } from './VisitsStats';
 
 export type ShortUrlVisitsProps = {

--- a/src/visits/TagVisits.tsx
+++ b/src/visits/TagVisits.tsx
@@ -1,6 +1,5 @@
 import { useCallback } from 'react';
 import { useParams } from 'react-router-dom';
-import type { ShlinkVisitsParams } from '../api-contract';
 import type { FCWithDeps } from '../container/utils';
 import { componentFactory, useDependencies } from '../container/utils';
 import type { MercureBoundProps } from '../mercure/helpers/boundToMercureHub';
@@ -9,8 +8,9 @@ import { Topics } from '../mercure/helpers/Topics';
 import type { ColorGenerator } from '../utils/services/ColorGenerator';
 import type { ReportExporter } from '../utils/services/ReportExporter';
 import type { LoadTagVisits, TagVisits as TagVisitsState } from './reducers/tagVisits';
+import type { GetVisitsOptions } from './reducers/types';
 import { TagVisitsHeader } from './TagVisitsHeader';
-import type { NormalizedVisit } from './types';
+import type { NormalizedVisit, VisitsParams } from './types';
 import { toApiParams } from './types/helpers';
 import { VisitsStats } from './VisitsStats';
 
@@ -31,8 +31,11 @@ const TagVisits: FCWithDeps<MercureBoundProps & TagVisitsProps, TagVisitsDeps> =
   const { ColorGenerator: colorGenerator, ReportExporter: reportExporter } = useDependencies(TagVisits);
   const { tag = '' } = useParams();
   const loadVisits = useCallback(
-    (params: ShlinkVisitsParams, doIntervalFallback?: boolean) =>
-      getTagVisits({ tag, query: toApiParams(params), doIntervalFallback }),
+    (params: VisitsParams, options: GetVisitsOptions) => getTagVisits({
+      ...options,
+      tag,
+      query: toApiParams(params),
+    }),
     [getTagVisits, tag],
   );
   const exportCsv = useCallback(

--- a/src/visits/TagVisits.tsx
+++ b/src/visits/TagVisits.tsx
@@ -7,7 +7,6 @@ import { boundToMercureHub } from '../mercure/helpers/boundToMercureHub';
 import { Topics } from '../mercure/helpers/Topics';
 import type { ColorGenerator } from '../utils/services/ColorGenerator';
 import type { ReportExporter } from '../utils/services/ReportExporter';
-import { toApiParams } from './helpers';
 import type { LoadTagVisits, TagVisits as TagVisitsState } from './reducers/tagVisits';
 import type { GetVisitsOptions } from './reducers/types';
 import { TagVisitsHeader } from './TagVisitsHeader';
@@ -31,11 +30,7 @@ const TagVisits: FCWithDeps<MercureBoundProps & TagVisitsProps, TagVisitsDeps> =
   const { ColorGenerator: colorGenerator, ReportExporter: reportExporter } = useDependencies(TagVisits);
   const { tag = '' } = useParams();
   const loadVisits = useCallback(
-    (params: VisitsParams, options: GetVisitsOptions) => getTagVisits({
-      ...options,
-      tag,
-      query: toApiParams(params),
-    }),
+    (params: VisitsParams, options: GetVisitsOptions) => getTagVisits({ tag, params, options }),
     [getTagVisits, tag],
   );
   const exportCsv = useCallback(

--- a/src/visits/TagVisits.tsx
+++ b/src/visits/TagVisits.tsx
@@ -7,11 +7,11 @@ import { boundToMercureHub } from '../mercure/helpers/boundToMercureHub';
 import { Topics } from '../mercure/helpers/Topics';
 import type { ColorGenerator } from '../utils/services/ColorGenerator';
 import type { ReportExporter } from '../utils/services/ReportExporter';
+import { toApiParams } from './helpers';
 import type { LoadTagVisits, TagVisits as TagVisitsState } from './reducers/tagVisits';
 import type { GetVisitsOptions } from './reducers/types';
 import { TagVisitsHeader } from './TagVisitsHeader';
 import type { NormalizedVisit, VisitsParams } from './types';
-import { toApiParams } from './types/helpers';
 import { VisitsStats } from './VisitsStats';
 
 export type TagVisitsProps = {

--- a/src/visits/VisitsStats.tsx
+++ b/src/visits/VisitsStats.tsx
@@ -21,7 +21,7 @@ import { OpenMapModalBtn } from './helpers/OpenMapModalBtn';
 import { VisitsFilterDropdown } from './helpers/VisitsFilterDropdown';
 import { VisitsLoadingFeedback } from './helpers/VisitsLoadingFeedback';
 import { VisitsStatsOptions } from './helpers/VisitsStatsOptions';
-import type { VisitsDeletion, VisitsInfo } from './reducers/types';
+import type { GetVisitsOptions, VisitsDeletion, VisitsInfo } from './reducers/types';
 import { normalizeVisits, processStatsFromVisits } from './services/VisitsParser';
 import type { NormalizedOrphanVisit, NormalizedVisit, VisitsParams } from './types';
 import type { HighlightableProps } from './types/helpers';
@@ -29,7 +29,7 @@ import { highlightedVisitsToStats } from './types/helpers';
 import { VisitsTable } from './VisitsTable';
 
 export type VisitsStatsProps = PropsWithChildren<{
-  getVisits: (params: VisitsParams, doIntervalFallback?: boolean) => void;
+  getVisits: (params: VisitsParams, options: GetVisitsOptions) => void;
   visitsInfo: VisitsInfo;
   cancelGetVisits: () => void;
   deletion?: {
@@ -83,11 +83,11 @@ export const VisitsStats: FC<VisitsStatsProps> = (props) => {
   const visitsSettings = useSetting('visits');
   const [activeInterval, setActiveInterval] = useState<DateInterval>();
   const setDates = useCallback(
-    ({ startDate: theStartDate, endDate: theEndDate }: DateRange, newDateInterval?: DateInterval) => {
+    ({ startDate: newStartDate, endDate: newEndDate }: DateRange, newDateInterval?: DateInterval) => {
       updateFiltering({
         dateRange: {
-          startDate: theStartDate ?? undefined,
-          endDate: theEndDate ?? undefined,
+          startDate: newStartDate ?? undefined,
+          endDate: newEndDate ?? undefined,
         },
       });
       setActiveInterval(newDateInterval);
@@ -101,8 +101,8 @@ export const VisitsStats: FC<VisitsStatsProps> = (props) => {
   const [highlightedLabel, setHighlightedLabel] = useState<string | undefined>();
   const isFirstLoad = useRef(true);
   const { search } = useLocation();
-
   const buildSectionUrl = useCallback((subPath?: string) => (!subPath ? search : `${subPath}${search}`), [search]);
+
   const normalizedVisits = useMemo(() => normalizeVisits(visits), [visits]);
   const { os, browsers, referrers, countries, cities, citiesForMap, visitedUrls } = useMemo(
     () => processStatsFromVisits(normalizedVisits),
@@ -112,11 +112,12 @@ export const VisitsStats: FC<VisitsStatsProps> = (props) => {
     Visits: Object.assign(normalizedVisits, { type: 'main' as const }),
     [highlightedLabel ?? 'Selected']: Object.assign(highlightedVisits, { type: 'highlighted' as const }),
   }), [highlightedLabel, highlightedVisits, normalizedVisits]);
+
   const resolvedFilter = useMemo(() => ({
     ...visitsFilter,
     excludeBots: visitsFilter.excludeBots ?? visitsSettings?.excludeBots,
   }), [visitsFilter, visitsSettings?.excludeBots]);
-  const mapLocations = Object.values(citiesForMap);
+  const mapLocations = useMemo(() => Object.values(citiesForMap), [citiesForMap]);
 
   const setSelectedVisits = useCallback((selectedVisits: NormalizedVisit[]) => {
     selectedBar = undefined;
@@ -139,10 +140,16 @@ export const VisitsStats: FC<VisitsStatsProps> = (props) => {
   useEffect(() => cancelGetVisits, [cancelGetVisits]);
   useEffect(() => {
     const resolvedDateRange = !isFirstLoad.current ? dateRange : (dateRange ?? toDateRange(initialInterval.current));
-    getVisits({ dateRange: resolvedDateRange, filter: resolvedFilter }, isFirstLoad.current);
-    setSelectedVisits([]); // Reset selected visits
+    const options: GetVisitsOptions = {
+      doIntervalFallback: isFirstLoad.current,
+      loadPrevInterval: visitsSettings?.loadPrevInterval,
+    };
+
+    getVisits({ dateRange: resolvedDateRange, filter: resolvedFilter }, options);
+
+    setSelectedVisits([]); // Reset selected visits every time we load visits
     isFirstLoad.current = false;
-  }, [dateRange, visitsFilter, getVisits, resolvedFilter, setSelectedVisits]);
+  }, [dateRange, visitsFilter, getVisits, resolvedFilter, setSelectedVisits, visitsSettings?.loadPrevInterval]);
   useEffect(() => {
     // As soon as the fallback is loaded, if the initial interval used the settings one, we do fall back
     if (fallbackInterval && initialInterval.current === (visitsSettings?.defaultInterval ?? 'last30Days')) {

--- a/src/visits/VisitsStats.tsx
+++ b/src/visits/VisitsStats.tsx
@@ -16,6 +16,7 @@ import { useSetting } from '../utils/settings';
 import { DoughnutChartCard } from './charts/DoughnutChartCard';
 import { LineChartCard } from './charts/LineChartCard';
 import { SortableBarChartCard } from './charts/SortableBarChartCard';
+import { highlightedVisitsToStats } from './helpers';
 import { useVisitsQuery } from './helpers/hooks';
 import { OpenMapModalBtn } from './helpers/OpenMapModalBtn';
 import { VisitsFilterDropdown } from './helpers/VisitsFilterDropdown';
@@ -23,9 +24,7 @@ import { VisitsLoadingFeedback } from './helpers/VisitsLoadingFeedback';
 import { VisitsStatsOptions } from './helpers/VisitsStatsOptions';
 import type { GetVisitsOptions, VisitsDeletion, VisitsInfo } from './reducers/types';
 import { normalizeVisits, processStatsFromVisits } from './services/VisitsParser';
-import type { NormalizedOrphanVisit, NormalizedVisit, VisitsParams } from './types';
-import type { HighlightableProps } from './types/helpers';
-import { highlightedVisitsToStats } from './types/helpers';
+import type { HighlightableProps, NormalizedOrphanVisit, NormalizedVisit, VisitsParams } from './types';
 import { VisitsTable } from './VisitsTable';
 
 export type VisitsStatsProps = PropsWithChildren<{

--- a/src/visits/helpers/index.ts
+++ b/src/visits/helpers/index.ts
@@ -6,14 +6,13 @@ import { formatIsoDate, isBetween } from '../../utils/dates/helpers/date';
 import type { DateRange } from '../../utils/dates/helpers/dateIntervals';
 import type {
   CreateVisit,
+  HighlightableProps,
   NormalizedOrphanVisit,
   NormalizedVisit,
   Stats,
   VisitsParams,
   VisitsQueryParams,
-} from './index';
-
-// FIXME This file should be in visits/helpers, not in visits/types
+} from '../types';
 
 export const isOrphanVisit = (visit: ShlinkVisit): visit is ShlinkOrphanVisit =>
   (visit as ShlinkOrphanVisit).visitedUrl !== undefined;
@@ -67,10 +66,6 @@ export const filterCreatedVisitsByTag = (
 ): CreateVisit[] => createdVisits.filter(
   ({ shortUrl, visit }) => shortUrl?.tags.includes(tag) && isBetween(visit.date, startDate, endDate),
 );
-
-export type HighlightableProps<T extends NormalizedVisit> = T extends NormalizedOrphanVisit
-  ? ('referer' | 'country' | 'city' | 'visitedUrl')
-  : ('referer' | 'country' | 'city');
 
 export const highlightedVisitsToStats = <T extends NormalizedVisit>(
   highlightedVisits: T[],

--- a/src/visits/helpers/index.ts
+++ b/src/visits/helpers/index.ts
@@ -11,7 +11,6 @@ import type {
   NormalizedVisit,
   Stats,
   VisitsParams,
-  VisitsQueryParams,
 } from '../types';
 
 export const isOrphanVisit = (visit: ShlinkVisit): visit is ShlinkOrphanVisit =>
@@ -34,35 +33,35 @@ export const groupNewVisitsByType = (createdVisits: CreateVisit[]): GroupedNewVi
 };
 
 /**
- * Filters provided created visits by those matching a short URL and query
+ * Filters created visits array by those matching a short URL and date range
  */
 export const filterCreatedVisitsByShortUrl = (
   createdVisits: CreateVisit[],
   { shortCode, domain }: ShortUrlIdentifier,
-  { endDate, startDate }: VisitsQueryParams,
+  { endDate, startDate }: DateRange = {},
 ): CreateVisit[] => createdVisits.filter(
   ({ shortUrl, visit }) =>
     shortUrl && shortUrlMatches(shortUrl, shortCode, domain) && isBetween(visit.date, startDate, endDate),
 );
 
 /**
- * Filters provided created visits by those matching a domain and query
+ * Filters created visits array by those matching a domain and date range
  */
 export const filterCreatedVisitsByDomain = (
   createdVisits: CreateVisit[],
   domain: string,
-  { endDate, startDate }: VisitsQueryParams,
+  { endDate, startDate }: DateRange = {},
 ): CreateVisit[] => createdVisits.filter(
   ({ shortUrl, visit }) => shortUrl && domainMatches(shortUrl, domain) && isBetween(visit.date, startDate, endDate),
 );
 
 /**
- * Filters provided created visits by those matching a domain and query
+ * Filters created visits array by those matching a domain and date range
  */
 export const filterCreatedVisitsByTag = (
   createdVisits: CreateVisit[],
   tag: string,
-  { endDate, startDate }: VisitsQueryParams,
+  { endDate, startDate }: DateRange = {},
 ): CreateVisit[] => createdVisits.filter(
   ({ shortUrl, visit }) => shortUrl?.tags.includes(tag) && isBetween(visit.date, startDate, endDate),
 );

--- a/src/visits/helpers/index.ts
+++ b/src/visits/helpers/index.ts
@@ -78,9 +78,11 @@ export const toApiDateRange = (dateRange?: DateRange): Pick<ShlinkVisitsParams, 
   return { startDate, endDate };
 };
 
-export const toApiParams = ({ page, itemsPerPage, filter, dateRange }: VisitsParams): ShlinkVisitsParams => {
+export const toApiParams = (
+  { filter, dateRange }: VisitsParams,
+): Omit<ShlinkVisitsParams, 'page' | 'itemsPerPage'> => {
   const { startDate, endDate } = toApiDateRange(dateRange);
   const excludeBots = filter?.excludeBots || undefined;
 
-  return { page, itemsPerPage, startDate, endDate, excludeBots };
+  return { startDate, endDate, excludeBots };
 };

--- a/src/visits/reducers/common/createVisitsAsyncThunk.ts
+++ b/src/visits/reducers/common/createVisitsAsyncThunk.ts
@@ -7,33 +7,32 @@ import type { LoadVisits, VisitsLoaded } from '../types';
 import type { LastVisitLoader, VisitsLoader } from './createLoadVisits';
 import { createLoadVisits } from './createLoadVisits';
 
-interface VisitsAsyncThunkOptions<T extends LoadVisits = LoadVisits, R extends VisitsLoaded = VisitsLoaded> {
+interface VisitsAsyncThunkOptions<T extends LoadVisits = LoadVisits> {
   typePrefix: string;
   createLoaders: (params: T) => [VisitsLoader, LastVisitLoader];
-  getExtraFulfilledPayload: (params: T) => Partial<R>;
   shouldCancel: (getState: () => RootState) => boolean;
 }
 
-export const createVisitsAsyncThunk = <T extends LoadVisits = LoadVisits, R extends VisitsLoaded = VisitsLoaded>(
-  { typePrefix, createLoaders, getExtraFulfilledPayload, shouldCancel }: VisitsAsyncThunkOptions<T, R>,
+export const createVisitsAsyncThunk = <T extends LoadVisits = LoadVisits>(
+  { typePrefix, createLoaders, shouldCancel }: VisitsAsyncThunkOptions<T>,
 ) => {
   const progressChanged = createAction<number>(`${typePrefix}/progressChanged`);
   const fallbackToInterval = createAction<DateInterval>(`${typePrefix}/fallbackToInterval`);
 
-  const asyncThunk = createAsyncThunk(typePrefix, async (params: T, { getState, dispatch }): Promise<Partial<R>> => {
-    const [visitsLoader, lastVisitLoader] = createLoaders(params);
+  const asyncThunk = createAsyncThunk(typePrefix, async (param: T, { getState, dispatch }): Promise<VisitsLoaded> => {
+    const [visitsLoader, lastVisitLoader] = createLoaders(param);
     const loadVisits = createLoadVisits({
       visitsLoader,
       shouldCancel: () => shouldCancel(getState),
       progressChanged: (progress) => dispatch(progressChanged(progress)),
     });
-    const [visits, lastVisit] = await Promise.all([loadVisits(), lastVisitLoader(params.query?.excludeBots)]);
+    const [visits, lastVisit] = await Promise.all([loadVisits(), lastVisitLoader(param.params.filter?.excludeBots)]);
 
     if (!visits.length && lastVisit) {
       dispatch(fallbackToInterval(dateToMatchingInterval(lastVisit.date)));
     }
 
-    return { ...getExtraFulfilledPayload(params), visits };
+    return { ...param, visits };
   });
 
   // Enhance the async thunk with extra actions

--- a/src/visits/reducers/common/createVisitsReducer.ts
+++ b/src/visits/reducers/common/createVisitsReducer.ts
@@ -30,6 +30,7 @@ export const createVisitsReducer = <State extends VisitsInfo, AT extends ReturnT
         { ...initialState, errorData: parseApiError(error) ?? null }
       ));
       builder.addCase(fulfilled, (state, { payload }) => (
+        // Unpack the whole payload, as it could have different props depending on the concrete reducer
         { ...state, ...payload, loading: false, progress: null, errorData: null }
       ));
 

--- a/src/visits/reducers/domainVisits.ts
+++ b/src/visits/reducers/domainVisits.ts
@@ -1,5 +1,5 @@
 import type { ShlinkApiClient } from '../../api-contract';
-import { filterCreatedVisitsByDomain } from '../types/helpers';
+import { filterCreatedVisitsByDomain } from '../helpers';
 import { createVisitsAsyncThunk, createVisitsReducer, lastVisitLoaderForLoader } from './common';
 import type { LoadVisits, VisitsInfo } from './types';
 

--- a/src/visits/reducers/orphanVisits.ts
+++ b/src/visits/reducers/orphanVisits.ts
@@ -1,6 +1,6 @@
 import type { ShlinkApiClient, ShlinkOrphanVisit, ShlinkOrphanVisitType } from '../../api-contract';
 import { isBetween } from '../../utils/dates/helpers/date';
-import { isOrphanVisit } from '../helpers';
+import { isOrphanVisit, toApiParams } from '../helpers';
 import { createVisitsAsyncThunk, createVisitsReducer, lastVisitLoaderForLoader } from './common';
 import type { deleteOrphanVisits } from './orphanVisitsDeletion';
 import type { LoadVisits, VisitsInfo } from './types';
@@ -24,19 +24,20 @@ const matchesType = (visit: ShlinkOrphanVisit, orphanVisitsType?: ShlinkOrphanVi
 
 export const getOrphanVisits = (apiClientFactory: () => ShlinkApiClient) => createVisitsAsyncThunk({
   typePrefix: `${REDUCER_PREFIX}/getOrphanVisits`,
-  createLoaders: ({ orphanVisitsType, query = {}, doIntervalFallback = false }: LoadOrphanVisits) => {
+  createLoaders: ({ orphanVisitsType, params, options }: LoadOrphanVisits) => {
     const apiClient = apiClientFactory();
+    const { doIntervalFallback = false } = options;
+
     const visitsLoader = async (page: number, itemsPerPage: number) => apiClient.getOrphanVisits(
-      { ...query, page, itemsPerPage },
+      { ...toApiParams(params), page, itemsPerPage },
     ).then((result) => {
       const visits = result.data.filter((visit) => isOrphanVisit(visit) && matchesType(visit, orphanVisitsType));
       return { ...result, data: visits };
     });
-    const lastVisitLoader = lastVisitLoaderForLoader(doIntervalFallback, (params) => apiClient.getOrphanVisits(params));
+    const lastVisitLoader = lastVisitLoaderForLoader(doIntervalFallback, (query) => apiClient.getOrphanVisits(query));
 
     return [visitsLoader, lastVisitLoader];
   },
-  getExtraFulfilledPayload: ({ query = {} }: LoadOrphanVisits) => ({ query }),
   shouldCancel: (getState) => getState().orphanVisits.cancelLoad,
 });
 
@@ -50,8 +51,8 @@ export const orphanVisitsReducerCreator = (
   extraReducers: (builder) => {
     builder.addCase(deleteOrphanVisitsThunk.fulfilled, (state) => ({ ...state, visits: [] }));
   },
-  filterCreatedVisits: ({ query = {} }, createdVisits) => {
-    const { startDate, endDate } = query;
+  filterCreatedVisits: ({ params }, createdVisits) => {
+    const { startDate, endDate } = params?.dateRange ?? {};
     return createdVisits.filter(({ visit, shortUrl }) => !shortUrl && isBetween(visit.date, startDate, endDate));
   },
 });

--- a/src/visits/reducers/orphanVisits.ts
+++ b/src/visits/reducers/orphanVisits.ts
@@ -1,6 +1,6 @@
 import type { ShlinkApiClient, ShlinkOrphanVisit, ShlinkOrphanVisitType } from '../../api-contract';
 import { isBetween } from '../../utils/dates/helpers/date';
-import { isOrphanVisit } from '../types/helpers';
+import { isOrphanVisit } from '../helpers';
 import { createVisitsAsyncThunk, createVisitsReducer, lastVisitLoaderForLoader } from './common';
 import type { deleteOrphanVisits } from './orphanVisitsDeletion';
 import type { LoadVisits, VisitsInfo } from './types';

--- a/src/visits/reducers/shortUrlVisits.ts
+++ b/src/visits/reducers/shortUrlVisits.ts
@@ -1,6 +1,6 @@
 import type { ShlinkShortUrlVisitsParams } from '@shlinkio/shlink-js-sdk/api-contract';
 import type { ShlinkApiClient } from '../../api-contract';
-import { filterCreatedVisitsByShortUrl } from '../types/helpers';
+import { filterCreatedVisitsByShortUrl } from '../helpers';
 import { createVisitsAsyncThunk, createVisitsReducer, lastVisitLoaderForLoader } from './common';
 import type { deleteShortUrlVisits } from './shortUrlVisitsDeletion';
 import type { LoadVisits, VisitsInfo } from './types';

--- a/src/visits/reducers/shortUrlVisits.ts
+++ b/src/visits/reducers/shortUrlVisits.ts
@@ -1,17 +1,13 @@
-import type { ShlinkShortUrlVisitsParams } from '@shlinkio/shlink-js-sdk/api-contract';
 import type { ShlinkApiClient } from '../../api-contract';
-import { filterCreatedVisitsByShortUrl } from '../helpers';
+import type { ShortUrlIdentifier } from '../../short-urls/data';
+import { filterCreatedVisitsByShortUrl, toApiParams } from '../helpers';
 import { createVisitsAsyncThunk, createVisitsReducer, lastVisitLoaderForLoader } from './common';
 import type { deleteShortUrlVisits } from './shortUrlVisitsDeletion';
 import type { LoadVisits, VisitsInfo } from './types';
 
 const REDUCER_PREFIX = 'shlink/shortUrlVisits';
 
-type WithShortCode = {
-  shortCode: string;
-};
-
-export type ShortUrlVisits = VisitsInfo<ShlinkShortUrlVisitsParams> & WithShortCode;
+export type ShortUrlVisits = VisitsInfo & ShortUrlIdentifier;
 
 const initialState: ShortUrlVisits = {
   visits: [],
@@ -22,12 +18,14 @@ const initialState: ShortUrlVisits = {
   progress: null,
 };
 
-export type LoadShortUrlVisits = LoadVisits<ShlinkShortUrlVisitsParams> & WithShortCode;
+export type LoadShortUrlVisits = LoadVisits & ShortUrlIdentifier;
 
 export const getShortUrlVisits = (apiClientFactory: () => ShlinkApiClient) => createVisitsAsyncThunk({
   typePrefix: `${REDUCER_PREFIX}/getShortUrlVisits`,
-  createLoaders: ({ shortCode, query = {}, doIntervalFallback = false }: LoadShortUrlVisits) => {
+  createLoaders: ({ shortCode, domain, params, options }: LoadShortUrlVisits) => {
     const apiClient = apiClientFactory();
+    const { doIntervalFallback = false } = options;
+    const query = { ...toApiParams(params), domain };
 
     // TODO
     //     console.log(loadPrevInterval);
@@ -49,14 +47,11 @@ export const getShortUrlVisits = (apiClientFactory: () => ShlinkApiClient) => cr
     );
     const lastVisitLoader = lastVisitLoaderForLoader(
       doIntervalFallback,
-      async (params) => apiClient.getShortUrlVisits(shortCode, { ...params, domain: query.domain }),
+      async (q) => apiClient.getShortUrlVisits(shortCode, { ...q, domain }),
     );
 
     return [visitsLoader, lastVisitLoader];
   },
-  getExtraFulfilledPayload: ({ shortCode, query = {} }: LoadShortUrlVisits) => (
-    { shortCode, query, domain: query.domain }
-  ),
   shouldCancel: (getState) => getState().shortUrlVisits.cancelLoad,
 });
 
@@ -70,15 +65,16 @@ export const shortUrlVisitsReducerCreator = (
   asyncThunkCreator,
   extraReducers: (builder) => {
     builder.addCase(deleteShortUrlVisitsThunk.fulfilled, (state, { payload }) => {
-      if (state.shortCode === payload.shortCode && state.query?.domain === payload.domain) {
+      if (state.shortCode === payload.shortCode && state.domain === payload.domain) {
         return { ...state, visits: [] };
       }
 
       return state;
     });
   },
-  filterCreatedVisits: ({ shortCode, query = {} }: ShortUrlVisits, createdVisits) => {
-    const { domain, ...restOfQuery } = query;
-    return filterCreatedVisitsByShortUrl(createdVisits, { shortCode, domain }, restOfQuery);
-  },
+  filterCreatedVisits: ({ shortCode, domain, params }: ShortUrlVisits, createdVisits) => filterCreatedVisitsByShortUrl(
+    createdVisits,
+    { shortCode, domain },
+    params?.dateRange,
+  ),
 });

--- a/src/visits/reducers/shortUrlVisits.ts
+++ b/src/visits/reducers/shortUrlVisits.ts
@@ -1,4 +1,5 @@
-import type { ShlinkApiClient, ShlinkVisitsParams } from '../../api-contract';
+import type { ShlinkShortUrlVisitsParams } from '@shlinkio/shlink-js-sdk/api-contract';
+import type { ShlinkApiClient } from '../../api-contract';
 import { filterCreatedVisitsByShortUrl } from '../types/helpers';
 import { createVisitsAsyncThunk, createVisitsReducer, lastVisitLoaderForLoader } from './common';
 import type { deleteShortUrlVisits } from './shortUrlVisitsDeletion';
@@ -10,9 +11,7 @@ type WithShortCode = {
   shortCode: string;
 };
 
-export type ShortUrlVisits = VisitsInfo<ShlinkVisitsParams> & WithShortCode;
-
-export type LoadShortUrlVisits = LoadVisits<ShlinkVisitsParams> & WithShortCode;
+export type ShortUrlVisits = VisitsInfo<ShlinkShortUrlVisitsParams> & WithShortCode;
 
 const initialState: ShortUrlVisits = {
   visits: [],
@@ -23,10 +22,27 @@ const initialState: ShortUrlVisits = {
   progress: null,
 };
 
+export type LoadShortUrlVisits = LoadVisits<ShlinkShortUrlVisitsParams> & WithShortCode;
+
 export const getShortUrlVisits = (apiClientFactory: () => ShlinkApiClient) => createVisitsAsyncThunk({
   typePrefix: `${REDUCER_PREFIX}/getShortUrlVisits`,
   createLoaders: ({ shortCode, query = {}, doIntervalFallback = false }: LoadShortUrlVisits) => {
     const apiClient = apiClientFactory();
+
+    // TODO
+    //     console.log(loadPrevInterval);
+    //  1. Extract start and end dates from query.
+    //  2. Calculate the previous date range, by checking the distance from start to end, and getting an equivalent
+    //     range where the new end date is the same as provided start date.
+    //  3. Pass a third visitsLoader which is the same as the first, but overwriting the dates.
+    //  ---
+    //  Nice to have:
+    //  1. There should be a helper, like `lastVisitLoaderForLoader`, which creates visitsLoader and prevVisitsLoader
+    //  2. `query` is coming casted into API params, which is happening on every visits component. Ideally we should get
+    //     a `VisitsParams` object instead, and call toApiParams() only once in the common helper, and additionally, it
+    //     would simplify calculating prev interval from Date objects instead of strings, and reduce the
+    //     Date-to-string-to-Date back and forth
+
     const visitsLoader = async (page: number, itemsPerPage: number) => apiClient.getShortUrlVisits(
       shortCode,
       { ...query, page, itemsPerPage },

--- a/src/visits/reducers/shortUrlVisits.ts
+++ b/src/visits/reducers/shortUrlVisits.ts
@@ -28,18 +28,13 @@ export const getShortUrlVisits = (apiClientFactory: () => ShlinkApiClient) => cr
     const query = { ...toApiParams(params), domain };
 
     // TODO
-    //     console.log(loadPrevInterval);
-    //  1. Extract start and end dates from query.
+    //  1. Extract dateRange from params.
     //  2. Calculate the previous date range, by checking the distance from start to end, and getting an equivalent
     //     range where the new end date is the same as provided start date.
     //  3. Pass a third visitsLoader which is the same as the first, but overwriting the dates.
     //  ---
     //  Nice to have:
     //  1. There should be a helper, like `lastVisitLoaderForLoader`, which creates visitsLoader and prevVisitsLoader
-    //  2. `query` is coming casted into API params, which is happening on every visits component. Ideally we should get
-    //     a `VisitsParams` object instead, and call toApiParams() only once in the common helper, and additionally, it
-    //     would simplify calculating prev interval from Date objects instead of strings, and reduce the
-    //     Date-to-string-to-Date back and forth
 
     const visitsLoader = async (page: number, itemsPerPage: number) => apiClient.getShortUrlVisits(
       shortCode,

--- a/src/visits/reducers/tagVisits.ts
+++ b/src/visits/reducers/tagVisits.ts
@@ -1,17 +1,15 @@
 import type { ShlinkApiClient } from '../../api-contract';
-import { filterCreatedVisitsByTag } from '../helpers';
+import { filterCreatedVisitsByTag, toApiParams } from '../helpers';
 import { createVisitsAsyncThunk, createVisitsReducer, lastVisitLoaderForLoader } from './common';
 import type { LoadVisits, VisitsInfo } from './types';
 
 const REDUCER_PREFIX = 'shlink/tagVisits';
 
-interface WithTag {
+type WithTag = {
   tag: string;
-}
+};
 
-export interface TagVisits extends VisitsInfo, WithTag {}
-
-export interface LoadTagVisits extends LoadVisits, WithTag {}
+export type TagVisits = VisitsInfo & WithTag;
 
 const initialState: TagVisits = {
   visits: [],
@@ -22,22 +20,22 @@ const initialState: TagVisits = {
   progress: null,
 };
 
+export type LoadTagVisits = LoadVisits & WithTag;
+
 export const getTagVisits = (apiClientFactory: () => ShlinkApiClient) => createVisitsAsyncThunk({
   typePrefix: `${REDUCER_PREFIX}/getTagVisits`,
-  createLoaders: ({ tag, query = {}, doIntervalFallback = false }: LoadTagVisits) => {
+  createLoaders: ({ tag, params, options }: LoadTagVisits) => {
     const apiClient = apiClientFactory();
+    const { doIntervalFallback = false } = options;
+
     const visitsLoader = async (page: number, itemsPerPage: number) => apiClient.getTagVisits(
       tag,
-      { ...query, page, itemsPerPage },
+      { ...toApiParams(params), page, itemsPerPage },
     );
-    const lastVisitLoader = lastVisitLoaderForLoader(doIntervalFallback, async (params) => apiClient.getTagVisits(
-      tag,
-      params,
-    ));
+    const lastVisitLoader = lastVisitLoaderForLoader(doIntervalFallback, async (q) => apiClient.getTagVisits(tag, q));
 
     return [visitsLoader, lastVisitLoader];
   },
-  getExtraFulfilledPayload: ({ tag, query = {} }: LoadTagVisits) => ({ tag, query }),
   shouldCancel: (getState) => getState().tagVisits.cancelLoad,
 });
 
@@ -46,9 +44,9 @@ export const tagVisitsReducerCreator = (asyncThunkCreator: ReturnType<typeof get
   initialState,
   // @ts-expect-error TODO Fix type inference
   asyncThunkCreator,
-  filterCreatedVisits: ({ tag, query = {} }: TagVisits, createdVisits) => filterCreatedVisitsByTag(
+  filterCreatedVisits: ({ tag, params }: TagVisits, createdVisits) => filterCreatedVisitsByTag(
     createdVisits,
     tag,
-    query,
+    params?.dateRange,
   ),
 });

--- a/src/visits/reducers/tagVisits.ts
+++ b/src/visits/reducers/tagVisits.ts
@@ -1,5 +1,5 @@
 import type { ShlinkApiClient } from '../../api-contract';
-import { filterCreatedVisitsByTag } from '../types/helpers';
+import { filterCreatedVisitsByTag } from '../helpers';
 import { createVisitsAsyncThunk, createVisitsReducer, lastVisitLoaderForLoader } from './common';
 import type { LoadVisits, VisitsInfo } from './types';
 

--- a/src/visits/reducers/types/index.ts
+++ b/src/visits/reducers/types/index.ts
@@ -8,17 +8,22 @@ export type VisitsLoadingInfo = {
   progress: number | null;
 };
 
-export interface VisitsInfo<QueryType extends VisitsQueryParams = VisitsQueryParams> extends VisitsLoadingInfo {
+export type VisitsInfo<QueryType extends VisitsQueryParams = VisitsQueryParams> = VisitsLoadingInfo & {
   visits: ShlinkVisit[];
+  prevVisits?: ShlinkVisit[];
   cancelLoad: boolean;
   query?: QueryType;
   fallbackInterval?: DateInterval;
-}
+};
 
-export interface LoadVisits<QueryType extends VisitsQueryParams = VisitsQueryParams> {
-  query?: QueryType;
+export type GetVisitsOptions = {
   doIntervalFallback?: boolean;
-}
+  loadPrevInterval?: boolean;
+};
+
+export type LoadVisits<QueryType extends VisitsQueryParams = VisitsQueryParams> = GetVisitsOptions & {
+  query?: QueryType;
+};
 
 export type VisitsLoaded<QueryType extends VisitsQueryParams = VisitsQueryParams, T = {}> = T & {
   visits: ShlinkVisit[];

--- a/src/visits/reducers/types/index.ts
+++ b/src/visits/reducers/types/index.ts
@@ -1,33 +1,32 @@
 import type { ProblemDetailsError, ShlinkVisit } from '../../../api-contract';
 import type { DateInterval } from '../../../utils/dates/helpers/dateIntervals';
-import type { VisitsQueryParams } from '../../types';
-
-export type VisitsLoadingInfo = {
-  loading: boolean;
-  errorData: ProblemDetailsError | null;
-  progress: number | null;
-};
-
-export type VisitsInfo<QueryType extends VisitsQueryParams = VisitsQueryParams> = VisitsLoadingInfo & {
-  visits: ShlinkVisit[];
-  prevVisits?: ShlinkVisit[];
-  cancelLoad: boolean;
-  query?: QueryType;
-  fallbackInterval?: DateInterval;
-};
+import type { VisitsParams } from '../../types';
 
 export type GetVisitsOptions = {
   doIntervalFallback?: boolean;
   loadPrevInterval?: boolean;
 };
 
-export type LoadVisits<QueryType extends VisitsQueryParams = VisitsQueryParams> = GetVisitsOptions & {
-  query?: QueryType;
+export type LoadVisits = {
+  params: VisitsParams; // TODO Should this be the params except for `page` and `itemsPerPage`?
+  options: GetVisitsOptions;
 };
 
-export type VisitsLoaded<QueryType extends VisitsQueryParams = VisitsQueryParams, T = {}> = T & {
+export type VisitsLoaded = {
   visits: ShlinkVisit[];
-  query?: QueryType;
+  prevVisits?: ShlinkVisit[];
+  params?: VisitsParams; // TODO Should this be the params except for `page` and `itemsPerPage`?
+};
+
+export type VisitsLoadingInfo = {
+  loading: boolean;
+  cancelLoad: boolean;
+  errorData: ProblemDetailsError | null;
+  progress: number | null;
+};
+
+export type VisitsInfo = VisitsLoadingInfo & VisitsLoaded & {
+  fallbackInterval?: DateInterval;
 };
 
 export type VisitsDeletion = {

--- a/src/visits/reducers/types/index.ts
+++ b/src/visits/reducers/types/index.ts
@@ -8,14 +8,14 @@ export type GetVisitsOptions = {
 };
 
 export type LoadVisits = {
-  params: VisitsParams; // TODO Should this be the params except for `page` and `itemsPerPage`?
+  params: VisitsParams;
   options: GetVisitsOptions;
 };
 
 export type VisitsLoaded = {
   visits: ShlinkVisit[];
   prevVisits?: ShlinkVisit[];
-  params?: VisitsParams; // TODO Should this be the params except for `page` and `itemsPerPage`?
+  params?: VisitsParams;
 };
 
 export type VisitsLoadingInfo = {

--- a/src/visits/reducers/visitsOverview.ts
+++ b/src/visits/reducers/visitsOverview.ts
@@ -1,8 +1,8 @@
 import { createSlice } from '@reduxjs/toolkit';
 import type { ShlinkApiClient } from '../../api-contract';
 import { createAsyncThunk } from '../../utils/redux';
+import { groupNewVisitsByType } from '../helpers';
 import type { CreateVisit } from '../types';
-import { groupNewVisitsByType } from '../types/helpers';
 import { createNewVisits } from './visitCreation';
 
 const REDUCER_PREFIX = 'shlink/visitsOverview';

--- a/src/visits/services/VisitsParser.ts
+++ b/src/visits/services/VisitsParser.ts
@@ -1,6 +1,6 @@
 import type { ShlinkVisit } from '../../api-contract';
+import { isNormalizedOrphanVisit, isOrphanVisit } from '../helpers';
 import type { CityStats, NormalizedVisit, Stats, VisitsStats } from '../types';
-import { isNormalizedOrphanVisit, isOrphanVisit } from '../types/helpers';
 import { extractDomain, parseUserAgent } from '../utils';
 
 /* eslint-disable no-param-reassign */

--- a/src/visits/types/helpers.ts
+++ b/src/visits/types/helpers.ts
@@ -3,6 +3,7 @@ import type { ShlinkOrphanVisit, ShlinkVisit, ShlinkVisitsParams } from '../../a
 import type { ShortUrlIdentifier } from '../../short-urls/data';
 import { domainMatches, shortUrlMatches } from '../../short-urls/helpers';
 import { formatIsoDate, isBetween } from '../../utils/dates/helpers/date';
+import type { DateRange } from '../../utils/dates/helpers/dateIntervals';
 import type {
   CreateVisit,
   NormalizedOrphanVisit,
@@ -76,9 +77,15 @@ export const highlightedVisitsToStats = <T extends NormalizedVisit>(
   property: HighlightableProps<T>,
 ): Stats => countBy(highlightedVisits, (value: any) => value[property]);
 
-export const toApiParams = ({ page, itemsPerPage, filter, dateRange }: VisitsParams): ShlinkVisitsParams => {
+export const toApiDateRange = (dateRange?: DateRange): Pick<ShlinkVisitsParams, 'startDate' | 'endDate'> => {
   const startDate = (dateRange?.startDate && formatIsoDate(dateRange?.startDate)) ?? undefined;
   const endDate = (dateRange?.endDate && formatIsoDate(dateRange?.endDate)) ?? undefined;
+
+  return { startDate, endDate };
+};
+
+export const toApiParams = ({ page, itemsPerPage, filter, dateRange }: VisitsParams): ShlinkVisitsParams => {
+  const { startDate, endDate } = toApiDateRange(dateRange);
   const excludeBots = filter?.excludeBots || undefined;
 
   return { page, itemsPerPage, startDate, endDate, excludeBots };

--- a/src/visits/types/index.ts
+++ b/src/visits/types/index.ts
@@ -53,14 +53,15 @@ export interface VisitsFilter {
   excludeBots?: boolean;
 }
 
-export interface VisitsParams {
-  page?: number;
-  itemsPerPage?: number;
+export type VisitsFilteringParams = {
   dateRange?: DateRange;
   filter?: VisitsFilter;
-}
+};
 
-export type VisitsQueryParams = Omit<ShlinkVisitsParams, 'page' | 'itemsPerPage'>;
+export type VisitsParams = VisitsFilteringParams & {
+  page?: number;
+  itemsPerPage?: number;
+};
 
 export type HighlightableProps<T extends NormalizedVisit> = T extends NormalizedOrphanVisit
   ? ('referer' | 'country' | 'city' | 'visitedUrl')

--- a/src/visits/types/index.ts
+++ b/src/visits/types/index.ts
@@ -61,3 +61,7 @@ export interface VisitsParams {
 }
 
 export type VisitsQueryParams = Omit<ShlinkVisitsParams, 'page' | 'itemsPerPage'>;
+
+export type HighlightableProps<T extends NormalizedVisit> = T extends NormalizedOrphanVisit
+  ? ('referer' | 'country' | 'city' | 'visitedUrl')
+  : ('referer' | 'country' | 'city');

--- a/src/visits/types/index.ts
+++ b/src/visits/types/index.ts
@@ -1,4 +1,4 @@
-import type { ShlinkOrphanVisitType, ShlinkShortUrl, ShlinkVisit, ShlinkVisitsParams } from '../../api-contract';
+import type { ShlinkOrphanVisitType, ShlinkShortUrl, ShlinkVisit } from '../../api-contract';
 import type { DateRange } from '../../utils/dates/helpers/dateIntervals';
 
 export interface UserAgent {
@@ -53,14 +53,9 @@ export interface VisitsFilter {
   excludeBots?: boolean;
 }
 
-export type VisitsFilteringParams = {
+export type VisitsParams = {
   dateRange?: DateRange;
   filter?: VisitsFilter;
-};
-
-export type VisitsParams = VisitsFilteringParams & {
-  page?: number;
-  itemsPerPage?: number;
 };
 
 export type HighlightableProps<T extends NormalizedVisit> = T extends NormalizedOrphanVisit

--- a/src/visits/types/index.ts
+++ b/src/visits/types/index.ts
@@ -60,4 +60,4 @@ export interface VisitsParams {
   filter?: VisitsFilter;
 }
 
-export type VisitsQueryParams = Omit<ShlinkVisitsParams, 'page' | 'itemsPerPage' | 'domain'>;
+export type VisitsQueryParams = Omit<ShlinkVisitsParams, 'page' | 'itemsPerPage'>;

--- a/src/visits/visits-comparison/VisitsComparison.tsx
+++ b/src/visits/visits-comparison/VisitsComparison.tsx
@@ -8,11 +8,11 @@ import { toDateRange } from '../../utils/dates/helpers/dateIntervals';
 import { useSetting } from '../../utils/settings';
 import { chartColorForIndex } from '../charts/constants';
 import { LineChartCard, type VisitsList } from '../charts/LineChartCard';
+import { toApiParams } from '../helpers';
 import { useVisitsQuery } from '../helpers/hooks';
 import { VisitsFilterDropdown } from '../helpers/VisitsFilterDropdown';
 import { VisitsLoadingFeedback } from '../helpers/VisitsLoadingFeedback';
 import { normalizeVisits } from '../services/VisitsParser';
-import { toApiParams } from '../types/helpers';
 import type { LoadVisitsForComparison, VisitsComparisonInfo } from './reducers/types';
 
 type VisitsComparisonProps = {

--- a/src/visits/visits-comparison/VisitsComparison.tsx
+++ b/src/visits/visits-comparison/VisitsComparison.tsx
@@ -8,7 +8,6 @@ import { toDateRange } from '../../utils/dates/helpers/dateIntervals';
 import { useSetting } from '../../utils/settings';
 import { chartColorForIndex } from '../charts/constants';
 import { LineChartCard, type VisitsList } from '../charts/LineChartCard';
-import { toApiParams } from '../helpers';
 import { useVisitsQuery } from '../helpers/hooks';
 import { VisitsFilterDropdown } from '../helpers/VisitsFilterDropdown';
 import { VisitsLoadingFeedback } from '../helpers/VisitsLoadingFeedback';
@@ -69,7 +68,7 @@ export const VisitsComparison: FC<VisitsComparisonProps> = ({
   useEffect(() => {
     const resolvedDateRange = !isFirstLoad.current ? dateRange : (dateRange ?? toDateRange(initialInterval.current));
     getVisitsForComparison({
-      query: toApiParams({ dateRange: resolvedDateRange, filter: resolvedFilter }),
+      params: { dateRange: resolvedDateRange, filter: resolvedFilter },
     });
     isFirstLoad.current = false;
 

--- a/src/visits/visits-comparison/reducers/common/createVisitsComparisonAsyncThunk.ts
+++ b/src/visits/visits-comparison/reducers/common/createVisitsComparisonAsyncThunk.ts
@@ -17,8 +17,8 @@ export const createVisitsComparisonAsyncThunk = <CreateLoadersParam extends Load
   const progressChanged = createAction<number>(`${typePrefix}/progressChanged`);
   const asyncThunk = createAsyncThunk(
     typePrefix,
-    async (options: CreateLoadersParam, { getState, dispatch }): Promise<VisitsForComparisonLoaded> => {
-      const visitsLoaders = createLoaders(options);
+    async (param: CreateLoadersParam, { getState, dispatch }): Promise<VisitsForComparisonLoaded> => {
+      const visitsLoaders = createLoaders(param);
       const loadVisits = createLoadVisitsForComparison({
         visitsLoaders,
         shouldCancel: () => shouldCancel(getState),
@@ -26,7 +26,7 @@ export const createVisitsComparisonAsyncThunk = <CreateLoadersParam extends Load
       });
       const visitsGroups = await loadVisits();
 
-      return { visitsGroups, query: options.query };
+      return { ...param, visitsGroups };
     },
   );
 

--- a/src/visits/visits-comparison/reducers/domainVisitsComparison.ts
+++ b/src/visits/visits-comparison/reducers/domainVisitsComparison.ts
@@ -1,5 +1,5 @@
 import type { ShlinkApiClient } from '../../../api-contract';
-import { filterCreatedVisitsByDomain } from '../../types/helpers';
+import { filterCreatedVisitsByDomain } from '../../helpers';
 import { createVisitsComparisonAsyncThunk } from './common/createVisitsComparisonAsyncThunk';
 import { createVisitsComparisonReducer } from './common/createVisitsComparisonReducer';
 import type { LoadVisitsForComparison, VisitsComparisonInfo } from './types';

--- a/src/visits/visits-comparison/reducers/domainVisitsComparison.ts
+++ b/src/visits/visits-comparison/reducers/domainVisitsComparison.ts
@@ -1,5 +1,5 @@
 import type { ShlinkApiClient } from '../../../api-contract';
-import { filterCreatedVisitsByDomain } from '../../helpers';
+import { filterCreatedVisitsByDomain, toApiParams } from '../../helpers';
 import { createVisitsComparisonAsyncThunk } from './common/createVisitsComparisonAsyncThunk';
 import { createVisitsComparisonReducer } from './common/createVisitsComparisonReducer';
 import type { LoadVisitsForComparison, VisitsComparisonInfo } from './types';
@@ -19,13 +19,13 @@ const initialState: VisitsComparisonInfo = {
 export const getDomainVisitsForComparison = (apiClientFactory: () => ShlinkApiClient) =>
   createVisitsComparisonAsyncThunk({
     typePrefix: `${REDUCER_PREFIX}/getDomainVisitsForComparison`,
-    createLoaders: ({ domains, query = {} }: LoadDomainVisitsForComparison) => {
+    createLoaders: ({ domains, params }: LoadDomainVisitsForComparison) => {
       const apiClient = apiClientFactory();
       const loaderEntries = domains.map((domain) => [
         domain,
         async (page: number, itemsPerPage: number) => apiClient.getDomainVisits(
           domain,
-          { ...query, page, itemsPerPage },
+          { ...toApiParams(params), page, itemsPerPage },
         ),
       ]);
 
@@ -41,9 +41,9 @@ export const domainVisitsComparisonReducerCreator = (
   initialState,
   // @ts-expect-error TODO Fix type inference
   asyncThunkCreator,
-  filterCreatedVisitsForGroup: ({ groupKey: domain, query = {} }, createdVisits) => filterCreatedVisitsByDomain(
+  filterCreatedVisitsForGroup: ({ groupKey: domain, params }, createdVisits) => filterCreatedVisitsByDomain(
     createdVisits,
     domain,
-    query,
+    params?.dateRange,
   ),
 });

--- a/src/visits/visits-comparison/reducers/shortUrlVisitsComparison.ts
+++ b/src/visits/visits-comparison/reducers/shortUrlVisitsComparison.ts
@@ -1,7 +1,7 @@
 import type { ShlinkApiClient } from '../../../api-contract';
 import type { ShortUrlIdentifier } from '../../../short-urls/data';
 import { queryToShortUrl, shortUrlToQuery } from '../../../short-urls/helpers';
-import { filterCreatedVisitsByShortUrl } from '../../types/helpers';
+import { filterCreatedVisitsByShortUrl } from '../../helpers';
 import { createVisitsComparisonAsyncThunk } from './common/createVisitsComparisonAsyncThunk';
 import { createVisitsComparisonReducer } from './common/createVisitsComparisonReducer';
 import type { LoadVisitsForComparison, VisitsComparisonInfo } from './types';

--- a/src/visits/visits-comparison/reducers/shortUrlVisitsComparison.ts
+++ b/src/visits/visits-comparison/reducers/shortUrlVisitsComparison.ts
@@ -1,7 +1,7 @@
 import type { ShlinkApiClient } from '../../../api-contract';
 import type { ShortUrlIdentifier } from '../../../short-urls/data';
 import { queryToShortUrl, shortUrlToQuery } from '../../../short-urls/helpers';
-import { filterCreatedVisitsByShortUrl } from '../../helpers';
+import { filterCreatedVisitsByShortUrl, toApiParams } from '../../helpers';
 import { createVisitsComparisonAsyncThunk } from './common/createVisitsComparisonAsyncThunk';
 import { createVisitsComparisonReducer } from './common/createVisitsComparisonReducer';
 import type { LoadVisitsForComparison, VisitsComparisonInfo } from './types';
@@ -21,13 +21,13 @@ const initialState: VisitsComparisonInfo = {
 export const getShortUrlVisitsForComparison = (apiClientFactory: () => ShlinkApiClient) =>
   createVisitsComparisonAsyncThunk({
     typePrefix: `${REDUCER_PREFIX}/getShortUrlVisitsForComparison`,
-    createLoaders: ({ shortUrls, query = {} }: LoadShortUrlVisitsForComparison) => {
+    createLoaders: ({ shortUrls, params }: LoadShortUrlVisitsForComparison) => {
       const apiClient = apiClientFactory();
       const loaderEntries = shortUrls.map((identifier) => [
         shortUrlToQuery(identifier),
         async (page: number, itemsPerPage: number) => apiClient.getShortUrlVisits(
           identifier.shortCode,
-          { ...query, domain: identifier.domain, page, itemsPerPage },
+          { ...toApiParams(params), domain: identifier.domain, page, itemsPerPage },
         ),
       ]);
 
@@ -43,9 +43,9 @@ export const shortUrlVisitsComparisonReducerCreator = (
   initialState,
   // @ts-expect-error TODO Fix type inference
   asyncThunkCreator,
-  filterCreatedVisitsForGroup: ({ groupKey, query = {} }, createdVisits) => filterCreatedVisitsByShortUrl(
+  filterCreatedVisitsForGroup: ({ groupKey, params }, createdVisits) => filterCreatedVisitsByShortUrl(
     createdVisits,
     queryToShortUrl(groupKey),
-    query,
+    params?.dateRange,
   ),
 });

--- a/src/visits/visits-comparison/reducers/tagVisitsComparison.ts
+++ b/src/visits/visits-comparison/reducers/tagVisitsComparison.ts
@@ -1,5 +1,5 @@
 import type { ShlinkApiClient } from '../../../api-contract';
-import { filterCreatedVisitsByTag } from '../../helpers';
+import { filterCreatedVisitsByTag, toApiParams } from '../../helpers';
 import { createVisitsComparisonAsyncThunk } from './common/createVisitsComparisonAsyncThunk';
 import { createVisitsComparisonReducer } from './common/createVisitsComparisonReducer';
 import type { LoadVisitsForComparison, VisitsComparisonInfo } from './types';
@@ -18,13 +18,13 @@ const initialState: VisitsComparisonInfo = {
 
 export const getTagVisitsForComparison = (apiClientFactory: () => ShlinkApiClient) => createVisitsComparisonAsyncThunk({
   typePrefix: `${REDUCER_PREFIX}/getTagVisitsForComparison`,
-  createLoaders: ({ tags, query = {} }: LoadTagVisitsForComparison) => {
+  createLoaders: ({ tags, params }: LoadTagVisitsForComparison) => {
     const apiClient = apiClientFactory();
     const loaderEntries = tags.map((tag) => [
       tag,
       async (page: number, itemsPerPage: number) => apiClient.getTagVisits(
         tag,
-        { ...query, page, itemsPerPage },
+        { ...toApiParams(params), page, itemsPerPage },
       ),
     ]);
 
@@ -39,9 +39,9 @@ export const tagVisitsComparisonReducerCreator = (asyncThunkCreator: ReturnType<
     initialState,
     // @ts-expect-error TODO Fix type inference
     asyncThunkCreator,
-    filterCreatedVisitsForGroup: ({ groupKey: tag, query = {} }, createdVisits) => filterCreatedVisitsByTag(
+    filterCreatedVisitsForGroup: ({ groupKey: tag, params }, createdVisits) => filterCreatedVisitsByTag(
       createdVisits,
       tag,
-      query,
+      params?.dateRange,
     ),
   });

--- a/src/visits/visits-comparison/reducers/tagVisitsComparison.ts
+++ b/src/visits/visits-comparison/reducers/tagVisitsComparison.ts
@@ -1,5 +1,5 @@
 import type { ShlinkApiClient } from '../../../api-contract';
-import { filterCreatedVisitsByTag } from '../../types/helpers';
+import { filterCreatedVisitsByTag } from '../../helpers';
 import { createVisitsComparisonAsyncThunk } from './common/createVisitsComparisonAsyncThunk';
 import { createVisitsComparisonReducer } from './common/createVisitsComparisonReducer';
 import type { LoadVisitsForComparison, VisitsComparisonInfo } from './types';

--- a/src/visits/visits-comparison/reducers/types.ts
+++ b/src/visits/visits-comparison/reducers/types.ts
@@ -1,17 +1,14 @@
 import type { ShlinkVisit } from '../../../api-contract';
 import type { VisitsLoadingInfo } from '../../reducers/types';
-import type { VisitsQueryParams } from '../../types';
-
-export type VisitsComparisonInfo = VisitsLoadingInfo & {
-  visitsGroups: Record<string, ShlinkVisit[]>;
-  query?: VisitsQueryParams;
-};
+import type { VisitsParams } from '../../types';
 
 export type LoadVisitsForComparison = {
-  query?: VisitsQueryParams;
+  params: VisitsParams;
 };
 
-export type VisitsForComparisonLoaded<T = {}> = T & {
+export type VisitsForComparisonLoaded = {
   visitsGroups: Record<string, ShlinkVisit[]>;
-  query?: VisitsQueryParams;
+  params?: VisitsParams;
 };
+
+export type VisitsComparisonInfo = VisitsLoadingInfo & VisitsForComparisonLoaded;

--- a/src/visits/visits-comparison/reducers/types.ts
+++ b/src/visits/visits-comparison/reducers/types.ts
@@ -4,7 +4,6 @@ import type { VisitsQueryParams } from '../../types';
 
 export type VisitsComparisonInfo = VisitsLoadingInfo & {
   visitsGroups: Record<string, ShlinkVisit[]>;
-  cancelLoad: boolean;
   query?: VisitsQueryParams;
 };
 

--- a/test/utils/dates/helpers/date.test.ts
+++ b/test/utils/dates/helpers/date.test.ts
@@ -22,6 +22,7 @@ describe('date', () => {
   describe('isBetween', () => {
     it.each([
       [now, undefined, undefined, true],
+      [now, null, null, true],
       [now, subDays(now, 1), undefined, true],
       [now, now, undefined, true],
       [now, undefined, addDays(now, 1), true],

--- a/test/visits/ShortUrlVisits.test.tsx
+++ b/test/visits/ShortUrlVisits.test.tsx
@@ -46,7 +46,12 @@ describe('<ShortUrlVisits />', () => {
     </MemoryRouter>,
   );
 
-  it('passes a11y checks', () => checkAccessibility(setUp()));
+  it(
+    'passes a11y checks',
+    () => checkAccessibility(setUp()),
+    // FIXME This test is slow in Node 21. Set 10 second timeout and fix later.
+    10_000,
+  );
 
   it('wraps visits stats and header', () => {
     setUp();

--- a/test/visits/reducers/nonOrphanVisits.test.ts
+++ b/test/visits/reducers/nonOrphanVisits.test.ts
@@ -25,7 +25,10 @@ describe('nonOrphanVisitsReducer', () => {
     const buildState = (data: Partial<VisitsInfo>) => fromPartial<VisitsInfo>(data);
 
     it('returns loading when pending', () => {
-      const { loading } = reducer(buildState({ loading: false }), getNonOrphanVisits.pending('', {}));
+      const { loading } = reducer(
+        buildState({ loading: false }),
+        getNonOrphanVisits.pending('', fromPartial({}), undefined),
+      );
       expect(loading).toEqual(true);
     });
 
@@ -37,7 +40,7 @@ describe('nonOrphanVisitsReducer', () => {
     it('stops loading and returns error when rejected', () => {
       const { loading, errorData } = reducer(
         buildState({ loading: true, errorData: null }),
-        getNonOrphanVisits.rejected(problemDetailsError, '', {}),
+        getNonOrphanVisits.rejected(problemDetailsError, '', fromPartial({}), undefined, undefined),
       );
 
       expect(loading).toEqual(false);
@@ -48,7 +51,7 @@ describe('nonOrphanVisitsReducer', () => {
       const actionVisits: ShlinkVisit[] = [fromPartial({}), fromPartial({})];
       const { loading, errorData, visits } = reducer(
         buildState({ loading: true, errorData: null }),
-        getNonOrphanVisits.fulfilled({ visits: actionVisits }, '', {}),
+        getNonOrphanVisits.fulfilled({ visits: actionVisits }, '', fromPartial({}), undefined),
       );
 
       expect(loading).toEqual(false);
@@ -60,30 +63,38 @@ describe('nonOrphanVisitsReducer', () => {
       [{}, visitsMocks.length + 2],
       [
         fromPartial<VisitsInfo>({
-          query: { endDate: formatIsoDate(subDays(now, 1)) ?? undefined },
-        }),
-        visitsMocks.length,
-      ],
-      [
-        fromPartial<VisitsInfo>({
-          query: { startDate: formatIsoDate(addDays(now, 1)) ?? undefined },
-        }),
-        visitsMocks.length,
-      ],
-      [
-        fromPartial<VisitsInfo>({
-          query: {
-            startDate: formatIsoDate(subDays(now, 5)) ?? undefined,
-            endDate: formatIsoDate(subDays(now, 2)) ?? undefined,
+          params: {
+            dateRange: { endDate: subDays(now, 1) },
           },
         }),
         visitsMocks.length,
       ],
       [
         fromPartial<VisitsInfo>({
-          query: {
-            startDate: formatIsoDate(subDays(now, 5)) ?? undefined,
-            endDate: formatIsoDate(addDays(now, 3)) ?? undefined,
+          params: {
+            dateRange: { startDate: addDays(now, 1) },
+          },
+        }),
+        visitsMocks.length,
+      ],
+      [
+        fromPartial<VisitsInfo>({
+          params: {
+            dateRange: {
+              startDate: subDays(now, 5),
+              endDate: subDays(now, 2),
+            },
+          },
+        }),
+        visitsMocks.length,
+      ],
+      [
+        fromPartial<VisitsInfo>({
+          params: {
+            dateRange: {
+              startDate: subDays(now, 5),
+              endDate: addDays(now, 3),
+            },
           },
         }),
         visitsMocks.length + 2,
@@ -116,11 +127,10 @@ describe('nonOrphanVisitsReducer', () => {
       orphanVisits: { cancelLoad: false },
     });
 
-    it.each([
-      [undefined],
-      [{}],
-    ])('dispatches start and success when promise is resolved', async (query) => {
+    it('dispatches start and success when promise is resolved', async () => {
       const visits = visitsMocks.map((visit) => ({ ...visit, visitedUrl: '' }));
+      const getVisitsParam = { params: {}, options: {} };
+
       getNonOrphanVisitsCall.mockResolvedValue({
         data: visits,
         pagination: {
@@ -130,11 +140,11 @@ describe('nonOrphanVisitsReducer', () => {
         },
       });
 
-      await getNonOrphanVisits({ query })(dispatchMock, getState, {});
+      await getNonOrphanVisits(getVisitsParam)(dispatchMock, getState, {});
 
       expect(dispatchMock).toHaveBeenCalledTimes(2);
       expect(dispatchMock).toHaveBeenLastCalledWith(expect.objectContaining({
-        payload: { visits, query: query ?? {} },
+        payload: { ...getVisitsParam, visits },
       }));
       expect(getNonOrphanVisitsCall).toHaveBeenCalledOnce();
     });
@@ -168,7 +178,7 @@ describe('nonOrphanVisitsReducer', () => {
         .mockResolvedValueOnce(buildVisitsResult())
         .mockResolvedValueOnce(buildVisitsResult(lastVisits));
 
-      await getNonOrphanVisits({ doIntervalFallback: true })(dispatchMock, getState, {});
+      await getNonOrphanVisits({ params: {}, options: { doIntervalFallback: true } })(dispatchMock, getState, {});
 
       expect(dispatchMock).toHaveBeenCalledTimes(expectedAmountOfDispatches);
       expect(dispatchMock).toHaveBeenNthCalledWith(2, expectedSecondDispatch);

--- a/test/visits/types/helpers.test.ts
+++ b/test/visits/types/helpers.test.ts
@@ -52,25 +52,20 @@ describe('visitsTypeHelpers', () => {
 
   describe('toApiParams', () => {
     it.each([
-      [{ page: 5, itemsPerPage: 100 } as VisitsParams, { page: 5, itemsPerPage: 100 } as ShlinkVisitsParams],
       [
         {
-          page: 1,
-          itemsPerPage: 30,
           filter: { excludeBots: true },
-        } as VisitsParams,
-        { page: 1, itemsPerPage: 30, excludeBots: true } as ShlinkVisitsParams,
+        } satisfies VisitsParams,
+        { excludeBots: true } as ShlinkVisitsParams,
       ],
       (() => {
         const endDate = parseDate('2020-05-05', 'yyyy-MM-dd');
 
         return [
           {
-            page: 20,
-            itemsPerPage: 1,
             dateRange: { endDate },
-          } as VisitsParams,
-          { page: 20, itemsPerPage: 1, endDate: formatIsoDate(endDate) } as ShlinkVisitsParams,
+          } satisfies VisitsParams,
+          { endDate: formatIsoDate(endDate) } as ShlinkVisitsParams,
         ];
       })(),
       (() => {
@@ -79,14 +74,10 @@ describe('visitsTypeHelpers', () => {
 
         return [
           {
-            page: 20,
-            itemsPerPage: 1,
             dateRange: { startDate, endDate },
             filter: { excludeBots: false },
-          } as VisitsParams,
+          } satisfies VisitsParams,
           {
-            page: 20,
-            itemsPerPage: 1,
             startDate: formatIsoDate(startDate),
             endDate: formatIsoDate(endDate),
           } as ShlinkVisitsParams,

--- a/test/visits/types/helpers.test.ts
+++ b/test/visits/types/helpers.test.ts
@@ -1,9 +1,9 @@
 import { fromPartial } from '@total-typescript/shoehorn';
 import type { ShlinkOrphanVisit, ShlinkVisitsParams } from '../../../src/api-contract';
 import { formatIsoDate, parseDate } from '../../../src/utils/dates/helpers/date';
+import type { GroupedNewVisits } from '../../../src/visits/helpers';
+import { groupNewVisitsByType, toApiParams } from '../../../src/visits/helpers';
 import type { CreateVisit, VisitsParams } from '../../../src/visits/types';
-import type { GroupedNewVisits } from '../../../src/visits/types/helpers';
-import { groupNewVisitsByType, toApiParams } from '../../../src/visits/types/helpers';
 
 describe('visitsTypeHelpers', () => {
   describe('groupNewVisitsByType', () => {


### PR DESCRIPTION
Part of #9 

This PR adds a new setting that can be used to decide if previous interval should be loaded when loading visits.

It also refactors the whole visits and visits comparisons reducers logic, to avoid parsing params into API raw queries too soon, allowing to delay the calculation of the previous interval as much as possible.