### PR TITLE
Feature/line chart selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 * Document how `<ShlinkWebSettings />` is used.
 * [#411](https://github.com/shlinkio/shlink-web-component/issues/411) Add support for `ip-address` redirect conditions when Shlink server is >=4.2
+* [#196](https://github.com/shlinkio/shlink-web-component/issues/196) Allow active date range to be changed by selecting a range in visits and visits-comparison line charts.
 
 ### Changed
 * Update to `@shlinkio/eslint-config-js-coding-standard` 3.0, and migrate to ESLint flat config.

--- a/src/visits/VisitsStats.tsx
+++ b/src/visits/VisitsStats.tsx
@@ -251,7 +251,11 @@ export const VisitsStats: FC<VisitsStatsProps> = (props) => {
                   element={(
                     <VisitsSectionWithFallback showFallback={visits.length === 0}>
                       <div className="col-12 mt-3" data-testid="line-chart-container">
-                        <LineChartCard visitsGroups={visitsGroups} setSelectedVisits={setSelectedVisits} />
+                        <LineChartCard
+                          visitsGroups={visitsGroups}
+                          setSelectedVisits={setSelectedVisits}
+                          onDateRangeChange={setDates}
+                        />
                       </div>
                       <PrevVisitsNotice display={!!resolvedFilter.loadPrevInterval && !prevVisits} />
                     </VisitsSectionWithFallback>

--- a/src/visits/visits-comparison/VisitsComparison.tsx
+++ b/src/visits/visits-comparison/VisitsComparison.tsx
@@ -106,7 +106,7 @@ export const VisitsComparison: FC<VisitsComparisonProps> = ({
       <VisitsLoadingFeedback info={visitsComparisonInfo} />
       {!loading && (
         <VisitsSectionWithFallback showFallback={showFallback}>
-          <LineChartCard visitsGroups={normalizedVisitsGroups} />
+          <LineChartCard visitsGroups={normalizedVisitsGroups} onDateRangeChange={setDates} />
         </VisitsSectionWithFallback>
       )}
     </>

--- a/test/visits/charts/__snapshots__/LineChartCard.test.tsx.snap
+++ b/test/visits/charts/__snapshots__/LineChartCard.test.tsx.snap
@@ -71,7 +71,7 @@ exports[`<LineChartCard /> > renders chart with expected data 1`] = `
       class="card-body"
     >
       <div
-        class="recharts-wrapper"
+        class="recharts-wrapper user-select-none"
         style="position: relative; cursor: default; width: 800px; height: 400px;"
       >
         <svg
@@ -252,7 +252,7 @@ exports[`<LineChartCard /> > renders chart with expected data 2`] = `
       class="card-body"
     >
       <div
-        class="recharts-wrapper"
+        class="recharts-wrapper user-select-none"
         style="position: relative; cursor: default; width: 800px; height: 400px;"
       >
         <svg
@@ -479,7 +479,7 @@ exports[`<LineChartCard /> > renders chart with expected data 3`] = `
       class="card-body"
     >
       <div
-        class="recharts-wrapper"
+        class="recharts-wrapper user-select-none"
         style="position: relative; cursor: default; width: 800px; height: 400px;"
       >
         <svg
@@ -1041,7 +1041,7 @@ exports[`<LineChartCard /> > renders chart with expected data 4`] = `
       class="card-body"
     >
       <div
-        class="recharts-wrapper"
+        class="recharts-wrapper user-select-none"
         style="position: relative; cursor: default; width: 800px; height: 400px;"
       >
         <svg
@@ -1645,7 +1645,7 @@ exports[`<LineChartCard /> > renders chart with expected data 5`] = `
       class="card-body"
     >
       <div
-        class="recharts-wrapper"
+        class="recharts-wrapper user-select-none"
         style="position: relative; cursor: default; width: 800px; height: 400px;"
       >
         <svg


### PR DESCRIPTION
Closes #196 

Allow active date range to be changed in visits and visits-comparison sections, by selecting a range in the line chart via drag and drop.

[Grabación de pantalla desde 2024-09-14 16-46-38.webm](https://github.com/user-attachments/assets/0203ddee-5358-49e1-8d03-05f5ebdb055d)
