### PR TITLE
Add logic to load prev visits to remaining reducers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 shlinkio
+Copyright (c) 2023-2024 shlinkio
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/visits/helpers/VisitsDropdown.tsx
+++ b/src/visits/helpers/VisitsDropdown.tsx
@@ -27,7 +27,7 @@ export const VisitsDropdown = ({
   const { orphanVisitsType, excludeBots = false, loadPrevInterval = false } = selected;
   const propsForOrphanVisitsTypeItem = (type: ShlinkOrphanVisitType): DropdownItemProps => ({
     active: orphanVisitsType === type,
-    onClick: () => onChange({ orphanVisitsType: type === orphanVisitsType ? undefined : type }),
+    onClick: () => onChange({ ...selected, orphanVisitsType: type === orphanVisitsType ? undefined : type }),
   });
   const onBotsClick = useCallback(
     () => onChange({ ...selected, excludeBots: !excludeBots }),

--- a/src/visits/reducers/domainVisits.ts
+++ b/src/visits/reducers/domainVisits.ts
@@ -1,5 +1,5 @@
 import type { ShlinkApiClient } from '../../api-contract';
-import { filterCreatedVisitsByDomain, toApiParams } from '../helpers';
+import { filterCreatedVisitsByDomain, isStrictRangeParams, paramsForPrevDateRange, toApiParams } from '../helpers';
 import { createVisitsAsyncThunk, createVisitsReducer, lastVisitLoaderForLoader } from './common';
 import type { LoadVisits, VisitsInfo } from './types';
 
@@ -28,18 +28,25 @@ export const getDomainVisits = (apiClientFactory: () => ShlinkApiClient) => crea
   typePrefix: `${REDUCER_PREFIX}/getDomainVisits`,
   createLoaders: ({ domain, params, options }: LoadDomainVisits) => {
     const apiClient = apiClientFactory();
-    const { doIntervalFallback = false } = options;
+    const { doIntervalFallback = false, loadPrevInterval } = options;
+    const query = toApiParams(params);
+    const queryForPrevVisits = loadPrevInterval && isStrictRangeParams(params)
+      ? toApiParams(paramsForPrevDateRange(params))
+      : undefined;
 
-    const visitsLoader = async (page: number, itemsPerPage: number) => apiClient.getDomainVisits(
+    const visitsLoader = (page: number, itemsPerPage: number) => apiClient.getDomainVisits(
       domain,
-      { ...toApiParams(params), page, itemsPerPage },
+      { ...query, page, itemsPerPage },
     );
-    const lastVisitLoader = lastVisitLoaderForLoader(doIntervalFallback, async (query) => apiClient.getDomainVisits(
-      domain,
-      query,
-    ));
+    const lastVisitLoader = lastVisitLoaderForLoader(doIntervalFallback, (q) => apiClient.getDomainVisits(domain, q));
+    const prevVisitsLoader = queryForPrevVisits && (
+      (page: number, itemsPerPage: number) => apiClient.getDomainVisits(
+        domain,
+        { ...queryForPrevVisits, page, itemsPerPage },
+      )
+    );
 
-    return { visitsLoader, lastVisitLoader };
+    return { visitsLoader, lastVisitLoader, prevVisitsLoader };
   },
   shouldCancel: (getState) => getState().domainVisits.cancelLoad,
 });

--- a/src/visits/reducers/shortUrlVisits.ts
+++ b/src/visits/reducers/shortUrlVisits.ts
@@ -24,23 +24,23 @@ export const getShortUrlVisits = (apiClientFactory: () => ShlinkApiClient) => cr
   typePrefix: `${REDUCER_PREFIX}/getShortUrlVisits`,
   createLoaders: ({ shortCode, domain, params, options }: LoadShortUrlVisits) => {
     const apiClient = apiClientFactory();
-    const { doIntervalFallback = false, loadPrevInterval = false } = options;
+    const { doIntervalFallback = false, loadPrevInterval } = options;
     const query = { ...toApiParams(params), domain };
     const queryForPrevVisits = loadPrevInterval && isStrictRangeParams(params) ? {
       ...toApiParams(paramsForPrevDateRange(params)),
       domain,
     } : undefined;
 
-    const visitsLoader = async (page: number, itemsPerPage: number) => apiClient.getShortUrlVisits(
+    const visitsLoader = (page: number, itemsPerPage: number) => apiClient.getShortUrlVisits(
       shortCode,
       { ...query, page, itemsPerPage },
     );
     const lastVisitLoader = lastVisitLoaderForLoader(
       doIntervalFallback,
-      async (q) => apiClient.getShortUrlVisits(shortCode, { ...q, domain }),
+      (q) => apiClient.getShortUrlVisits(shortCode, { ...q, domain }),
     );
     const prevVisitsLoader = queryForPrevVisits && (
-      async (page: number, itemsPerPage: number) => apiClient.getShortUrlVisits(
+      (page: number, itemsPerPage: number) => apiClient.getShortUrlVisits(
         shortCode,
         { ...queryForPrevVisits, page, itemsPerPage },
       )

--- a/test/visits/helpers/VisitsDropdown.test.tsx
+++ b/test/visits/helpers/VisitsDropdown.test.tsx
@@ -87,7 +87,9 @@ describe('<VisitsDropdown />', () => {
     ['Compare with previous period', { loadPrevInterval: true }, {}],
     ['Compare with previous period', { loadPrevInterval: false }, { loadPrevInterval: true }],
     ['Base URL', { orphanVisitsType: 'base_url' }, {}],
+    ['Base URL', { excludeBots: true, orphanVisitsType: 'base_url' }, { excludeBots: true }],
     ['Invalid short URL', { orphanVisitsType: 'invalid_short_url' }, {}],
+    ['Invalid short URL', { orphanVisitsType: undefined }, { orphanVisitsType: 'invalid_short_url' as const }],
     ['Regular 404', { orphanVisitsType: 'regular_404' }, {}],
     [
       'Reset to defaults',

--- a/test/visits/reducers/shortUrlVisits.test.ts
+++ b/test/visits/reducers/shortUrlVisits.test.ts
@@ -258,43 +258,43 @@ describe('shortUrlVisitsReducer', () => {
 
     it.each([
       // Strict date range and loadPrevInterval: true -> prev visits are loaded
-      [{
+      {
         dateRange: { startDate: subDays(now, 1), endDate: addDays(now, 1) },
         loadPrevInterval: true,
         expectedPrevVisits: visitsMocks.map(
           ({ date, ...rest }, index) => ({ ...rest, date: dateForVisit(index + 1 + visitsMocks.length) }),
         ),
-      }],
+      },
       // Undefined date range and loadPrevInterval: true -> prev visits are NOT loaded
-      [{
+      {
         dateRange: undefined,
         loadPrevInterval: true,
         expectedPrevVisits: undefined,
-      }],
+      },
       // Empty date range and loadPrevInterval: true -> prev visits are NOT loaded
-      [{
+      {
         dateRange: {},
         loadPrevInterval: true,
         expectedPrevVisits: undefined,
-      }],
+      },
       // Start date only and loadPrevInterval: true -> prev visits are NOT loaded
-      [{
+      {
         dateRange: { startDate: now },
         loadPrevInterval: true,
         expectedPrevVisits: undefined,
-      }],
+      },
       // End date only and loadPrevInterval: true -> prev visits are NOT loaded
-      [{
+      {
         dateRange: { endDate: now },
         loadPrevInterval: true,
         expectedPrevVisits: undefined,
-      }],
+      },
       // Strict date range and loadPrevInterval: false -> prev visits are NOT loaded
-      [{
+      {
         dateRange: { startDate: subDays(now, 1), endDate: addDays(now, 1) },
         loadPrevInterval: false,
         expectedPrevVisits: undefined,
-      }],
+      },
     ])('returns visits from prev interval when requested and possible', async (
       { dateRange, loadPrevInterval, expectedPrevVisits },
     ) => {


### PR DESCRIPTION
Part of #9 

Add logic to load visits from previous period for tags, domains, orphan visits and non-orphan visits