### PR TITLE
Add toggle in visits section to enable/disable prev visits

### DIFF
--- a/dev/App.tsx
+++ b/dev/App.tsx
@@ -17,8 +17,7 @@ export const App: FC = () => {
     [serverInfo],
   );
   const settings = useMemo((): Settings => ({
-    realTimeUpdates: { enabled: true },
-    visits: { defaultInterval: 'last30Days', loadPrevInterval: true },
+    realTimeUpdates: { enabled: false },
   }), []);
   const routesPrefix = useMemo(
     () => (window.location.pathname.startsWith('/sub/route') ? '/sub/route' : undefined),

--- a/src/visits/VisitsStats.tsx
+++ b/src/visits/VisitsStats.tsx
@@ -19,7 +19,7 @@ import { SortableBarChartCard } from './charts/SortableBarChartCard';
 import { highlightedVisitsToStats } from './helpers';
 import { useVisitsQuery } from './helpers/hooks';
 import { OpenMapModalBtn } from './helpers/OpenMapModalBtn';
-import { VisitsFilterDropdown } from './helpers/VisitsFilterDropdown';
+import { VisitsDropdown } from './helpers/VisitsDropdown';
 import { VisitsLoadingFeedback } from './helpers/VisitsLoadingFeedback';
 import { VisitsSectionWithFallback } from './helpers/VisitsSectionWithFallback';
 import { VisitsStatsOptions } from './helpers/VisitsStatsOptions';
@@ -174,7 +174,7 @@ export const VisitsStats: FC<VisitsStatsProps> = (props) => {
                   onDatesChange={setDates}
                 />
               </div>
-              <VisitsFilterDropdown
+              <VisitsDropdown
                 disabled={loading}
                 className="ms-0 ms-md-2 mt-3 mt-md-0"
                 isOrphanVisits={isOrphanVisits}

--- a/src/visits/helpers/VisitsDropdown.tsx
+++ b/src/visits/helpers/VisitsDropdown.tsx
@@ -5,25 +5,25 @@ import { DropdownItem } from 'reactstrap';
 import type { ShlinkOrphanVisitType } from '../../api-contract';
 import type { VisitsFilter } from '../types';
 
-export type Filter = VisitsFilter & { loadPrevInterval?: boolean };
+export type DropdownOptions = VisitsFilter & { loadPrevInterval?: boolean };
 
-interface VisitsFilterDropdownProps {
-  onChange: (filters: Filter) => void;
-  selected?: Filter;
+interface VisitsDropdownProps {
+  onChange: (selected: DropdownOptions) => void;
+  selected?: DropdownOptions;
   className?: string;
   isOrphanVisits?: boolean;
   withPrevInterval?: boolean;
   disabled?: boolean;
 }
 
-export const VisitsFilterDropdown = ({
+export const VisitsDropdown = ({
   onChange,
   selected = {},
   className,
   isOrphanVisits = false,
   withPrevInterval = false,
   disabled,
-}: VisitsFilterDropdownProps) => {
+}: VisitsDropdownProps) => {
   const { orphanVisitsType, excludeBots = false, loadPrevInterval = false } = selected;
   const propsForOrphanVisitsTypeItem = (type: ShlinkOrphanVisitType): DropdownItemProps => ({
     active: orphanVisitsType === type,

--- a/src/visits/visits-comparison/VisitsComparison.tsx
+++ b/src/visits/visits-comparison/VisitsComparison.tsx
@@ -9,7 +9,7 @@ import { useSetting } from '../../utils/settings';
 import { chartColorForIndex } from '../charts/constants';
 import { LineChartCard, type VisitsList } from '../charts/LineChartCard';
 import { useVisitsQuery } from '../helpers/hooks';
-import { VisitsFilterDropdown } from '../helpers/VisitsFilterDropdown';
+import { VisitsDropdown } from '../helpers/VisitsDropdown';
 import { VisitsLoadingFeedback } from '../helpers/VisitsLoadingFeedback';
 import { VisitsSectionWithFallback } from '../helpers/VisitsSectionWithFallback';
 import { normalizeVisits } from '../services/VisitsParser';
@@ -93,7 +93,7 @@ export const VisitsComparison: FC<VisitsComparisonProps> = ({
               onDatesChange={setDates}
             />
           </div>
-          <VisitsFilterDropdown
+          <VisitsDropdown
             disabled={loading}
             className="ms-0 ms-md-2 mt-3 mt-md-0"
             selected={resolvedFilter}

--- a/src/visits/visits-comparison/VisitsComparison.tsx
+++ b/src/visits/visits-comparison/VisitsComparison.tsx
@@ -44,11 +44,11 @@ export const VisitsComparison: FC<VisitsComparisonProps> = ({
   const showFallback = useMemo(() => Object.values(visitsGroups).every((group) => group.length === 0), [visitsGroups]);
 
   // State related with visits filtering
-  const [{ dateRange, visitsFilter }, updateFiltering] = useVisitsQuery();
+  const [{ dateRange, visitsFilter }, updateQuery] = useVisitsQuery();
   const [activeInterval, setActiveInterval] = useState<DateInterval>();
   const setDates = useCallback(
     ({ startDate: theStartDate, endDate: theEndDate }: DateRange, newDateInterval?: DateInterval) => {
-      updateFiltering({
+      updateQuery({
         dateRange: {
           startDate: theStartDate ?? undefined,
           endDate: theEndDate ?? undefined,
@@ -56,7 +56,7 @@ export const VisitsComparison: FC<VisitsComparisonProps> = ({
       });
       setActiveInterval(newDateInterval);
     },
-    [updateFiltering],
+    [updateQuery],
   );
   const initialInterval = useRef<DateRange | DateInterval>(
     dateRange ?? visitsSettings?.defaultInterval ?? 'last30Days',
@@ -97,7 +97,9 @@ export const VisitsComparison: FC<VisitsComparisonProps> = ({
             disabled={loading}
             className="ms-0 ms-md-2 mt-3 mt-md-0"
             selected={resolvedFilter}
-            onChange={(newVisitsFilter) => updateFiltering({ visitsFilter: newVisitsFilter })}
+            onChange={({ orphanVisitsType, excludeBots }) => updateQuery({
+              visitsFilter: { orphanVisitsType, excludeBots },
+            })}
           />
         </div>
       </div>

--- a/test/visits/VisitsStats.test.tsx
+++ b/test/visits/VisitsStats.test.tsx
@@ -121,7 +121,7 @@ describe('<VisitsStats />', () => {
 
     expect(history.location.search).toEqual('');
 
-    await user.click(screen.getByRole('button', { name: /Filters/ }));
+    await user.click(screen.getByRole('button', { name: /More/ }));
     await waitFor(() => screen.getByRole('menu'));
     await user.click(screen.getByRole('menuitem', { name: 'Exclude potential bots' }));
     expectSearchContains(['excludeBots=true']);

--- a/test/visits/helpers/VisitsDropdown.test.tsx
+++ b/test/visits/helpers/VisitsDropdown.test.tsx
@@ -1,23 +1,23 @@
 import { screen } from '@testing-library/react';
 import type { UserEvent } from '@testing-library/user-event';
 import type { ShlinkOrphanVisitType } from '../../../src/api-contract';
-import type { Filter } from '../../../src/visits/helpers/VisitsFilterDropdown';
-import { VisitsFilterDropdown } from '../../../src/visits/helpers/VisitsFilterDropdown';
+import type { DropdownOptions } from '../../../src/visits/helpers/VisitsDropdown';
+import { VisitsDropdown } from '../../../src/visits/helpers/VisitsDropdown';
 import { checkAccessibility } from '../../__helpers__/accessibility';
 import { renderWithEvents } from '../../__helpers__/setUpTest';
 
 type SetUpOptions = {
-  selected?: Filter;
+  selected?: DropdownOptions;
   isOrphanVisits?: boolean
   withPrevInterval?: boolean
 };
 
-describe('<VisitsFilterDropdown />', () => {
+describe('<VisitsDropdown />', () => {
   const onChange = vi.fn();
   const setUp = (
     { selected = {}, isOrphanVisits = true, withPrevInterval = false }: SetUpOptions = {},
   ) => renderWithEvents(
-    <VisitsFilterDropdown
+    <VisitsDropdown
       isOrphanVisits={isOrphanVisits}
       withPrevInterval={withPrevInterval}
       selected={selected}

--- a/test/visits/helpers/VisitsFilterDropdown.test.tsx
+++ b/test/visits/helpers/VisitsFilterDropdown.test.tsx
@@ -1,21 +1,30 @@
 import { screen } from '@testing-library/react';
 import type { UserEvent } from '@testing-library/user-event';
 import type { ShlinkOrphanVisitType } from '../../../src/api-contract';
+import type { Filter } from '../../../src/visits/helpers/VisitsFilterDropdown';
 import { VisitsFilterDropdown } from '../../../src/visits/helpers/VisitsFilterDropdown';
-import type { VisitsFilter } from '../../../src/visits/types';
 import { checkAccessibility } from '../../__helpers__/accessibility';
 import { renderWithEvents } from '../../__helpers__/setUpTest';
 
+type SetUpOptions = {
+  selected?: Filter;
+  isOrphanVisits?: boolean
+  withPrevInterval?: boolean
+};
+
 describe('<VisitsFilterDropdown />', () => {
   const onChange = vi.fn();
-  const setUp = (selected: VisitsFilter = {}, isOrphanVisits = true) => renderWithEvents(
+  const setUp = (
+    { selected = {}, isOrphanVisits = true, withPrevInterval = false }: SetUpOptions = {},
+  ) => renderWithEvents(
     <VisitsFilterDropdown
       isOrphanVisits={isOrphanVisits}
+      withPrevInterval={withPrevInterval}
       selected={selected}
       onChange={onChange}
     />,
   );
-  const openDropdown = (user: UserEvent) => user.click(screen.getByRole('button', { name: 'Filters' }));
+  const openDropdown = (user: UserEvent) => user.click(screen.getByRole('button', { name: 'More' }));
 
   it.each([
     [setUp],
@@ -30,20 +39,25 @@ describe('<VisitsFilterDropdown />', () => {
 
   it('has expected text', () => {
     setUp();
-    expect(screen.getByRole('button', { name: 'Filters' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'More' })).toBeInTheDocument();
   });
 
   it.each([
-    [false, 1, 1],
-    [true, 4, 2],
-  ])('renders expected amount of items', async (isOrphanVisits, expectedItemsAmount, expectedHeadersAmount) => {
-    const { user } = setUp({}, isOrphanVisits);
+    [false, false, 1, 1],
+    [true, false, 4, 2],
+    [false, true, 2, 1],
+    [true, true, 5, 2],
+  ])(
+    'renders expected amount of items',
+    async (isOrphanVisits, withPrevInterval, expectedItemsAmount, expectedHeadersAmount) => {
+      const { user } = setUp({ isOrphanVisits, withPrevInterval });
 
-    await openDropdown(user);
+      await openDropdown(user);
 
-    expect(screen.getAllByRole('menuitem')).toHaveLength(expectedItemsAmount);
-    expect(screen.getAllByRole('heading', { hidden: true })).toHaveLength(expectedHeadersAmount);
-  });
+      expect(screen.getAllByRole('menuitem')).toHaveLength(expectedItemsAmount);
+      expect(screen.getAllByRole('heading', { hidden: true })).toHaveLength(expectedHeadersAmount);
+    },
+  );
 
   it.each([
     ['base_url' as ShlinkOrphanVisitType, 1, 1],
@@ -51,7 +65,7 @@ describe('<VisitsFilterDropdown />', () => {
     ['regular_404' as ShlinkOrphanVisitType, 3, 1],
     [undefined, -1, 0],
   ])('sets expected item as active', async (orphanVisitsType, expectedSelectedIndex, expectedActiveItems) => {
-    const { user } = setUp({ orphanVisitsType });
+    const { user } = setUp({ selected: { orphanVisitsType } });
 
     await openDropdown(user);
 
@@ -68,17 +82,24 @@ describe('<VisitsFilterDropdown />', () => {
   });
 
   it.each([
-    [0, { excludeBots: true }, {}],
-    [1, { orphanVisitsType: 'base_url' }, {}],
-    [2, { orphanVisitsType: 'invalid_short_url' }, {}],
-    [3, { orphanVisitsType: 'regular_404' }, {}],
-    [4, { orphanVisitsType: undefined, excludeBots: false }, { excludeBots: true }],
-  ])('invokes onChange with proper selection when an item is clicked', async (index, expectedSelection, selected) => {
-    const { user } = setUp(selected);
+    ['Exclude potential bots', { excludeBots: true }, {}],
+    ['Exclude potential bots', { excludeBots: false }, { excludeBots: true }],
+    ['Compare with previous period', { loadPrevInterval: true }, {}],
+    ['Compare with previous period', { loadPrevInterval: false }, { loadPrevInterval: true }],
+    ['Base URL', { orphanVisitsType: 'base_url' }, {}],
+    ['Invalid short URL', { orphanVisitsType: 'invalid_short_url' }, {}],
+    ['Regular 404', { orphanVisitsType: 'regular_404' }, {}],
+    [
+      'Reset to defaults',
+      { orphanVisitsType: undefined, excludeBots: undefined, loadPrevInterval: undefined },
+      { excludeBots: true },
+    ],
+  ])('invokes onChange with proper selection when an item is clicked', async (name, expectedSelection, selected) => {
+    const { user } = setUp({ selected, withPrevInterval: true });
 
     expect(onChange).not.toHaveBeenCalled();
     await openDropdown(user);
-    await user.click(screen.getAllByRole('menuitem')[index]);
+    await user.click(screen.getByRole('menuitem', { name }));
     expect(onChange).toHaveBeenCalledWith(expectedSelection);
   });
 });

--- a/test/visits/reducers/shortUrlVisits.test.ts
+++ b/test/visits/reducers/shortUrlVisits.test.ts
@@ -256,7 +256,7 @@ describe('shortUrlVisitsReducer', () => {
       expect(getShortUrlVisitsCall).toHaveBeenCalledTimes(2);
     });
 
-    it.only.each([
+    it.each([
       // Strict date range and loadPrevInterval: true -> prev visits are loaded
       [{
         dateRange: { startDate: subDays(now, 1), endDate: addDays(now, 1) },

--- a/test/visits/visits-comparison/VisitsComparison.test.tsx
+++ b/test/visits/visits-comparison/VisitsComparison.test.tsx
@@ -42,7 +42,7 @@ describe('<VisitsComparison />', () => {
     await user.click(screen.getByRole('button', { name: 'Last 30 days' }));
     expect(screen.queryByRole('menu')).not.toBeInTheDocument();
 
-    await user.click(screen.getByRole('button', { name: 'Filters' }));
+    await user.click(screen.getByRole('button', { name: 'More' }));
     expect(screen.queryByRole('menu')).not.toBeInTheDocument();
   });
 
@@ -82,7 +82,7 @@ describe('<VisitsComparison />', () => {
     expect(formatISO(firstCallParams.dateRange!.startDate!)).toEqual(formatISO(subDays(startOfDay(now), 1)));
     expect(formatISO(firstCallParams.dateRange!.endDate!)).toEqual(formatISO(subDays(endOfDay(now), 1)));
 
-    await user.click(screen.getByRole('button', { name: 'Filters' }));
+    await user.click(screen.getByRole('button', { name: 'More' }));
     await user.click(screen.getByRole('menuitem', { name: 'Exclude potential bots' }));
 
     const { params: secondCallParams } = getLastCallParams();


### PR DESCRIPTION
Part of #9 

Rename `Filters" dropdown in visits section to "Mode", and add a new item there to load prev visits.

This option has an initial value matching the config, and is only visible for single item visits, not visits comparison.

![image](https://github.com/shlinkio/shlink-web-component/assets/2719332/18cd1383-0a31-4d39-8f43-95c2afd9c5ae)

