### PR TITLE
Send orphan visits type to server when listing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org).
 
-## [Unreleased]
+## [0.6.2] - 2024-04.17
 ### Added
 * *Nothing*
 
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 * Make sure project dependencies are not bundled with package.
 * [#244](https://github.com/shlinkio/shlink-web-component/issues/244) Display `visitedUrl` in visits table if the visit object has it, regardless of it being an orphan visit or not.
+* [#327](https://github.com/shlinkio/shlink-web-component/issues/327) Ensure orphan visits type is sent to the server, to enable server-side filtering when consumed Shlink supports it.
 
 
 ## [0.6.1] - 2024-04-10

--- a/src/visits/reducers/orphanVisits.ts
+++ b/src/visits/reducers/orphanVisits.ts
@@ -34,7 +34,11 @@ export const getOrphanVisits = (apiClientFactory: () => ShlinkApiClient) => crea
     const apiClient = apiClientFactory();
     const { doIntervalFallback = false } = options;
 
-    const visitsLoader = async (query: ShlinkVisitsParams) => apiClient.getOrphanVisits(query).then(
+    const visitsLoader = async (query: ShlinkVisitsParams) => apiClient.getOrphanVisits({
+      ...query,
+      type: orphanVisitsType, // Send type to the server, in case it supports filtering by type
+    }).then(
+      // We still try to filter locally, for Shlink older than 4.0.0
       (resp) => filterOrphanVisitsByType(resp, orphanVisitsType),
     );
     const lastVisitLoader = lastVisitLoaderForLoader(doIntervalFallback, (q) => apiClient.getOrphanVisits(q));


### PR DESCRIPTION
Closes #327 

Shlink 4.0.0 allows filtering orphan visits by type server-side. This PR ensures the type is sent to the server so that we can have faster requests and smaller payloads when possible.