### PR TITLE
Add support for ip-address redirect rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 ### Added
 * Document how `<ShlinkWebSettings />` is used.
+* Add support for `ip-address` redirect conditions when using Shlink 4.2.
 
 ### Changed
 * Update to `@shlinkio/eslint-config-js-coding-standard` 3.0, and migrate to ESLint flat config.

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "@fortawesome/react-fontawesome": "^0.2.0",
         "@reduxjs/toolkit": "^2.0.1",
         "@shlinkio/shlink-frontend-kit": "^0.5.2",
-        "@shlinkio/shlink-js-sdk": "^1.1.0",
+        "@shlinkio/shlink-js-sdk": "^1.2.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-redux": "^9.0.1",
@@ -1886,9 +1886,9 @@
       }
     },
     "node_modules/@shlinkio/shlink-js-sdk": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@shlinkio/shlink-js-sdk/-/shlink-js-sdk-1.1.0.tgz",
-      "integrity": "sha512-KHvFCmRxkK0H0nja66aGzFrjh5VQpC9m2KXnk/Lb7HMpmoWvf8CZqBYyiPFy3Evaa+GnIHjFv7LtqFce+FVFVg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@shlinkio/shlink-js-sdk/-/shlink-js-sdk-1.2.0.tgz",
+      "integrity": "sha512-kYok17WEFcXRknRcbMjO4oTXtmY5XzmmQ4092q+awH0jqQfLDPfY6V2TJGUFhxYseGC4Imz4HX4tbqhcc2xntw==",
       "optional": true,
       "peer": true
     },

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@fortawesome/react-fontawesome": "^0.2.0",
     "@reduxjs/toolkit": "^2.0.1",
     "@shlinkio/shlink-frontend-kit": "^0.5.2",
-    "@shlinkio/shlink-js-sdk": "^1.1.0",
+    "@shlinkio/shlink-js-sdk": "^1.2.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-redux": "^9.0.1",

--- a/src/redirect-rules/helpers/RedirectRuleCard.tsx
+++ b/src/redirect-rules/helpers/RedirectRuleCard.tsx
@@ -66,6 +66,7 @@ export const RedirectRuleCard: FC<RedirectRuleCardProps> = (
                 {condition.type === 'query-param' && (
                   <>Query string contains {condition.matchKey}={condition.matchValue}</>
                 )}
+                {condition.type === 'ip-address' && <>IP address matches {condition.matchValue}</>}
               </div>
             ))}
           </div>

--- a/src/redirect-rules/helpers/RedirectRuleModal.scss
+++ b/src/redirect-rules/helpers/RedirectRuleModal.scss
@@ -6,3 +6,18 @@
 .redirect-rule-modal__footer.redirect-rule-modal__footer {
   background-color: var(--primary-color);
 }
+
+.redirect-rule-modal__remove-condition-button.redirect-rule-modal__remove-condition-button {
+  top: -15px;
+  right: -15px;
+  background-color: var(--primary-color);
+}
+
+.redirect-rule-modal__remove-condition-button-icon {
+  width: 14px;
+  line-height: 14px;
+}
+
+.redirect-rule-modal__conditions-row.redirect-rule-modal__conditions-row {
+  padding-right: 0.8rem;
+}

--- a/src/utils/features.ts
+++ b/src/utils/features.ts
@@ -10,6 +10,7 @@ const supportedFeatures = {
   orphanVisitsDeletion: { minVersion: '3.7.0' },
   shortUrlRedirectRules: { minVersion: '4.0.0' },
   urlValidation: { maxVersion: '3.*.*' },
+  ipRedirectCondition: { minVersion: '4.2.*' },
 } as const satisfies Record<string, Versions>;
 
 Object.freeze(supportedFeatures);
@@ -27,6 +28,7 @@ const getFeaturesForVersion = (serverVersion: SemVerOrLatest): Record<Feature, b
   orphanVisitsDeletion: isFeatureEnabledForVersion('orphanVisitsDeletion', serverVersion),
   shortUrlRedirectRules: isFeatureEnabledForVersion('shortUrlRedirectRules', serverVersion),
   urlValidation: isFeatureEnabledForVersion('urlValidation', serverVersion),
+  ipRedirectCondition: isFeatureEnabledForVersion('ipRedirectCondition', serverVersion),
 });
 
 const FeaturesContext = createContext(getFeaturesForVersion('0.0.0'));

--- a/test/redirect-rules/helpers/RedirectRuleCard.test.tsx
+++ b/test/redirect-rules/helpers/RedirectRuleCard.test.tsx
@@ -11,6 +11,7 @@ describe('<RedirectRuleCard />', () => {
     { type: 'device', matchValue: 'android', matchKey: null },
     { type: 'language', matchValue: 'es-ES', matchKey: null },
     { type: 'query-param', matchValue: 'bar', matchKey: 'foo' },
+    { type: 'ip-address', matchValue: '1.2.3.4', matchKey: null },
   ];
   const setUp = (props: Partial<RedirectRuleCardProps> = {}) => renderWithEvents(
     <RedirectRuleCard
@@ -53,6 +54,7 @@ describe('<RedirectRuleCard />', () => {
     expect(screen.getByText('Device is android')).toBeInTheDocument();
     expect(screen.getByText('es-ES language is accepted')).toBeInTheDocument();
     expect(screen.getByText('Query string contains foo=bar')).toBeInTheDocument();
+    expect(screen.getByText('IP address matches 1.2.3.4')).toBeInTheDocument();
   });
 
   it('can delete the rule', async () => {

--- a/test/redirect-rules/helpers/RedirectRuleModal.test.tsx
+++ b/test/redirect-rules/helpers/RedirectRuleModal.test.tsx
@@ -90,7 +90,7 @@ describe('<RedirectRuleModal />', () => {
     await user.type(screen.getByLabelText('Param value:'), 'the_value');
 
     // Remove the existing language condition
-    await user.click(screen.getAllByLabelText('Delete condition')[1]);
+    await user.click(screen.getAllByLabelText('Remove condition')[1]);
 
     // Add a new condition of type language
     await user.click(screen.getByLabelText('Add condition'));

--- a/test/redirect-rules/helpers/RedirectRuleModal.test.tsx
+++ b/test/redirect-rules/helpers/RedirectRuleModal.test.tsx
@@ -4,6 +4,7 @@ import type {
   ShlinkRedirectRuleData,
 } from '@shlinkio/shlink-js-sdk/api-contract';
 import { screen, waitFor } from '@testing-library/react';
+import type { UserEvent } from '@testing-library/user-event';
 import { fromPartial } from '@total-typescript/shoehorn';
 import { RedirectRuleModal } from '../../../src/redirect-rules/helpers/RedirectRuleModal';
 import { FeaturesProvider } from '../../../src/utils/features';
@@ -11,17 +12,27 @@ import { checkAccessibility } from '../../__helpers__/accessibility';
 import { renderWithEvents } from '../../__helpers__/setUpTest';
 import { TestModalWrapper } from '../../__helpers__/TestModalWrapper';
 
+type SetUpOptions = {
+  initialData?: ShlinkRedirectRuleData;
+  ipRedirectCondition?: boolean;
+};
+
 describe('<RedirectRuleModal />', () => {
   const onSave = vi.fn();
-  const setUp = (initialData?: ShlinkRedirectRuleData) => renderWithEvents(
+  const setUp = ({ initialData, ipRedirectCondition = true }: SetUpOptions) => renderWithEvents(
     <TestModalWrapper
       renderModal={(args) => (
-        <FeaturesProvider value={fromPartial({ ipRedirectCondition: true })}>
+        <FeaturesProvider value={fromPartial({ ipRedirectCondition })}>
           <RedirectRuleModal {...args} onSave={onSave} initialData={initialData} />
         </FeaturesProvider>
       )}
     />,
   );
+  const addConditionWithType = async (user: UserEvent, option: ShlinkRedirectConditionType) => {
+    await user.click(screen.getByLabelText('Add condition'));
+    const [lastTypeSelect] = screen.getAllByLabelText('Type:').reverse();
+    await user.selectOptions(lastTypeSelect, [option]);
+  };
 
   it.each([
     [undefined],
@@ -36,16 +47,17 @@ describe('<RedirectRuleModal />', () => {
         { type: 'language', matchValue: 'en-US', matchKey: null },
       ],
     } satisfies ShlinkRedirectRuleData],
-  ])('passes a11y checks', (initialData) => checkAccessibility(setUp(initialData)));
+  ])('passes a11y checks', (initialData) => checkAccessibility(setUp({ initialData })));
 
   it('can add more conditions', async () => {
-    const { user } = setUp({
+    const initialData: ShlinkRedirectRuleData = {
       longUrl: 'https://example.com',
       conditions: [
         { type: 'device', matchValue: 'android', matchKey: null },
         { type: 'language', matchValue: 'en-US', matchKey: null },
       ],
-    });
+    };
+    const { user } = setUp({ initialData });
 
     expect(screen.getAllByLabelText('Type:')).toHaveLength(2);
 
@@ -61,7 +73,9 @@ describe('<RedirectRuleModal />', () => {
     [[]],
     [[{ type: 'device', matchValue: 'android', matchKey: null } satisfies ShlinkRedirectCondition]],
   ])('disables confirm button as long as there are no conditions', (conditions) => {
-    setUp({ longUrl: 'https://example.com', conditions });
+    setUp({
+      initialData: { longUrl: 'https://example.com', conditions },
+    });
 
     if (conditions.length === 0) {
       expect(screen.getByRole('button', { name: 'Confirm' })).toHaveAttribute('disabled');
@@ -71,18 +85,14 @@ describe('<RedirectRuleModal />', () => {
   });
 
   it('saves rule when form is submit, and closes modal', async () => {
-    const initialRule: ShlinkRedirectRuleData = {
+    const initialData: ShlinkRedirectRuleData = {
       longUrl: 'https://example.com',
       conditions: [
         { type: 'device', matchValue: 'android', matchKey: null },
         { type: 'language', matchValue: 'en-US', matchKey: null },
       ],
     };
-    const { user } = setUp(initialRule);
-    const changeConditionType = async (option: ShlinkRedirectConditionType) => {
-      await user.click(screen.getByLabelText('Add condition'));
-      await user.selectOptions(screen.getAllByLabelText('Type:')[2], [option]);
-    };
+    const { user } = setUp({ initialData });
 
     // Wait for modal to finish opening, otherwise focus may transition to long URL field while some other field is
     // being edited
@@ -96,31 +106,51 @@ describe('<RedirectRuleModal />', () => {
     await user.selectOptions(screen.getByLabelText('Device type:'), ['ios']);
 
     // Add a new condition of type query-param
-    await changeConditionType('query-param');
+    await addConditionWithType(user, 'query-param');
     await user.type(screen.getByLabelText('Param name:'), 'the_key');
     await user.type(screen.getByLabelText('Param value:'), 'the_value');
 
     // Remove the existing language condition
     await user.click(screen.getAllByLabelText('Remove condition')[1]);
 
+    // Add a new condition of type language
+    await addConditionWithType(user, 'language');
+    await user.type(screen.getByLabelText('Language:'), 'es-ES');
+
     // Add a new condition of type ip-address
-    await changeConditionType('ip-address');
+    await addConditionWithType(user, 'ip-address');
     await user.type(screen.getByLabelText('IP address:'), '192.168.1.*');
 
     await user.click(screen.getByRole('button', { name: 'Confirm' }));
-
-    console.log(onSave.mock.lastCall);
 
     expect(onSave).toHaveBeenCalledWith({
       longUrl: 'https://www.example.com/edited',
       conditions: [
         { type: 'device', matchValue: 'ios', matchKey: null },
         { type: 'query-param', matchValue: 'the_value', matchKey: 'the_key' },
+        { type: 'language', matchValue: 'es-ES', matchKey: null },
         { type: 'ip-address', matchValue: '192.168.1.*', matchKey: null },
       ],
     });
 
     // After form is submit, the modal itself is closed
     await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+  });
+
+  it.each([
+    { ipRedirectCondition: true, expectedOptions: ['Device', 'Language', 'Query param', 'IP address'] as const },
+    { ipRedirectCondition: false, expectedOptions: ['Device', 'Language', 'Query param'] as const },
+  ])('displays only supported options', async ({ ipRedirectCondition, expectedOptions }) => {
+    const { user } = setUp({ ipRedirectCondition });
+
+    // Add a condition box, with a type other than device-type (default one), so that device type options to not affect
+    // assertions and cause false negatives
+    await addConditionWithType(user, 'language');
+    const options = screen.getAllByRole('option');
+
+    expect(options).toHaveLength(expectedOptions.length);
+    options.forEach((option, index) => {
+      expect(option).toHaveTextContent(expectedOptions[index]);
+    });
   });
 });


### PR DESCRIPTION
Closes #411 

Update to the latest version of the JS SDK, and add support to the new `ip-address` redirect condition type.

Additionally, change the way redirect conditions are removed from a rule, from a trash-can button next to the condition type select, to a close button on the upper-right corner.

Before/After:

![image](https://github.com/user-attachments/assets/2ac79fc6-58f8-4873-9983-9715de492ced)
![image](https://github.com/user-attachments/assets/178439e1-8aaf-462c-be18-c87b81d0d7bb)
