### PR TITLE
Feature/delete confirmation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Document how `<ShlinkWebSettings />` is used.
 * [#411](https://github.com/shlinkio/shlink-web-component/issues/411) Add support for `ip-address` redirect conditions when Shlink server is >=4.2
 * [#196](https://github.com/shlinkio/shlink-web-component/issues/196) Allow active date range to be changed by selecting a range in visits and visits-comparison line charts.
+* [#307](https://github.com/shlinkio/shlink-web-component/issues/307) Add new setting to disable short URL deletions confirmation.
 
 ### Changed
 * Update to `@shlinkio/eslint-config-js-coding-standard` 3.0, and migrate to ESLint flat config.

--- a/src/settings/components/ShortUrlCreationSettings.tsx
+++ b/src/settings/components/ShortUrlCreationSettings.tsx
@@ -1,6 +1,6 @@
 import { DropdownBtn, LabeledFormGroup, SimpleCard, ToggleSwitch } from '@shlinkio/shlink-frontend-kit';
 import type { FC, ReactNode } from 'react';
-import { DropdownItem, FormGroup } from 'reactstrap';
+import { DropdownItem } from 'reactstrap';
 import type { ShortUrlCreationSettings as ShortUrlsSettings } from '..';
 import { useSetting } from '..';
 import { FormText } from './FormText';
@@ -26,8 +26,8 @@ export const ShortUrlCreationSettings: FC<ShortUrlCreationProps> = ({ updateShor
   );
 
   return (
-    <SimpleCard title="Short URLs form" className="h-100">
-      <FormGroup>
+    <SimpleCard title="Short URLs form" className="h-100" bodyClassName="d-flex flex-column gap-3">
+      <div>
         <ToggleSwitch
           checked={shortUrlCreation.validateUrls ?? false}
           onChange={(validateUrls) => updateShortUrlCreationSettings({ ...shortUrlCreation, validateUrls })}
@@ -39,8 +39,8 @@ export const ShortUrlCreationSettings: FC<ShortUrlCreationProps> = ({ updateShor
             be <b>{shortUrlCreation.validateUrls ? 'checked' : 'unchecked'}</b>.
           </FormText>
         </ToggleSwitch>
-      </FormGroup>
-      <FormGroup>
+      </div>
+      <div>
         <ToggleSwitch
           checked={shortUrlCreation.forwardQuery ?? true}
           onChange={(forwardQuery) => updateShortUrlCreationSettings({ ...shortUrlCreation, forwardQuery })}
@@ -51,7 +51,7 @@ export const ShortUrlCreationSettings: FC<ShortUrlCreationProps> = ({ updateShor
             be <b>{shortUrlCreation.forwardQuery ?? true ? 'checked' : 'unchecked'}</b>.
           </FormText>
         </ToggleSwitch>
-      </FormGroup>
+      </div>
       <LabeledFormGroup noMargin label="Tag suggestions search mode:">
         <DropdownBtn text={tagFilteringModeText(shortUrlCreation.tagFilteringMode)}>
           <DropdownItem

--- a/src/settings/components/ShortUrlCreationSettings.tsx
+++ b/src/settings/components/ShortUrlCreationSettings.tsx
@@ -27,31 +27,27 @@ export const ShortUrlCreationSettings: FC<ShortUrlCreationProps> = ({ updateShor
 
   return (
     <SimpleCard title="Short URLs form" className="h-100" bodyClassName="d-flex flex-column gap-3">
-      <div>
-        <ToggleSwitch
-          checked={shortUrlCreation.validateUrls ?? false}
-          onChange={(validateUrls) => updateShortUrlCreationSettings({ ...shortUrlCreation, validateUrls })}
-        >
-          Request validation on long URLs when creating new short URLs.{' '}
-          <b>This option is ignored by Shlink {'>='}4.0.0</b>
-          <FormText>
-            The initial state of the <b>Validate URL</b> checkbox will
-            be <b>{shortUrlCreation.validateUrls ? 'checked' : 'unchecked'}</b>.
-          </FormText>
-        </ToggleSwitch>
-      </div>
-      <div>
-        <ToggleSwitch
-          checked={shortUrlCreation.forwardQuery ?? true}
-          onChange={(forwardQuery) => updateShortUrlCreationSettings({ ...shortUrlCreation, forwardQuery })}
-        >
-          Make all new short URLs forward their query params to the long URL.
-          <FormText>
-            The initial state of the <b>Forward query params on redirect</b> checkbox will
-            be <b>{shortUrlCreation.forwardQuery ?? true ? 'checked' : 'unchecked'}</b>.
-          </FormText>
-        </ToggleSwitch>
-      </div>
+      <ToggleSwitch
+        checked={shortUrlCreation.validateUrls ?? false}
+        onChange={(validateUrls) => updateShortUrlCreationSettings({ ...shortUrlCreation, validateUrls })}
+      >
+        Request validation on long URLs when creating new short URLs.{' '}
+        <b>This option is ignored by Shlink {'>='}4.0.0</b>
+        <FormText>
+          The initial state of the <b>Validate URL</b> checkbox will
+          be <b>{shortUrlCreation.validateUrls ? 'checked' : 'unchecked'}</b>.
+        </FormText>
+      </ToggleSwitch>
+      <ToggleSwitch
+        checked={shortUrlCreation.forwardQuery ?? true}
+        onChange={(forwardQuery) => updateShortUrlCreationSettings({ ...shortUrlCreation, forwardQuery })}
+      >
+        Make all new short URLs forward their query params to the long URL.
+        <FormText>
+          The initial state of the <b>Forward query params on redirect</b> checkbox will
+          be <b>{shortUrlCreation.forwardQuery ?? true ? 'checked' : 'unchecked'}</b>.
+        </FormText>
+      </ToggleSwitch>
       <LabeledFormGroup noMargin label="Tag suggestions search mode:">
         <DropdownBtn text={tagFilteringModeText(shortUrlCreation.tagFilteringMode)}>
           <DropdownItem

--- a/src/settings/components/ShortUrlsListSettings.tsx
+++ b/src/settings/components/ShortUrlsListSettings.tsx
@@ -25,6 +25,15 @@ export const ShortUrlsListSettings: FC<ShortUrlsListSettingsProps> = (
 
   return (
     <SimpleCard title="Short URLs list" className="h-100" bodyClassName="d-flex flex-column gap-3">
+      <ToggleSwitch
+        checked={confirmDeletions}
+        onChange={(confirmDeletions) => updateShortUrlsListSettings({ ...shortUrlsList, confirmDeletions })}
+      >
+        Request confirmation before deleting a short URL.
+        <FormText>
+          When deleting a short URL, confirmation <b>{confirmDeletions ? 'will' : 'won\'t'}</b> be required.
+        </FormText>
+      </ToggleSwitch>
       <LabeledFormGroup noMargin label="Default ordering for short URLs list:">
         <OrderingDropdown
           items={SHORT_URLS_ORDERABLE_FIELDS}
@@ -32,17 +41,6 @@ export const ShortUrlsListSettings: FC<ShortUrlsListSettingsProps> = (
           onChange={(field, dir) => updateShortUrlsListSettings({ defaultOrdering: { field, dir } })}
         />
       </LabeledFormGroup>
-      <div>
-        <ToggleSwitch
-          checked={confirmDeletions}
-          onChange={(confirmDeletions) => updateShortUrlsListSettings({ ...shortUrlsList, confirmDeletions })}
-        >
-          Request confirmation before deleting a short URL.
-          <FormText>
-            When deleting a short URL, confirmation <b>{confirmDeletions ? 'will' : 'won\'t'}</b> be required.
-          </FormText>
-        </ToggleSwitch>
-      </div>
     </SimpleCard>
   );
 };

--- a/src/settings/components/ShortUrlsListSettings.tsx
+++ b/src/settings/components/ShortUrlsListSettings.tsx
@@ -1,7 +1,8 @@
-import { LabeledFormGroup, OrderingDropdown, SimpleCard } from '@shlinkio/shlink-frontend-kit';
+import { LabeledFormGroup, OrderingDropdown, SimpleCard, ToggleSwitch } from '@shlinkio/shlink-frontend-kit';
 import type { FC } from 'react';
 import type { ShortUrlsListSettings as ShortUrlsSettings } from '..';
 import { useSetting } from '..';
+import { FormText } from './FormText';
 
 export type ShortUrlsListSettingsProps = {
   updateShortUrlsListSettings: (settings: ShortUrlsSettings) => void;
@@ -20,9 +21,10 @@ export const ShortUrlsListSettings: FC<ShortUrlsListSettingsProps> = (
   { updateShortUrlsListSettings, defaultOrdering },
 ) => {
   const shortUrlsList = useSetting('shortUrlsList');
+  const confirmDeletions = shortUrlsList?.confirmDeletions ?? true;
 
   return (
-    <SimpleCard title="Short URLs list" className="h-100">
+    <SimpleCard title="Short URLs list" className="h-100" bodyClassName="d-flex flex-column gap-3">
       <LabeledFormGroup noMargin label="Default ordering for short URLs list:">
         <OrderingDropdown
           items={SHORT_URLS_ORDERABLE_FIELDS}
@@ -30,6 +32,17 @@ export const ShortUrlsListSettings: FC<ShortUrlsListSettingsProps> = (
           onChange={(field, dir) => updateShortUrlsListSettings({ defaultOrdering: { field, dir } })}
         />
       </LabeledFormGroup>
+      <div>
+        <ToggleSwitch
+          checked={confirmDeletions}
+          onChange={(confirmDeletions) => updateShortUrlsListSettings({ ...shortUrlsList, confirmDeletions })}
+        >
+          Request confirmation before deleting a short URL.
+          <FormText>
+            When deleting a short URL, confirmation <b>{confirmDeletions ? 'will' : 'won\'t'}</b> be required.
+          </FormText>
+        </ToggleSwitch>
+      </div>
     </SimpleCard>
   );
 };

--- a/src/settings/types.ts
+++ b/src/settings/types.ts
@@ -34,6 +34,7 @@ export type TagsSettings = {
 
 export type ShortUrlsListSettings = {
   defaultOrdering?: Order<'dateCreated' | 'shortCode' | 'longUrl' | 'title' | 'visits'>;
+  confirmDeletions?: boolean;
 };
 
 export type UiSettings = {

--- a/src/short-urls/helpers/DeleteShortUrlModal.tsx
+++ b/src/short-urls/helpers/DeleteShortUrlModal.tsx
@@ -7,12 +7,15 @@ import { ShlinkApiError } from '../../common/ShlinkApiError';
 import type { ShortUrlIdentifier, ShortUrlModalProps } from '../data';
 import type { ShortUrlDeletion } from '../reducers/shortUrlDeletion';
 
-interface DeleteShortUrlModalConnectProps extends ShortUrlModalProps {
-  shortUrlDeletion: ShortUrlDeletion;
+export type DeleteShortUrlModalProps = ShortUrlModalProps & {
   deleteShortUrl: (shortUrl: ShortUrlIdentifier) => Promise<void>;
   shortUrlDeleted: (shortUrl: ShortUrlIdentifier) => void;
+};
+
+type DeleteShortUrlModalConnectProps = DeleteShortUrlModalProps & {
+  shortUrlDeletion: ShortUrlDeletion;
   resetDeleteShortUrl: () => void;
-}
+};
 
 const DELETION_PATTERN = 'delete';
 

--- a/src/short-urls/services/provideServices.ts
+++ b/src/short-urls/services/provideServices.ts
@@ -28,8 +28,10 @@ export const provideServices = (bottle: Bottle, connect: ConnectDecorator) => {
 
   bottle.factory('ShortUrlsTable', ShortUrlsTableFactory);
   bottle.factory('ShortUrlsRow', ShortUrlsRowFactory);
-  bottle.factory('ShortUrlsRowMenu', ShortUrlsRowMenuFactory);
   bottle.factory('CreateShortUrlResult', CreateShortUrlResultFactory);
+
+  bottle.factory('ShortUrlsRowMenu', ShortUrlsRowMenuFactory);
+  bottle.decorator('ShortUrlsRowMenu', connect(null, ['shortUrlDeleted', 'deleteShortUrl']));
 
   bottle.factory('ShortUrlForm', ShortUrlFormFactory);
   bottle.decorator('ShortUrlForm', connect(['tagsList']));
@@ -47,10 +49,7 @@ export const provideServices = (bottle: Bottle, connect: ConnectDecorator) => {
   ));
 
   bottle.serviceFactory('DeleteShortUrlModal', () => DeleteShortUrlModal);
-  bottle.decorator('DeleteShortUrlModal', connect(
-    ['shortUrlDeletion'],
-    ['deleteShortUrl', 'shortUrlDeleted', 'resetDeleteShortUrl'],
-  ));
+  bottle.decorator('DeleteShortUrlModal', connect(['shortUrlDeletion'], ['resetDeleteShortUrl']));
 
   bottle.factory('QrCodeModal', QrCodeModalFactory);
   bottle.factory('ExportShortUrlsBtn', ExportShortUrlsBtnFactory);

--- a/test/settings/components/ShortUrlsListSettings.test.tsx
+++ b/test/settings/components/ShortUrlsListSettings.test.tsx
@@ -43,4 +43,38 @@ describe('<ShortUrlsListSettings />', () => {
     await user.click(screen.getByRole('menuitem', { name }));
     expect(setSettings).toHaveBeenCalledWith({ defaultOrdering: { field, dir } });
   });
+
+  it.each([
+    [{ confirmDeletions: true }, true],
+    [{ confirmDeletions: false }, false],
+    [undefined, true],
+  ])('Deletion confirmation switch has proper initial state', (shortUrlCreation, expectedChecked) => {
+    const matcher = /^Request confirmation before deleting a short URL./;
+
+    setUp(shortUrlCreation);
+
+    const checkbox = screen.getByLabelText(matcher);
+    const label = screen.getByText(matcher);
+
+    if (expectedChecked) {
+      expect(checkbox).toBeChecked();
+      expect(label).toHaveTextContent('When deleting a short URL, confirmation will be required.');
+      expect(label).not.toHaveTextContent('When deleting a short URL, confirmation won\'t be required.');
+    } else {
+      expect(checkbox).not.toBeChecked();
+      expect(label).toHaveTextContent('When deleting a short URL, confirmation won\'t be required.');
+      expect(label).not.toHaveTextContent('When deleting a short URL, confirmation will be required.');
+    }
+  });
+
+  it.each([
+    { confirmDeletions: true },
+    { confirmDeletions: false },
+  ])('invokes setSettings when delete confirmation toggle value changes', async ({ confirmDeletions }) => {
+    const { user } = setUp({ confirmDeletions });
+
+    expect(setSettings).not.toHaveBeenCalled();
+    await user.click(screen.getByLabelText(/^Request confirmation before deleting a short URL./));
+    expect(setSettings).toHaveBeenCalledWith({ confirmDeletions: !confirmDeletions });
+  });
 });


### PR DESCRIPTION
Closes #307 

Add a new setting to disable confirmations when deleting short URLs.

If this setting is switched off, when a short URL is deleted there won't be a modal requesting a second step.

![image](https://github.com/user-attachments/assets/deb586c7-7b90-4dde-a4f0-44c0296383e8)
