### PR TITLE
Add prev visits to doughnut charts

### DIFF
--- a/src/visits/VisitsStats.tsx
+++ b/src/visits/VisitsStats.tsx
@@ -263,10 +263,10 @@ export const VisitsStats: FC<VisitsStatsProps> = (props) => {
                   element={(
                     <VisitsSectionWithFallback showFallback={visits.length === 0}>
                       <div className={clsx('mt-3 col-lg-6', { 'col-xl-4': !isOrphanVisits })}>
-                        <DoughnutChartCard title="Operating systems" stats={os} />
+                        <DoughnutChartCard title="Operating systems" stats={os} prevStats={processedPrevStats.os} />
                       </div>
                       <div className={clsx('mt-3 col-lg-6', { 'col-xl-4': !isOrphanVisits })}>
-                        <DoughnutChartCard title="Browsers" stats={browsers} />
+                        <DoughnutChartCard title="Browsers" stats={browsers} prevStats={processedPrevStats.browsers} />
                       </div>
                       <div className={clsx('mt-3', { 'col-xl-4': !isOrphanVisits, 'col-lg-6': isOrphanVisits })}>
                         <SortableBarChartCard

--- a/src/visits/charts/DoughnutChartCard.tsx
+++ b/src/visits/charts/DoughnutChartCard.tsx
@@ -1,18 +1,14 @@
 import { ToggleSwitch, useToggle } from '@shlinkio/shlink-frontend-kit';
 import type { FC } from 'react';
-import type { Stats } from '../types';
 import { ChartCard } from './ChartCard';
+import type { DoughnutChartProps } from './DoughnutChart';
 import { DoughnutChart } from './DoughnutChart';
 
-interface DoughnutChartCardProps {
+type DoughnutChartCardProps = Omit<DoughnutChartProps, 'showNumbersInLegend'> & {
   title: string;
-  stats: Stats;
+};
 
-  /** Test seam. For tests, a responsive container cannot be used */
-  dimensions?: { width: number; height: number };
-}
-
-export const DoughnutChartCard: FC<DoughnutChartCardProps> = ({ title, stats, dimensions }) => {
+export const DoughnutChartCard: FC<DoughnutChartCardProps> = ({ title, ...rest }) => {
   const [showNumbersInLegend, toggleShowNumbersInLegend] = useToggle(false);
 
   return (
@@ -28,7 +24,7 @@ export const DoughnutChartCard: FC<DoughnutChartCardProps> = ({ title, stats, di
         </>
       )}
     >
-      <DoughnutChart stats={stats} showNumbersInLegend={showNumbersInLegend} dimensions={dimensions} />
+      <DoughnutChart {...rest} showNumbersInLegend={showNumbersInLegend} />
     </ChartCard>
   );
 };

--- a/test/visits/charts/DoughnutChart.test.tsx
+++ b/test/visits/charts/DoughnutChart.test.tsx
@@ -6,12 +6,18 @@ import { renderWithEvents } from '../../__helpers__/setUpTest';
 describe('<DoughnutChart />', () => {
   const stats = { foo: 123, bar: 456 };
   const dimensions = { width: 800, height: 300 };
-  const setUp = () => renderWithEvents(<DoughnutChart stats={stats} dimensions={dimensions} showNumbersInLegend />);
+  const setUp = (prevStats = {}) => renderWithEvents(
+    <DoughnutChart stats={stats} prevStats={prevStats} dimensions={dimensions} showNumbersInLegend />,
+  );
 
   it('passes a11y checks', () => checkAccessibility(setUp()));
 
-  it('renders Doughnut with expected props', () => {
-    const { container } = setUp();
+  it.each([
+    [{}],
+    [{ foo: 300, baz: 33 }],
+    [{ ...stats, baz: 20 }],
+  ])('renders Doughnut with expected props', (prevStats) => {
+    const { container } = setUp(prevStats);
     expect(container).toMatchSnapshot();
   });
 

--- a/test/visits/charts/DoughnutChartCard.test.tsx
+++ b/test/visits/charts/DoughnutChartCard.test.tsx
@@ -6,7 +6,9 @@ import { renderWithEvents } from '../../__helpers__/setUpTest';
 describe('<DoughnutChartCard />', () => {
   const stats = { foo: 10, bar: 5602 };
   const dimensions = { width: 800, height: 400 };
-  const setUp = () => renderWithEvents(<DoughnutChartCard title="Stats" stats={stats} dimensions={dimensions} />);
+  const setUp = () => renderWithEvents(
+    <DoughnutChartCard title="Stats" stats={stats} prevStats={{}} dimensions={dimensions} />,
+  );
 
   it('passes a11y checks', () => checkAccessibility(setUp()));
 

--- a/test/visits/charts/__snapshots__/DoughnutChart.test.tsx.snap
+++ b/test/visits/charts/__snapshots__/DoughnutChart.test.tsx.snap
@@ -123,3 +123,289 @@ exports[`<DoughnutChart /> > renders Doughnut with expected props 1`] = `
   </div>
 </div>
 `;
+
+exports[`<DoughnutChart /> > renders Doughnut with expected props 2`] = `
+<div>
+  <div
+    class="row align-items-center"
+  >
+    <div
+      class="col-sm-12 col-md-7"
+    >
+      <div
+        style="width: 800px; height: 300px;"
+      >
+        <div
+          class="recharts-wrapper"
+          role="region"
+          style="position: relative; cursor: default; width: 800px; height: 300px;"
+        >
+          <svg
+            class="recharts-surface"
+            cx="50%"
+            cy="50%"
+            height="300"
+            style="width: 100%; height: 100%;"
+            viewBox="0 0 800 300"
+            width="800"
+          >
+            <title />
+            <desc />
+            <defs>
+              <clippath
+                id="recharts5-clip"
+              >
+                <rect
+                  height="290"
+                  width="790"
+                  x="5"
+                  y="5"
+                />
+              </clippath>
+            </defs>
+            <g
+              class="recharts-layer recharts-pie"
+              tabindex="0"
+            >
+              <g
+                class="recharts-layer"
+              >
+                <g
+                  class="recharts-layer recharts-pie-sector"
+                  tabindex="-1"
+                />
+                <g
+                  class="recharts-layer recharts-pie-sector"
+                  tabindex="-1"
+                />
+              </g>
+            </g>
+            <g
+              class="recharts-layer recharts-pie"
+              tabindex="0"
+            >
+              <g
+                class="recharts-layer"
+              >
+                <g
+                  class="recharts-layer recharts-pie-sector"
+                  tabindex="-1"
+                />
+                <g
+                  class="recharts-layer recharts-pie-sector"
+                  tabindex="-1"
+                />
+              </g>
+            </g>
+          </svg>
+          <div
+            class="recharts-tooltip-wrapper"
+            role="dialog"
+            style="visibility: hidden; pointer-events: none; position: absolute; top: 0px; left: 0px;"
+            tabindex="-1"
+          >
+            <div
+              class="recharts-default-tooltip"
+              style="margin: 0px; padding: 10px; background-color: rgb(255, 255, 255); white-space: nowrap; color: white; border-radius: 5px;"
+            >
+              <p
+                class="recharts-tooltip-label"
+                style="margin: 0px;"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="col-sm-12 col-md-5"
+    >
+      <ul
+        class="doughnut-chart-legend"
+      >
+        <li
+          class="doughnut-chart-legend__item d-flex"
+        >
+          <div
+            class="doughnut-chart-legend__item-color"
+            style="background-color: rgb(151, 187, 205);"
+          />
+          <small
+            class="doughnut-chart-legend__item-text flex-fill"
+          >
+            foo
+            <b>
+               (
+              123
+              )
+            </b>
+          </small>
+        </li>
+        <li
+          class="doughnut-chart-legend__item d-flex"
+        >
+          <div
+            class="doughnut-chart-legend__item-color"
+            style="background-color: rgb(247, 70, 74);"
+          />
+          <small
+            class="doughnut-chart-legend__item-text flex-fill"
+          >
+            bar
+            <b>
+               (
+              456
+              )
+            </b>
+          </small>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<DoughnutChart /> > renders Doughnut with expected props 3`] = `
+<div>
+  <div
+    class="row align-items-center"
+  >
+    <div
+      class="col-sm-12 col-md-7"
+    >
+      <div
+        style="width: 800px; height: 300px;"
+      >
+        <div
+          class="recharts-wrapper"
+          role="region"
+          style="position: relative; cursor: default; width: 800px; height: 300px;"
+        >
+          <svg
+            class="recharts-surface"
+            cx="50%"
+            cy="50%"
+            height="300"
+            style="width: 100%; height: 100%;"
+            viewBox="0 0 800 300"
+            width="800"
+          >
+            <title />
+            <desc />
+            <defs>
+              <clippath
+                id="recharts8-clip"
+              >
+                <rect
+                  height="290"
+                  width="790"
+                  x="5"
+                  y="5"
+                />
+              </clippath>
+            </defs>
+            <g
+              class="recharts-layer recharts-pie"
+              tabindex="0"
+            >
+              <g
+                class="recharts-layer"
+              >
+                <g
+                  class="recharts-layer recharts-pie-sector"
+                  tabindex="-1"
+                />
+                <g
+                  class="recharts-layer recharts-pie-sector"
+                  tabindex="-1"
+                />
+              </g>
+            </g>
+            <g
+              class="recharts-layer recharts-pie"
+              tabindex="0"
+            >
+              <g
+                class="recharts-layer"
+              >
+                <g
+                  class="recharts-layer recharts-pie-sector"
+                  tabindex="-1"
+                />
+                <g
+                  class="recharts-layer recharts-pie-sector"
+                  tabindex="-1"
+                />
+                <g
+                  class="recharts-layer recharts-pie-sector"
+                  tabindex="-1"
+                />
+              </g>
+            </g>
+          </svg>
+          <div
+            class="recharts-tooltip-wrapper"
+            role="dialog"
+            style="visibility: hidden; pointer-events: none; position: absolute; top: 0px; left: 0px;"
+            tabindex="-1"
+          >
+            <div
+              class="recharts-default-tooltip"
+              style="margin: 0px; padding: 10px; background-color: rgb(255, 255, 255); white-space: nowrap; color: white; border-radius: 5px;"
+            >
+              <p
+                class="recharts-tooltip-label"
+                style="margin: 0px;"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="col-sm-12 col-md-5"
+    >
+      <ul
+        class="doughnut-chart-legend"
+      >
+        <li
+          class="doughnut-chart-legend__item d-flex"
+        >
+          <div
+            class="doughnut-chart-legend__item-color"
+            style="background-color: rgb(151, 187, 205);"
+          />
+          <small
+            class="doughnut-chart-legend__item-text flex-fill"
+          >
+            foo
+            <b>
+               (
+              123
+              )
+            </b>
+          </small>
+        </li>
+        <li
+          class="doughnut-chart-legend__item d-flex"
+        >
+          <div
+            class="doughnut-chart-legend__item-color"
+            style="background-color: rgb(247, 70, 74);"
+          />
+          <small
+            class="doughnut-chart-legend__item-text flex-fill"
+          >
+            bar
+            <b>
+               (
+              456
+              )
+            </b>
+          </small>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+`;


### PR DESCRIPTION
Closes #9 

Enable prev stats in doughnut charts, by loading an inner chart with prev visits.

This is a bit rough solution, but should be ok for now. Will need to be improved in the future, as it lacks info in the legend, or different colors per entry.