### PR TITLE
Allow previous visits to be calculated as soon as start Date is set

### DIFF
--- a/src/visits/helpers/index.ts
+++ b/src/visits/helpers/index.ts
@@ -3,8 +3,8 @@ import type { ShlinkOrphanVisit, ShlinkVisit, ShlinkVisitsParams } from '../../a
 import type { ShortUrlIdentifier } from '../../short-urls/data';
 import { domainMatches, shortUrlMatches } from '../../short-urls/helpers';
 import { formatIsoDate, isBetween } from '../../utils/dates/helpers/date';
-import type { DateRange, StrictDateRange } from '../../utils/dates/helpers/dateIntervals';
-import { calcPrevDateRange, isStrictDateRange } from '../../utils/dates/helpers/dateIntervals';
+import type { DateRange, MandatoryStartDateRange } from '../../utils/dates/helpers/dateIntervals';
+import { calcPrevDateRange, isMandatoryStartDateRange } from '../../utils/dates/helpers/dateIntervals';
 import type {
   CreateVisit,
   HighlightableProps,
@@ -88,15 +88,14 @@ export const toApiParams = (
   return { startDate, endDate, excludeBots };
 };
 
-type StrictRangeParams = Omit<VisitsParams, 'dateRange'> & {
-  dateRange: StrictDateRange;
+type MandatoryStartDateRangeParams = Omit<VisitsParams, 'dateRange'> & {
+  dateRange: MandatoryStartDateRange;
 };
 
-export const isStrictRangeParams = (params: VisitsParams): params is StrictRangeParams => isStrictDateRange(
-  params.dateRange,
-);
+export const isMandatoryStartDateRangeParams = (params: VisitsParams): params is MandatoryStartDateRangeParams =>
+  isMandatoryStartDateRange(params.dateRange);
 
-export const paramsForPrevDateRange = ({ dateRange, ...rest }: StrictRangeParams): VisitsParams => ({
+export const paramsForPrevDateRange = ({ dateRange, ...rest }: MandatoryStartDateRangeParams): VisitsParams => ({
   ...rest,
   dateRange: calcPrevDateRange(dateRange),
 });

--- a/src/visits/reducers/common/createVisitsAsyncThunk.ts
+++ b/src/visits/reducers/common/createVisitsAsyncThunk.ts
@@ -1,9 +1,9 @@
 import { createAction } from '@reduxjs/toolkit';
-import { addDays, differenceInDays } from 'date-fns';
+import { addDays } from 'date-fns';
 import type { RootState } from '../../../container/store';
 import { formatIsoDate, parseISO } from '../../../utils/dates/helpers/date';
 import type { DateInterval } from '../../../utils/dates/helpers/dateIntervals';
-import { dateToMatchingInterval, isStrictDateRange } from '../../../utils/dates/helpers/dateIntervals';
+import { dateRangeDaysDiff, dateToMatchingInterval } from '../../../utils/dates/helpers/dateIntervals';
 import { createAsyncThunk } from '../../../utils/redux';
 import type { LoadVisits, VisitsLoaded } from '../types';
 import type { Loaders } from './createLoadVisits';
@@ -24,9 +24,7 @@ export const createVisitsAsyncThunk = <T extends LoadVisits = LoadVisits>(
   const asyncThunk = createAsyncThunk(typePrefix, async (param: T, { getState, dispatch }): Promise<VisitsLoaded> => {
     const { visitsLoader, lastVisitLoader, prevVisitsLoader } = createLoaders(param);
     const batchSize = DEFAULT_BATCH_SIZE / (prevVisitsLoader ? 2 : 1);
-    const daysInDateRange = isStrictDateRange(param.params.dateRange)
-      ? differenceInDays(param.params.dateRange.endDate, param.params.dateRange.startDate)
-      : undefined;
+    const daysInDateRange = dateRangeDaysDiff(param.params.dateRange);
 
     const progresses = prevVisitsLoader ? { main: 0, prev: 0 } : { main: 0 };
     const computeProgress = (key: keyof typeof progresses, progress: number) => {

--- a/src/visits/reducers/domainVisits.ts
+++ b/src/visits/reducers/domainVisits.ts
@@ -1,5 +1,5 @@
 import type { ShlinkApiClient } from '../../api-contract';
-import { filterCreatedVisitsByDomain, isStrictRangeParams, paramsForPrevDateRange, toApiParams } from '../helpers';
+import { filterCreatedVisitsByDomain, isMandatoryStartDateRangeParams, paramsForPrevDateRange, toApiParams } from '../helpers';
 import { createVisitsAsyncThunk, createVisitsReducer, lastVisitLoaderForLoader } from './common';
 import type { LoadVisits, VisitsInfo } from './types';
 
@@ -30,7 +30,7 @@ export const getDomainVisits = (apiClientFactory: () => ShlinkApiClient) => crea
     const apiClient = apiClientFactory();
     const { doIntervalFallback = false, loadPrevInterval } = options;
     const query = toApiParams(params);
-    const queryForPrevVisits = loadPrevInterval && isStrictRangeParams(params)
+    const queryForPrevVisits = loadPrevInterval && isMandatoryStartDateRangeParams(params)
       ? toApiParams(paramsForPrevDateRange(params))
       : undefined;
 

--- a/src/visits/reducers/nonOrphanVisits.ts
+++ b/src/visits/reducers/nonOrphanVisits.ts
@@ -1,6 +1,6 @@
 import type { ShlinkApiClient } from '../../api-contract';
 import { isBetween } from '../../utils/dates/helpers/date';
-import { isStrictRangeParams, paramsForPrevDateRange, toApiParams } from '../helpers';
+import { isMandatoryStartDateRangeParams, paramsForPrevDateRange, toApiParams } from '../helpers';
 import { createVisitsAsyncThunk, createVisitsReducer, lastVisitLoaderForLoader } from './common';
 import type { VisitsInfo } from './types';
 
@@ -20,7 +20,7 @@ export const getNonOrphanVisits = (apiClientFactory: () => ShlinkApiClient) => c
     const apiClient = apiClientFactory();
     const { doIntervalFallback = false, loadPrevInterval } = options;
     const query = toApiParams(params);
-    const queryForPrevVisits = loadPrevInterval && isStrictRangeParams(params)
+    const queryForPrevVisits = loadPrevInterval && isMandatoryStartDateRangeParams(params)
       ? toApiParams(paramsForPrevDateRange(params))
       : undefined;
 

--- a/src/visits/reducers/orphanVisits.ts
+++ b/src/visits/reducers/orphanVisits.ts
@@ -1,7 +1,7 @@
 import type { ShlinkVisits } from '@shlinkio/shlink-js-sdk/api-contract';
 import type { ShlinkApiClient, ShlinkOrphanVisit, ShlinkOrphanVisitType } from '../../api-contract';
 import { isBetween } from '../../utils/dates/helpers/date';
-import { isOrphanVisit, isStrictRangeParams, paramsForPrevDateRange, toApiParams } from '../helpers';
+import { isMandatoryStartDateRangeParams, isOrphanVisit, paramsForPrevDateRange, toApiParams } from '../helpers';
 import { createVisitsAsyncThunk, createVisitsReducer, lastVisitLoaderForLoader } from './common';
 import type { deleteOrphanVisits } from './orphanVisitsDeletion';
 import type { LoadVisits, VisitsInfo } from './types';
@@ -34,7 +34,7 @@ export const getOrphanVisits = (apiClientFactory: () => ShlinkApiClient) => crea
     const apiClient = apiClientFactory();
     const { doIntervalFallback = false, loadPrevInterval } = options;
     const query = toApiParams(params);
-    const queryForPrevVisits = loadPrevInterval && isStrictRangeParams(params)
+    const queryForPrevVisits = loadPrevInterval && isMandatoryStartDateRangeParams(params)
       ? toApiParams(paramsForPrevDateRange(params))
       : undefined;
 

--- a/src/visits/reducers/shortUrlVisits.ts
+++ b/src/visits/reducers/shortUrlVisits.ts
@@ -1,6 +1,6 @@
 import type { ShlinkApiClient } from '../../api-contract';
 import type { ShortUrlIdentifier } from '../../short-urls/data';
-import { filterCreatedVisitsByShortUrl, isStrictRangeParams, paramsForPrevDateRange, toApiParams } from '../helpers';
+import { filterCreatedVisitsByShortUrl, isMandatoryStartDateRangeParams, paramsForPrevDateRange, toApiParams } from '../helpers';
 import { createVisitsAsyncThunk, createVisitsReducer, lastVisitLoaderForLoader } from './common';
 import type { deleteShortUrlVisits } from './shortUrlVisitsDeletion';
 import type { LoadVisits, VisitsInfo } from './types';
@@ -26,7 +26,7 @@ export const getShortUrlVisits = (apiClientFactory: () => ShlinkApiClient) => cr
     const apiClient = apiClientFactory();
     const { doIntervalFallback = false, loadPrevInterval } = options;
     const query = { ...toApiParams(params), domain };
-    const queryForPrevVisits = loadPrevInterval && isStrictRangeParams(params) ? {
+    const queryForPrevVisits = loadPrevInterval && isMandatoryStartDateRangeParams(params) ? {
       ...toApiParams(paramsForPrevDateRange(params)),
       domain,
     } : undefined;

--- a/src/visits/reducers/tagVisits.ts
+++ b/src/visits/reducers/tagVisits.ts
@@ -1,5 +1,5 @@
 import type { ShlinkApiClient } from '../../api-contract';
-import { filterCreatedVisitsByTag, isStrictRangeParams, paramsForPrevDateRange, toApiParams } from '../helpers';
+import { filterCreatedVisitsByTag, isMandatoryStartDateRangeParams, paramsForPrevDateRange, toApiParams } from '../helpers';
 import { createVisitsAsyncThunk, createVisitsReducer, lastVisitLoaderForLoader } from './common';
 import type { LoadVisits, VisitsInfo } from './types';
 
@@ -28,7 +28,7 @@ export const getTagVisits = (apiClientFactory: () => ShlinkApiClient) => createV
     const apiClient = apiClientFactory();
     const { doIntervalFallback = false, loadPrevInterval } = options;
     const query = toApiParams(params);
-    const queryForPrevVisits = loadPrevInterval && isStrictRangeParams(params)
+    const queryForPrevVisits = loadPrevInterval && isMandatoryStartDateRangeParams(params)
       ? toApiParams(paramsForPrevDateRange(params))
       : undefined;
 

--- a/test/visits/reducers/domainVisits.test.ts
+++ b/test/visits/reducers/domainVisits.test.ts
@@ -220,48 +220,49 @@ describe('domainVisitsReducer', () => {
       {
         dateRange: { startDate: subDays(now, 1), endDate: addDays(now, 1) },
         loadPrevInterval: true,
-        expectedPrevVisits: visitsMocks.map(
-          ({ date, ...rest }, index) => ({ ...rest, date: dateForVisit(index + 1 + visitsMocks.length) }),
-        ),
+        expectsPrevVisits: true,
       },
       // Undefined date range and loadPrevInterval: true -> prev visits are NOT loaded
       {
         dateRange: undefined,
         loadPrevInterval: true,
-        expectedPrevVisits: undefined,
+        expectsPrevVisits: false,
       },
       // Empty date range and loadPrevInterval: true -> prev visits are NOT loaded
       {
         dateRange: {},
         loadPrevInterval: true,
-        expectedPrevVisits: undefined,
+        expectsPrevVisits: false,
       },
       // Start date only and loadPrevInterval: true -> prev visits are NOT loaded
       {
-        dateRange: { startDate: now },
+        dateRange: { startDate: subDays(now, 2) },
         loadPrevInterval: true,
-        expectedPrevVisits: undefined,
+        expectsPrevVisits: true,
       },
       // End date only and loadPrevInterval: true -> prev visits are NOT loaded
       {
         dateRange: { endDate: now },
         loadPrevInterval: true,
-        expectedPrevVisits: undefined,
+        expectsPrevVisits: false,
       },
       // Strict date range and loadPrevInterval: false -> prev visits are NOT loaded
       {
         dateRange: { startDate: subDays(now, 1), endDate: addDays(now, 1) },
         loadPrevInterval: false,
-        expectedPrevVisits: undefined,
+        expectsPrevVisits: false,
       },
     ])('returns visits from prev interval when requested and possible', async (
-      { dateRange, loadPrevInterval, expectedPrevVisits },
+      { dateRange, loadPrevInterval, expectsPrevVisits },
     ) => {
       const getVisitsParam: LoadDomainVisits = {
         domain,
         params: { dateRange },
         options: { loadPrevInterval },
       };
+      const prevVisits = expectsPrevVisits ? visitsMocks.map(
+        ({ date, ...rest }, index) => ({ ...rest, date: dateForVisit(index + 1 + visitsMocks.length) }),
+      ) : undefined;
 
       getDomainVisitsCall.mockResolvedValue({
         data: visitsMocks,
@@ -276,9 +277,9 @@ describe('domainVisitsReducer', () => {
 
       expect(dispatchMock).toHaveBeenCalledTimes(2);
       expect(dispatchMock).toHaveBeenLastCalledWith(expect.objectContaining({
-        payload: { visits: visitsMocks, prevVisits: expectedPrevVisits, ...getVisitsParam },
+        payload: { visits: visitsMocks, prevVisits, ...getVisitsParam },
       }));
-      expect(getDomainVisitsCall).toHaveBeenCalledTimes(expectedPrevVisits ? 2 : 1);
+      expect(getDomainVisitsCall).toHaveBeenCalledTimes(expectsPrevVisits ? 2 : 1);
     });
   });
 });

--- a/test/visits/reducers/nonOrphanVisits.test.ts
+++ b/test/visits/reducers/nonOrphanVisits.test.ts
@@ -191,47 +191,48 @@ describe('nonOrphanVisitsReducer', () => {
       {
         dateRange: { startDate: subDays(now, 1), endDate: addDays(now, 1) },
         loadPrevInterval: true,
-        expectedPrevVisits: visitsMocks.map(
-          ({ date, ...rest }, index) => ({ ...rest, date: dateForVisit(index + 1 + visitsMocks.length) }),
-        ),
+        expectsPrevVisits: true,
       },
       // Undefined date range and loadPrevInterval: true -> prev visits are NOT loaded
       {
         dateRange: undefined,
         loadPrevInterval: true,
-        expectedPrevVisits: undefined,
+        expectsPrevVisits: false,
       },
       // Empty date range and loadPrevInterval: true -> prev visits are NOT loaded
       {
         dateRange: {},
         loadPrevInterval: true,
-        expectedPrevVisits: undefined,
+        expectsPrevVisits: false,
       },
       // Start date only and loadPrevInterval: true -> prev visits are NOT loaded
       {
-        dateRange: { startDate: now },
+        dateRange: { startDate: subDays(now, 2) },
         loadPrevInterval: true,
-        expectedPrevVisits: undefined,
+        expectsPrevVisits: true,
       },
       // End date only and loadPrevInterval: true -> prev visits are NOT loaded
       {
         dateRange: { endDate: now },
         loadPrevInterval: true,
-        expectedPrevVisits: undefined,
+        expectsPrevVisits: false,
       },
       // Strict date range and loadPrevInterval: false -> prev visits are NOT loaded
       {
         dateRange: { startDate: subDays(now, 1), endDate: addDays(now, 1) },
         loadPrevInterval: false,
-        expectedPrevVisits: undefined,
+        expectsPrevVisits: false,
       },
     ])('returns visits from prev interval when requested and possible', async (
-      { dateRange, loadPrevInterval, expectedPrevVisits },
+      { dateRange, loadPrevInterval, expectsPrevVisits },
     ) => {
       const getVisitsParam: LoadVisits = {
         params: { dateRange },
         options: { loadPrevInterval },
       };
+      const prevVisits = expectsPrevVisits ? visitsMocks.map(
+        ({ date, ...rest }, index) => ({ ...rest, date: dateForVisit(index + 1 + visitsMocks.length) }),
+      ) : undefined;
 
       getNonOrphanVisitsCall.mockResolvedValue({
         data: visitsMocks,
@@ -246,9 +247,9 @@ describe('nonOrphanVisitsReducer', () => {
 
       expect(dispatchMock).toHaveBeenCalledTimes(2);
       expect(dispatchMock).toHaveBeenLastCalledWith(expect.objectContaining({
-        payload: { visits: visitsMocks, prevVisits: expectedPrevVisits, ...getVisitsParam },
+        payload: { visits: visitsMocks, prevVisits, ...getVisitsParam },
       }));
-      expect(getNonOrphanVisitsCall).toHaveBeenCalledTimes(expectedPrevVisits ? 2 : 1);
+      expect(getNonOrphanVisitsCall).toHaveBeenCalledTimes(expectsPrevVisits ? 2 : 1);
     });
   });
 });

--- a/test/visits/reducers/orphanVisits.test.ts
+++ b/test/visits/reducers/orphanVisits.test.ts
@@ -203,47 +203,48 @@ describe('orphanVisitsReducer', () => {
       {
         dateRange: { startDate: subDays(now, 1), endDate: addDays(now, 1) },
         loadPrevInterval: true,
-        expectedPrevVisits: visitsMocks.map(
-          ({ date, ...rest }, index) => ({ ...rest, date: dateForVisit(index + 1 + visitsMocks.length) }),
-        ),
+        expectsPrevVisits: true,
       },
       // Undefined date range and loadPrevInterval: true -> prev visits are NOT loaded
       {
         dateRange: undefined,
         loadPrevInterval: true,
-        expectedPrevVisits: undefined,
+        expectsPrevVisits: false,
       },
       // Empty date range and loadPrevInterval: true -> prev visits are NOT loaded
       {
         dateRange: {},
         loadPrevInterval: true,
-        expectedPrevVisits: undefined,
+        expectsPrevVisits: false,
       },
       // Start date only and loadPrevInterval: true -> prev visits are NOT loaded
       {
-        dateRange: { startDate: now },
+        dateRange: { startDate: subDays(now, 2) },
         loadPrevInterval: true,
-        expectedPrevVisits: undefined,
+        expectsPrevVisits: true,
       },
       // End date only and loadPrevInterval: true -> prev visits are NOT loaded
       {
         dateRange: { endDate: now },
         loadPrevInterval: true,
-        expectedPrevVisits: undefined,
+        expectsPrevVisits: false,
       },
       // Strict date range and loadPrevInterval: false -> prev visits are NOT loaded
       {
         dateRange: { startDate: subDays(now, 1), endDate: addDays(now, 1) },
         loadPrevInterval: false,
-        expectedPrevVisits: undefined,
+        expectsPrevVisits: false,
       },
     ])('returns visits from prev interval when requested and possible', async (
-      { dateRange, loadPrevInterval, expectedPrevVisits },
+      { dateRange, loadPrevInterval, expectsPrevVisits },
     ) => {
       const getVisitsParam: LoadOrphanVisits = {
         params: { dateRange },
         options: { loadPrevInterval },
       };
+      const prevVisits = expectsPrevVisits ? visitsMocks.map(
+        ({ date, ...rest }, index) => ({ ...rest, date: dateForVisit(index + 1 + visitsMocks.length) }),
+      ) : undefined;
 
       getOrphanVisitsCall.mockResolvedValue({
         data: visitsMocks,
@@ -258,9 +259,9 @@ describe('orphanVisitsReducer', () => {
 
       expect(dispatchMock).toHaveBeenCalledTimes(2);
       expect(dispatchMock).toHaveBeenLastCalledWith(expect.objectContaining({
-        payload: { visits: visitsMocks, prevVisits: expectedPrevVisits, ...getVisitsParam },
+        payload: { visits: visitsMocks, prevVisits, ...getVisitsParam },
       }));
-      expect(getOrphanVisitsCall).toHaveBeenCalledTimes(expectedPrevVisits ? 2 : 1);
+      expect(getOrphanVisitsCall).toHaveBeenCalledTimes(expectsPrevVisits ? 2 : 1);
     });
   });
 });

--- a/test/visits/reducers/shortUrlVisits.test.ts
+++ b/test/visits/reducers/shortUrlVisits.test.ts
@@ -261,42 +261,40 @@ describe('shortUrlVisitsReducer', () => {
       {
         dateRange: { startDate: subDays(now, 1), endDate: addDays(now, 1) },
         loadPrevInterval: true,
-        expectedPrevVisits: visitsMocks.map(
-          ({ date, ...rest }, index) => ({ ...rest, date: dateForVisit(index + 1 + visitsMocks.length) }),
-        ),
+        expectsPrevVisits: true,
       },
       // Undefined date range and loadPrevInterval: true -> prev visits are NOT loaded
       {
         dateRange: undefined,
         loadPrevInterval: true,
-        expectedPrevVisits: undefined,
+        expectsPrevVisits: false,
       },
       // Empty date range and loadPrevInterval: true -> prev visits are NOT loaded
       {
         dateRange: {},
         loadPrevInterval: true,
-        expectedPrevVisits: undefined,
+        expectsPrevVisits: false,
       },
-      // Start date only and loadPrevInterval: true -> prev visits are NOT loaded
+      // Start date only and loadPrevInterval: true -> prev visits are loaded
       {
-        dateRange: { startDate: now },
+        dateRange: { startDate: subDays(now, 2) },
         loadPrevInterval: true,
-        expectedPrevVisits: undefined,
+        expectsPrevVisits: true,
       },
       // End date only and loadPrevInterval: true -> prev visits are NOT loaded
       {
         dateRange: { endDate: now },
         loadPrevInterval: true,
-        expectedPrevVisits: undefined,
+        expectsPrevVisits: false,
       },
       // Strict date range and loadPrevInterval: false -> prev visits are NOT loaded
       {
         dateRange: { startDate: subDays(now, 1), endDate: addDays(now, 1) },
         loadPrevInterval: false,
-        expectedPrevVisits: undefined,
+        expectsPrevVisits: false,
       },
     ])('returns visits from prev interval when requested and possible', async (
-      { dateRange, loadPrevInterval, expectedPrevVisits },
+      { dateRange, loadPrevInterval, expectsPrevVisits },
     ) => {
       const shortCode = 'abc123';
       const getVisitsParam: LoadShortUrlVisits = {
@@ -304,6 +302,9 @@ describe('shortUrlVisitsReducer', () => {
         params: { dateRange },
         options: { loadPrevInterval },
       };
+      const prevVisits = expectsPrevVisits ? visitsMocks.map(
+        ({ date, ...rest }, index) => ({ ...rest, date: dateForVisit(index + 1 + visitsMocks.length) }),
+      ) : undefined;
 
       getShortUrlVisitsCall.mockResolvedValue({
         data: visitsMocks,
@@ -318,9 +319,9 @@ describe('shortUrlVisitsReducer', () => {
 
       expect(dispatchMock).toHaveBeenCalledTimes(2);
       expect(dispatchMock).toHaveBeenLastCalledWith(expect.objectContaining({
-        payload: { visits: visitsMocks, prevVisits: expectedPrevVisits, ...getVisitsParam },
+        payload: { visits: visitsMocks, prevVisits, ...getVisitsParam },
       }));
-      expect(getShortUrlVisitsCall).toHaveBeenCalledTimes(expectedPrevVisits ? 2 : 1);
+      expect(getShortUrlVisitsCall).toHaveBeenCalledTimes(expectsPrevVisits ? 2 : 1);
     });
   });
 });

--- a/test/visits/reducers/tagVisits.test.ts
+++ b/test/visits/reducers/tagVisits.test.ts
@@ -217,48 +217,49 @@ describe('tagVisitsReducer', () => {
       {
         dateRange: { startDate: subDays(now, 1), endDate: addDays(now, 1) },
         loadPrevInterval: true,
-        expectedPrevVisits: visitsMocks.map(
-          ({ date, ...rest }, index) => ({ ...rest, date: dateForVisit(index + 1 + visitsMocks.length) }),
-        ),
+        expectsPrevVisits: true,
       },
       // Undefined date range and loadPrevInterval: true -> prev visits are NOT loaded
       {
         dateRange: undefined,
         loadPrevInterval: true,
-        expectedPrevVisits: undefined,
+        expectsPrevVisits: false,
       },
       // Empty date range and loadPrevInterval: true -> prev visits are NOT loaded
       {
         dateRange: {},
         loadPrevInterval: true,
-        expectedPrevVisits: undefined,
+        expectsPrevVisits: false,
       },
-      // Start date only and loadPrevInterval: true -> prev visits are NOT loaded
+      // Start date only and loadPrevInterval: true -> prev visits are loaded
       {
-        dateRange: { startDate: now },
+        dateRange: { startDate: subDays(now, 2) },
         loadPrevInterval: true,
-        expectedPrevVisits: undefined,
+        expectsPrevVisits: true,
       },
       // End date only and loadPrevInterval: true -> prev visits are NOT loaded
       {
         dateRange: { endDate: now },
         loadPrevInterval: true,
-        expectedPrevVisits: undefined,
+        expectsPrevVisits: false,
       },
       // Strict date range and loadPrevInterval: false -> prev visits are NOT loaded
       {
         dateRange: { startDate: subDays(now, 1), endDate: addDays(now, 1) },
         loadPrevInterval: false,
-        expectedPrevVisits: undefined,
+        expectsPrevVisits: false,
       },
     ])('returns visits from prev interval when requested and possible', async (
-      { dateRange, loadPrevInterval, expectedPrevVisits },
+      { dateRange, loadPrevInterval, expectsPrevVisits },
     ) => {
       const getVisitsParam: LoadTagVisits = {
         tag,
         params: { dateRange },
         options: { loadPrevInterval },
       };
+      const prevVisits = expectsPrevVisits ? visitsMocks.map(
+        ({ date, ...rest }, index) => ({ ...rest, date: dateForVisit(index + 1 + visitsMocks.length) }),
+      ) : undefined;
 
       getTagVisitsCall.mockResolvedValue({
         data: visitsMocks,
@@ -273,9 +274,9 @@ describe('tagVisitsReducer', () => {
 
       expect(dispatchMock).toHaveBeenCalledTimes(2);
       expect(dispatchMock).toHaveBeenLastCalledWith(expect.objectContaining({
-        payload: { visits: visitsMocks, prevVisits: expectedPrevVisits, ...getVisitsParam },
+        payload: { visits: visitsMocks, prevVisits, ...getVisitsParam },
       }));
-      expect(getTagVisitsCall).toHaveBeenCalledTimes(expectedPrevVisits ? 2 : 1);
+      expect(getTagVisitsCall).toHaveBeenCalledTimes(expectsPrevVisits ? 2 : 1);
     });
   });
 });


### PR DESCRIPTION
Part of #9 

Be less strict when calculating previous date range. If only `startDate` is set, we fall back `endDate` to current date, allowing prev interval to be calculated.