### PR TITLE
Reduce duplicated code in visits reducers regarding prev visits loading

### DIFF
--- a/src/visits/reducers/common/createVisitsAsyncThunk.ts
+++ b/src/visits/reducers/common/createVisitsAsyncThunk.ts
@@ -5,6 +5,7 @@ import { formatIsoDate, parseISO } from '../../../utils/dates/helpers/date';
 import type { DateInterval } from '../../../utils/dates/helpers/dateIntervals';
 import { dateRangeDaysDiff, dateToMatchingInterval } from '../../../utils/dates/helpers/dateIntervals';
 import { createAsyncThunk } from '../../../utils/redux';
+import { isMandatoryStartDateRangeParams, paramsForPrevDateRange, toApiParams } from '../../helpers';
 import type { LoadVisits, VisitsLoaded } from '../types';
 import type { Loaders } from './createLoadVisits';
 import { createLoadVisits, DEFAULT_BATCH_SIZE } from './createLoadVisits';
@@ -22,11 +23,16 @@ export const createVisitsAsyncThunk = <T extends LoadVisits = LoadVisits>(
   const fallbackToInterval = createAction<DateInterval>(`${typePrefix}/fallbackToInterval`);
 
   const asyncThunk = createAsyncThunk(typePrefix, async (param: T, { getState, dispatch }): Promise<VisitsLoaded> => {
-    const { visitsLoader, lastVisitLoader, prevVisitsLoader } = createLoaders(param);
-    const batchSize = DEFAULT_BATCH_SIZE / (prevVisitsLoader ? 2 : 1);
-    const daysInDateRange = dateRangeDaysDiff(param.params.dateRange);
+    const { params, options } = param;
+    const { visitsLoader, lastVisitLoader } = createLoaders(param);
+    const daysInDateRange = dateRangeDaysDiff(params.dateRange);
+    const query = toApiParams(params);
+    const queryForPrevVisits = options.loadPrevInterval && isMandatoryStartDateRangeParams(params)
+      ? toApiParams(paramsForPrevDateRange(params))
+      : undefined;
+    const batchSize = DEFAULT_BATCH_SIZE / (queryForPrevVisits ? 2 : 1);
 
-    const progresses = prevVisitsLoader ? { main: 0, prev: 0 } : { main: 0 };
+    const progresses = queryForPrevVisits ? { main: 0, prev: 0 } : { main: 0 };
     const computeProgress = (key: keyof typeof progresses, progress: number) => {
       progresses[key] = progress;
 
@@ -42,16 +48,10 @@ export const createVisitsAsyncThunk = <T extends LoadVisits = LoadVisits>(
       progressChanged: (progress) => computeProgress('main', progress),
       batchSize,
     });
-    const loadPrevVisits = prevVisitsLoader && createLoadVisits({
-      visitsLoader: prevVisitsLoader,
-      shouldCancel: () => shouldCancel(getState),
-      progressChanged: (progress) => computeProgress('prev', progress),
-      batchSize,
-    });
     const [visits, lastVisit, prevVisits] = await Promise.all([
-      loadVisits(),
-      lastVisitLoader(param.params.filter?.excludeBots),
-      loadPrevVisits?.().then((v) => v.map((visit) => {
+      loadVisits(query),
+      lastVisitLoader(params.filter?.excludeBots),
+      queryForPrevVisits ? loadVisits(queryForPrevVisits).then((v) => v.map((visit) => {
         if (daysInDateRange === undefined) {
           return visit;
         }
@@ -60,7 +60,7 @@ export const createVisitsAsyncThunk = <T extends LoadVisits = LoadVisits>(
         const { date, ...rest } = visit;
         const dateObj = addDays(parseISO(date), daysInDateRange);
         return { ...rest, date: formatIsoDate(dateObj)! }; // FIXME Fix formatIsoDate return type
-      })) ?? Promise.resolve(undefined),
+      })) : Promise.resolve(undefined),
     ]);
 
     if (!visits.length && lastVisit) {

--- a/src/visits/visits-comparison/reducers/common/createLoadVisitsForComparison.ts
+++ b/src/visits/visits-comparison/reducers/common/createLoadVisitsForComparison.ts
@@ -1,5 +1,5 @@
 import type { ShlinkVisit } from '@shlinkio/shlink-js-sdk/api-contract';
-import type { VisitsLoader } from '../../../reducers/common';
+import type { NonPageVisitsParams, VisitsLoader } from '../../../reducers/common';
 import { createLoadVisits } from '../../../reducers/common';
 
 type CreateLoadVisitsForComparisonOptions = {
@@ -35,7 +35,7 @@ export const createLoadVisitsForComparison = ({
   };
 
   const loadVisitsEntries = Object.entries(visitsLoaders).map(
-    ([key, visitsLoader]): [string, () => Promise<ShlinkVisit[]>] => [
+    ([key, visitsLoader]): [string, (query: NonPageVisitsParams) => Promise<ShlinkVisit[]>] => [
       key,
       createLoadVisits({
         visitsLoader,
@@ -46,11 +46,11 @@ export const createLoadVisitsForComparison = ({
     ],
   );
 
-  return async (): Promise<Record<string, ShlinkVisit[]>> => {
+  return async (query: NonPageVisitsParams): Promise<Record<string, ShlinkVisit[]>> => {
     // TODO Every loadVisits has a built-in batching logic, which is more or less "optimized" here by provided batchSize
     //      However, this Promise.all(...) may also need some batching if a large list of items is passed.
     const visitsEntries = await Promise.all(loadVisitsEntries.map(async ([key, loadVisits]) => {
-      const visits = await loadVisits();
+      const visits = await loadVisits(query);
       return [key, visits];
     }));
 

--- a/src/visits/visits-comparison/reducers/common/createVisitsComparisonAsyncThunk.ts
+++ b/src/visits/visits-comparison/reducers/common/createVisitsComparisonAsyncThunk.ts
@@ -1,6 +1,7 @@
 import { createAction } from '@reduxjs/toolkit';
 import type { RootState } from '../../../../container/store';
 import { createAsyncThunk } from '../../../../utils/redux';
+import { toApiParams } from '../../../helpers';
 import type { VisitsLoader } from '../../../reducers/common';
 import type { LoadVisitsForComparison, VisitsForComparisonLoaded } from '../types';
 import { createLoadVisitsForComparison } from './createLoadVisitsForComparison';
@@ -24,7 +25,7 @@ export const createVisitsComparisonAsyncThunk = <CreateLoadersParam extends Load
         shouldCancel: () => shouldCancel(getState),
         progressChanged: (progress) => dispatch(progressChanged(progress)),
       });
-      const visitsGroups = await loadVisits();
+      const visitsGroups = await loadVisits(toApiParams(param.params));
 
       return { ...param, visitsGroups };
     },

--- a/src/visits/visits-comparison/reducers/domainVisitsComparison.ts
+++ b/src/visits/visits-comparison/reducers/domainVisitsComparison.ts
@@ -1,5 +1,6 @@
+import type { ShlinkVisitsParams } from '@shlinkio/shlink-js-sdk/api-contract';
 import type { ShlinkApiClient } from '../../../api-contract';
-import { filterCreatedVisitsByDomain, toApiParams } from '../../helpers';
+import { filterCreatedVisitsByDomain } from '../../helpers';
 import { createVisitsComparisonAsyncThunk } from './common/createVisitsComparisonAsyncThunk';
 import { createVisitsComparisonReducer } from './common/createVisitsComparisonReducer';
 import type { LoadVisitsForComparison, VisitsComparisonInfo } from './types';
@@ -19,14 +20,11 @@ const initialState: VisitsComparisonInfo = {
 export const getDomainVisitsForComparison = (apiClientFactory: () => ShlinkApiClient) =>
   createVisitsComparisonAsyncThunk({
     typePrefix: `${REDUCER_PREFIX}/getDomainVisitsForComparison`,
-    createLoaders: ({ domains, params }: LoadDomainVisitsForComparison) => {
+    createLoaders: ({ domains }: LoadDomainVisitsForComparison) => {
       const apiClient = apiClientFactory();
       const loaderEntries = domains.map((domain) => [
         domain,
-        async (page: number, itemsPerPage: number) => apiClient.getDomainVisits(
-          domain,
-          { ...toApiParams(params), page, itemsPerPage },
-        ),
+        (query: ShlinkVisitsParams) => apiClient.getDomainVisits(domain, query),
       ]);
 
       return Object.fromEntries(loaderEntries);

--- a/src/visits/visits-comparison/reducers/shortUrlVisitsComparison.ts
+++ b/src/visits/visits-comparison/reducers/shortUrlVisitsComparison.ts
@@ -1,7 +1,8 @@
+import type { ShlinkVisitsParams } from '@shlinkio/shlink-js-sdk/api-contract';
 import type { ShlinkApiClient } from '../../../api-contract';
 import type { ShortUrlIdentifier } from '../../../short-urls/data';
 import { queryToShortUrl, shortUrlToQuery } from '../../../short-urls/helpers';
-import { filterCreatedVisitsByShortUrl, toApiParams } from '../../helpers';
+import { filterCreatedVisitsByShortUrl } from '../../helpers';
 import { createVisitsComparisonAsyncThunk } from './common/createVisitsComparisonAsyncThunk';
 import { createVisitsComparisonReducer } from './common/createVisitsComparisonReducer';
 import type { LoadVisitsForComparison, VisitsComparisonInfo } from './types';
@@ -21,13 +22,13 @@ const initialState: VisitsComparisonInfo = {
 export const getShortUrlVisitsForComparison = (apiClientFactory: () => ShlinkApiClient) =>
   createVisitsComparisonAsyncThunk({
     typePrefix: `${REDUCER_PREFIX}/getShortUrlVisitsForComparison`,
-    createLoaders: ({ shortUrls, params }: LoadShortUrlVisitsForComparison) => {
+    createLoaders: ({ shortUrls }: LoadShortUrlVisitsForComparison) => {
       const apiClient = apiClientFactory();
       const loaderEntries = shortUrls.map((identifier) => [
         shortUrlToQuery(identifier),
-        async (page: number, itemsPerPage: number) => apiClient.getShortUrlVisits(
+        (query: ShlinkVisitsParams) => apiClient.getShortUrlVisits(
           identifier.shortCode,
-          { ...toApiParams(params), domain: identifier.domain, page, itemsPerPage },
+          { ...query, domain: identifier.domain },
         ),
       ]);
 

--- a/src/visits/visits-comparison/reducers/tagVisitsComparison.ts
+++ b/src/visits/visits-comparison/reducers/tagVisitsComparison.ts
@@ -1,5 +1,6 @@
+import type { ShlinkVisitsParams } from '@shlinkio/shlink-js-sdk/api-contract';
 import type { ShlinkApiClient } from '../../../api-contract';
-import { filterCreatedVisitsByTag, toApiParams } from '../../helpers';
+import { filterCreatedVisitsByTag } from '../../helpers';
 import { createVisitsComparisonAsyncThunk } from './common/createVisitsComparisonAsyncThunk';
 import { createVisitsComparisonReducer } from './common/createVisitsComparisonReducer';
 import type { LoadVisitsForComparison, VisitsComparisonInfo } from './types';
@@ -18,14 +19,11 @@ const initialState: VisitsComparisonInfo = {
 
 export const getTagVisitsForComparison = (apiClientFactory: () => ShlinkApiClient) => createVisitsComparisonAsyncThunk({
   typePrefix: `${REDUCER_PREFIX}/getTagVisitsForComparison`,
-  createLoaders: ({ tags, params }: LoadTagVisitsForComparison) => {
+  createLoaders: ({ tags }: LoadTagVisitsForComparison) => {
     const apiClient = apiClientFactory();
     const loaderEntries = tags.map((tag) => [
       tag,
-      async (page: number, itemsPerPage: number) => apiClient.getTagVisits(
-        tag,
-        { ...toApiParams(params), page, itemsPerPage },
-      ),
+      (query: ShlinkVisitsParams) => apiClient.getTagVisits(tag, query),
     ]);
 
     return Object.fromEntries(loaderEntries);


### PR DESCRIPTION
Part of #9 

This PR removes the `loadPrevVisits` callback from every visits reducer, and moves the logic to calculate the query and prev interval query to the common code.

Then, the regular visits loader is used for both queries to load both visits datasets.