### PR TITLE
Use Shlink server defaults in QR modal

### DIFF
--- a/src/short-urls/helpers/QrCodeModal.tsx
+++ b/src/short-urls/helpers/QrCodeModal.tsx
@@ -22,10 +22,10 @@ const QrCodeModal: FCWithDeps<ShortUrlModalProps, QrCodeModalDeps> = (
   { shortUrl: { shortUrl, shortCode }, toggle, isOpen },
 ) => {
   const { ImageDownloader: imageDownloader } = useDependencies(QrCodeModal);
-  const [size, setSize] = useState(300);
-  const [margin, setMargin] = useState(0);
-  const [format, setFormat] = useState<QrCodeFormat>('png');
-  const [errorCorrection, setErrorCorrection] = useState<QrErrorCorrection>('L');
+  const [size, setSize] = useState<number|undefined>();
+  const [margin, setMargin] = useState<number|undefined>();
+  const [format, setFormat] = useState<QrCodeFormat|undefined>();
+  const [errorCorrection, setErrorCorrection] = useState<QrErrorCorrection|undefined>();
   const qrCodeUrl = useMemo(
     () => buildQrCodeUrl(shortUrl, { size, format, margin, errorCorrection }),
     [shortUrl, size, format, margin, errorCorrection],

--- a/src/short-urls/helpers/qr-codes/QrErrorCorrectionDropdown.tsx
+++ b/src/short-urls/helpers/qr-codes/QrErrorCorrectionDropdown.tsx
@@ -4,7 +4,7 @@ import { DropdownItem } from 'reactstrap';
 import type { QrErrorCorrection } from '../../../utils/helpers/qrCodes';
 
 interface QrErrorCorrectionDropdownProps {
-  errorCorrection: QrErrorCorrection;
+  errorCorrection: QrErrorCorrection|undefined;
   setErrorCorrection: (errorCorrection: QrErrorCorrection) => void;
 }
 

--- a/src/short-urls/helpers/qr-codes/QrFormatDropdown.tsx
+++ b/src/short-urls/helpers/qr-codes/QrFormatDropdown.tsx
@@ -4,7 +4,7 @@ import { DropdownItem } from 'reactstrap';
 import type { QrCodeFormat } from '../../../utils/helpers/qrCodes';
 
 interface QrFormatDropdownProps {
-  format: QrCodeFormat;
+  format: QrCodeFormat|undefined;
   setFormat: (format: QrCodeFormat) => void;
 }
 

--- a/src/utils/helpers/qrCodes.ts
+++ b/src/utils/helpers/qrCodes.ts
@@ -5,17 +5,17 @@ export type QrCodeFormat = 'svg' | 'png';
 export type QrErrorCorrection = 'L' | 'M' | 'Q' | 'H';
 
 export interface QrCodeOptions {
-  size: number;
-  format: QrCodeFormat;
-  margin: number;
-  errorCorrection: QrErrorCorrection;
+  size: number|undefined;
+  format: QrCodeFormat|undefined;
+  margin: number|undefined;
+  errorCorrection: QrErrorCorrection|undefined;
 }
 
 export const buildQrCodeUrl = (shortUrl: string, { margin, ...options }: QrCodeOptions): string => {
   const baseUrl = `${shortUrl}/qr-code`;
   const query = stringifyQuery({
     ...options,
-    margin: margin > 0 ? margin : undefined,
+    margin: (margin != undefined && margin > 0) ? margin : undefined,
   });
 
   return `${baseUrl}${!query ? '' : `?${query}`}`;


### PR DESCRIPTION
Made some quick changes to address the issue in #382 .
These changes will not initialize the QR code values in the modal and allow undefined parameters in the QR code URL helper.

It does break the totalSize and modalSize right now, I'm not yet sure how to properly fix those. For now it will just cause the modal to be full width.