### PR TITLE
Allow raw user agent to be displayed in visits list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * [#411](https://github.com/shlinkio/shlink-web-component/issues/411) Add support for `ip-address` redirect conditions when Shlink server is >=4.2
 * [#196](https://github.com/shlinkio/shlink-web-component/issues/196) Allow active date range to be changed by selecting a range in visits and visits-comparison line charts.
 * [#307](https://github.com/shlinkio/shlink-web-component/issues/307) Add new setting to disable short URL deletions confirmation.
+* [#435](https://github.com/shlinkio/shlink-web-component/issues/435) Allow toggling between displaying raw user agent and parsed browser/OS in visits table.
 
 ### Changed
 * Update to `@shlinkio/eslint-config-js-coding-standard` 3.0, and migrate to ESLint flat config.

--- a/src/visits/VisitsTable.scss
+++ b/src/visits/VisitsTable.scss
@@ -2,8 +2,6 @@
 @import '../utils/mixins/sticky-cell';
 
 .visits-table {
-  margin: 1.5rem 0 0;
-  position: relative;
   background-color: var(--primary-color);
   overflow-y: hidden;
 }
@@ -29,7 +27,6 @@
 .visits-table__footer-cell.visits-table__footer-cell {
   bottom: 0;
   margin-top: 34px;
-  padding: .5rem;
 
   @include sticky-cell();
 }

--- a/src/visits/VisitsTable.tsx
+++ b/src/visits/VisitsTable.tsx
@@ -2,9 +2,12 @@ import { faCheck as checkIcon, faRobot as botIcon } from '@fortawesome/free-soli
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { splitEvery } from '@shlinkio/data-manipulation';
 import type { Order } from '@shlinkio/shlink-frontend-kit';
+import { useToggle } from '@shlinkio/shlink-frontend-kit';
+import { ToggleSwitch } from '@shlinkio/shlink-frontend-kit';
+import { SimpleCard } from '@shlinkio/shlink-frontend-kit';
 import { determineOrderDir, SearchField, sortList } from '@shlinkio/shlink-frontend-kit';
 import { clsx } from 'clsx';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { UncontrolledTooltip } from 'reactstrap';
 import { SimplePaginator } from '../utils/components/SimplePaginator';
 import { Time } from '../utils/dates/Time';
@@ -22,19 +25,33 @@ export interface VisitsTableProps {
   matchMedia?: MediaMatcher;
 }
 
-type OrderableFields = 'date' | 'country' | 'city' | 'browser' | 'os' | 'referer' | 'visitedUrl' | 'potentialBot';
+type OrderableFields = 'date' | 'country' | 'city' | 'browser' | 'os' | 'referer' | 'userAgent' | 'visitedUrl' | 'potentialBot';
 type VisitsOrder = Order<OrderableFields>;
 
 const PAGE_SIZE = 20;
-const visitMatchesSearch = ({ browser, os, referer, country, city, ...rest }: NormalizedVisit, searchTerm: string) =>
-  `${browser} ${os} ${referer} ${country} ${city} ${(rest as NormalizedOrphanVisit).visitedUrl}`.toLowerCase().includes(
-    searchTerm.toLowerCase(),
-  );
-const searchVisits = (searchTerm: string, visits: NormalizedVisit[]) =>
-  visits.filter((visit) => visitMatchesSearch(visit, searchTerm));
+const visitMatchesSearch = (
+  { browser, os, referer, country, city, userAgent, ...rest }: NormalizedVisit,
+  searchTerm: string,
+  searchInRawUserAgent: boolean,
+) => {
+  const userAgentPattern = searchInRawUserAgent ? userAgent : `${country} ${city}`;
+  return `${browser} ${os} ${referer} ${userAgentPattern} ${(rest as NormalizedOrphanVisit).visitedUrl}`
+    .toLowerCase()
+    .includes(searchTerm.toLowerCase());
+};
+const searchVisits = (searchTerm: string, visits: NormalizedVisit[], searchInRawUserAgent: boolean) =>
+  visits.filter((visit) => visitMatchesSearch(visit, searchTerm, searchInRawUserAgent));
 const sortVisits = (order: VisitsOrder, visits: NormalizedVisit[]) => sortList<NormalizedVisit>(visits, order as any);
-const paginateVisits = (allVisits: NormalizedVisit[], searchTerm: string | undefined, order: VisitsOrder) => {
-  const filteredVisits = searchTerm ? searchVisits(searchTerm, allVisits) : [...allVisits];
+
+type PaginateVisitsOptions = {
+  visits: NormalizedVisit[];
+  searchTerm?: string;
+  order: VisitsOrder;
+  searchInRawUserAgent: boolean;
+};
+
+const paginateVisits = ({ visits: allVisits, searchTerm, order, searchInRawUserAgent }: PaginateVisitsOptions) => {
+  const filteredVisits = searchTerm ? searchVisits(searchTerm, allVisits, searchInRawUserAgent) : [...allVisits];
   const sortedVisits = sortVisits(order, filteredVisits);
   const total = sortedVisits.length;
   const visitsGroups = splitEvery(sortedVisits, PAGE_SIZE);
@@ -54,7 +71,15 @@ export const VisitsTable = ({
   const [searchTerm, setSearchTerm] = useState<string | undefined>(undefined);
   const prevSearchTerm = useRef<string | undefined>(searchTerm);
   const [order, setOrder] = useState<VisitsOrder>({});
-  const paginator = useMemo(() => paginateVisits(visits, searchTerm, order), [visits, searchTerm, order]);
+  const [showUserAgent, toggleShowUserAgent] = useToggle();
+  const toggleUserAgentAndResetOrder = useCallback(() => {
+    toggleShowUserAgent();
+    setOrder({});
+  }, [toggleShowUserAgent]);
+  const paginator = useMemo(
+    () => paginateVisits({ visits, searchTerm, order, searchInRawUserAgent: showUserAgent }),
+    [visits, searchTerm, order, showUserAgent],
+  );
   const [page, setPage] = useState(1);
   const end = page * PAGE_SIZE;
   const start = end - PAGE_SIZE;
@@ -62,7 +87,8 @@ export const VisitsTable = ({
     () => !!paginator.visitsGroups[page - 1]?.[0]?.visitedUrl,
     [page, paginator.visitsGroups],
   );
-  const fullSizeColSpan = 8 + Number(showVisitedUrl);
+  const fullSizeColSpan = 6 + Number(showVisitedUrl) + (showUserAgent ? 1 : 2);
+  const hasVisits = paginator.total > 0;
 
   const orderByColumn = (field: OrderableFields) =>
     () => setOrder({ field, dir: determineOrderDir(field, order.field, order.dir) });
@@ -79,137 +105,161 @@ export const VisitsTable = ({
   }, [searchTerm, setSelectedVisits]);
 
   return (
-    <div className="table-responsive-md">
-      <table className="table table-bordered table-hover table-sm visits-table">
-        <thead className="visits-table__header">
-          <tr>
-            <th
-              className={`${headerCellsClass} text-center`}
-              onClick={() => setSelectedVisits(
-                selectedVisits.length < paginator.total ? paginator.visitsGroups.flat() : [],
-              )}
-            >
-              <span className="sr-only">Is selected</span>
-              <FontAwesomeIcon icon={checkIcon} className={clsx({ 'text-primary': selectedVisits.length > 0 })} />
-            </th>
-            <th className={`${headerCellsClass} text-center`} onClick={orderByColumn('potentialBot')}>
-              <span className="sr-only">Is bot</span>
-              <FontAwesomeIcon icon={botIcon} />
-              {renderOrderIcon('potentialBot')}
-            </th>
-            <th className={headerCellsClass} onClick={orderByColumn('date')}>
-              Date
-              {renderOrderIcon('date')}
-            </th>
-            <th className={headerCellsClass} onClick={orderByColumn('country')}>
-              Country
-              {renderOrderIcon('country')}
-            </th>
-            <th className={headerCellsClass} onClick={orderByColumn('city')}>
-              City
-              {renderOrderIcon('city')}
-            </th>
-            <th className={headerCellsClass} onClick={orderByColumn('browser')}>
-              Browser
-              {renderOrderIcon('browser')}
-            </th>
-            <th className={headerCellsClass} onClick={orderByColumn('os')}>
-              OS
-              {renderOrderIcon('os')}
-            </th>
-            <th className={headerCellsClass} onClick={orderByColumn('referer')}>
-              Referrer
-              {renderOrderIcon('referer')}
-            </th>
-            {showVisitedUrl && (
-              <th className={headerCellsClass} onClick={orderByColumn('visitedUrl')}>
-                Visited URL
-                {renderOrderIcon('visitedUrl')}
-              </th>
-            )}
-          </tr>
-          <tr>
-            <td colSpan={fullSizeColSpan} className="p-0">
-              <SearchField noBorder large={false} onChange={setSearchTerm} />
-            </td>
-          </tr>
-        </thead>
-        <tbody>
-          {paginator.total === 0 && (
+    <SimpleCard
+      className="mt-3"
+      // Adding a bottom padding to work around the fact that it's not possible to set border radius in internal table
+      // elements, and we can also not hide the overflow of the table itself because then sticky elements get hidden
+      bodyClassName="p-0 pb-1"
+      title={
+        <div className="d-flex justify-content-between align-items-center">
+          Visits list
+          <ToggleSwitch checked={showUserAgent} onChange={toggleUserAgentAndResetOrder}>
+            Show user agent
+          </ToggleSwitch>
+        </div>
+      }>
+      <div className="table-responsive-md">
+        <table
+          className={clsx('table table-sm position-relative m-0 visits-table', {
+            'table-hover': hasVisits,
+          })}
+        >
+          <thead className="visits-table__header">
             <tr>
-              <td colSpan={fullSizeColSpan} className="text-center">
-                There are no visits matching current filter
-              </td>
-            </tr>
-          )}
-          {paginator.visitsGroups[page - 1]?.map((visit, index) => {
-            const isSelected = selectedVisits.includes(visit);
-
-            return (
-              <tr
-                key={index}
-                style={{ cursor: 'pointer' }}
-                className={clsx({ 'table-active': isSelected })}
+              <th
+                className={`${headerCellsClass} text-center`}
                 onClick={() => setSelectedVisits(
-                  isSelected ? selectedVisits.filter((v) => v !== visit) : [...selectedVisits, visit],
+                  selectedVisits.length < paginator.total ? paginator.visitsGroups.flat() : [],
                 )}
               >
-                <td className="text-center">
-                  {isSelected && <FontAwesomeIcon icon={checkIcon} className="text-primary" />}
+                <span className="sr-only">Is selected</span>
+                <FontAwesomeIcon icon={checkIcon} className={clsx({ 'text-primary': selectedVisits.length > 0 })} />
+              </th>
+              <th className={`${headerCellsClass} text-center`} onClick={orderByColumn('potentialBot')}>
+                <span className="sr-only">Is bot</span>
+                <FontAwesomeIcon icon={botIcon} />
+                {renderOrderIcon('potentialBot')}
+              </th>
+              <th className={headerCellsClass} onClick={orderByColumn('date')}>
+                Date
+                {renderOrderIcon('date')}
+              </th>
+              <th className={headerCellsClass} onClick={orderByColumn('country')}>
+                Country
+                {renderOrderIcon('country')}
+              </th>
+              <th className={headerCellsClass} onClick={orderByColumn('city')}>
+                City
+                {renderOrderIcon('city')}
+              </th>
+              {showUserAgent ? (
+                <th className={headerCellsClass} onClick={orderByColumn('userAgent')}>
+                  User agent
+                  {renderOrderIcon('userAgent')}
+                </th>
+              ) : (
+                <>
+                  <th className={headerCellsClass} onClick={orderByColumn('browser')}>
+                    Browser
+                    {renderOrderIcon('browser')}
+                  </th>
+                  <th className={headerCellsClass} onClick={orderByColumn('os')}>
+                    OS
+                    {renderOrderIcon('os')}
+                  </th>
+                </>
+              )}
+              <th className={headerCellsClass} onClick={orderByColumn('referer')}>
+                Referrer
+                {renderOrderIcon('referer')}
+              </th>
+              {showVisitedUrl && (
+                <th className={headerCellsClass} onClick={orderByColumn('visitedUrl')}>
+                  Visited URL
+                  {renderOrderIcon('visitedUrl')}
+                </th>
+              )}
+            </tr>
+            <tr>
+              <td colSpan={fullSizeColSpan} className="p-0">
+                <SearchField noBorder large={false} onChange={setSearchTerm} />
+              </td>
+            </tr>
+          </thead>
+          <tbody>
+            {!hasVisits && (
+              <tr>
+                <td colSpan={fullSizeColSpan} className="text-center">
+                  There are no visits matching current filter
                 </td>
-                <td className="text-center">
-                  {visit.potentialBot && (
+              </tr>
+            )}
+            {paginator.visitsGroups[page - 1]?.map((visit, index) => {
+              const isSelected = selectedVisits.includes(visit);
+
+              return (
+                <tr
+                  key={index}
+                  style={{ cursor: 'pointer' }}
+                  className={clsx({ 'table-active': isSelected })}
+                  onClick={() => setSelectedVisits(
+                    isSelected ? selectedVisits.filter((v) => v !== visit) : [...selectedVisits, visit],
+                  )}
+                >
+                  <td className="text-center">
+                    {isSelected && <FontAwesomeIcon icon={checkIcon} className="text-primary" />}
+                  </td>
+                  <td className="text-center">
+                    {visit.potentialBot && (
+                      <>
+                        <FontAwesomeIcon icon={botIcon} id={`botIcon${index}`} />
+                        <UncontrolledTooltip placement="right" target={`botIcon${index}`}>
+                          Potentially a visit from a bot or crawler
+                        </UncontrolledTooltip>
+                      </>
+                    )}
+                  </td>
+                  {/* eslint-disable-next-line jsx-a11y/control-has-associated-label */}
+                  <td><Time date={visit.date} /></td>
+                  <td>{visit.country}</td>
+                  <td>{visit.city}</td>
+                  {showUserAgent ? (
+                    <td>{visit.userAgent}</td>
+                  ) : (
                     <>
-                      <FontAwesomeIcon icon={botIcon} id={`botIcon${index}`} />
-                      <UncontrolledTooltip placement="right" target={`botIcon${index}`}>
-                        Potentially a visit from a bot or crawler
-                      </UncontrolledTooltip>
+                      <td>{visit.browser}</td>
+                      <td>{visit.os}</td>
                     </>
                   )}
-                </td>
-                {/* eslint-disable-next-line jsx-a11y/control-has-associated-label */}
-                <td><Time date={visit.date} /></td>
-                <td>{visit.country}</td>
-                <td>{visit.city}</td>
-                <td>{visit.browser}</td>
-                <td>{visit.os}</td>
-                <td>{visit.referer}</td>
-                {visit.visitedUrl && <td>{visit.visitedUrl}</td>}
-              </tr>
-            );
-          })}
-        </tbody>
-        {paginator.total > PAGE_SIZE && (
-          <tfoot>
-            <tr>
-              <td colSpan={fullSizeColSpan} className="visits-table__footer-cell visits-table__sticky">
-                <div className="row">
-                  <div className="col-md-6">
+                  <td>{visit.referer}</td>
+                  {visit.visitedUrl && <td>{visit.visitedUrl}</td>}
+                </tr>
+              );
+            })}
+          </tbody>
+          {paginator.total > PAGE_SIZE && (
+            <tfoot>
+              <tr>
+                <td colSpan={fullSizeColSpan} className="visits-table__footer-cell visits-table__sticky">
+                  <div className="d-flex flex-column flex-md-row justify-content-between align-items-center gap-3 p-2">
                     <SimplePaginator
                       pagesCount={Math.ceil(paginator.total / PAGE_SIZE)}
                       currentPage={page}
                       setCurrentPage={setPage}
                       centered={isMobileDevice}
                     />
-                  </div>
-                  <div
-                    className={clsx('col-md-6', {
-                      'd-flex align-items-center flex-row-reverse': !isMobileDevice,
-                      'text-center mt-3': isMobileDevice,
-                    })}
-                  >
                     <div>
                       Visits <b>{prettify(start + 1)}</b> to{' '}
                       <b>{prettify(Math.min(end, paginator.total))}</b> of{' '}
                       <b>{prettify(paginator.total)}</b>
                     </div>
                   </div>
-                </div>
-              </td>
-            </tr>
-          </tfoot>
-        )}
-      </table>
-    </div>
+                </td>
+              </tr>
+            </tfoot>
+          )}
+        </table>
+      </div>
+    </SimpleCard>
   );
 };

--- a/src/visits/services/VisitsParser.ts
+++ b/src/visits/services/VisitsParser.ts
@@ -85,6 +85,7 @@ export const normalizeVisits = (visits: ShlinkVisit[]) => visits.map((visit): No
   return {
     date,
     potentialBot,
+    userAgent,
     ...parseUserAgent(userAgent),
     referer: extractDomain(referer),
     country: visitLocation?.countryName || 'Unknown', // eslint-disable-line @typescript-eslint/prefer-nullish-coalescing

--- a/src/visits/types/index.ts
+++ b/src/visits/types/index.ts
@@ -1,13 +1,14 @@
 import type { ShlinkOrphanVisitType, ShlinkShortUrl, ShlinkVisit } from '../../api-contract';
 import type { DateRange } from '../../utils/dates/helpers/dateIntervals';
 
-export interface UserAgent {
+export interface ParsedUserAgent {
   browser: string;
   os: string;
 }
 
-export interface NormalizedRegularVisit extends UserAgent {
+export interface NormalizedRegularVisit extends ParsedUserAgent {
   date: string;
+  userAgent: string;
   referer: string;
   country: string;
   city: string;

--- a/src/visits/utils/index.ts
+++ b/src/visits/utils/index.ts
@@ -2,7 +2,7 @@ import { zipObj } from '@shlinkio/data-manipulation';
 import bowser from 'bowser';
 import type { Empty } from '../../utils/helpers';
 import { hasValue } from '../../utils/helpers';
-import type { Stats, UserAgent } from '../types';
+import type { ParsedUserAgent, Stats } from '../types';
 
 const DEFAULT = 'Others';
 const BROWSERS_ALLOWLIST = [
@@ -19,7 +19,7 @@ const BROWSERS_ALLOWLIST = [
   'WeChat',
 ];
 
-export const parseUserAgent = (userAgent: string | Empty): UserAgent => {
+export const parseUserAgent = (userAgent: string | Empty): ParsedUserAgent => {
   if (!hasValue(userAgent)) {
     return { browser: DEFAULT, os: DEFAULT };
   }

--- a/test/utils/services/ReportExporter.test.ts
+++ b/test/utils/services/ReportExporter.test.ts
@@ -24,6 +24,7 @@ describe('ReportExporter', () => {
           os: 'os',
           referer: 'referer',
           potentialBot: false,
+          userAgent: 'userAgent',
         },
       ];
 

--- a/test/visits/VisitsStats.test.tsx
+++ b/test/visits/VisitsStats.test.tsx
@@ -83,7 +83,7 @@ describe('<VisitsStats />', () => {
     ['/by-time', 2],
     ['/by-context', 4],
     ['/by-location', 3],
-    ['/list', 1],
+    ['/list', 2],
     ['/options', 2],
   ])('renders expected amount of cards per sub-route', (activeRoute, expectedCards) => {
     const { container } = setUp({ visitsInfo: { visits }, activeRoute, withDeletion: true });

--- a/test/visits/services/VisitsParser.test.ts
+++ b/test/visits/services/VisitsParser.test.ts
@@ -179,6 +179,7 @@ describe('VisitsParser', () => {
     it('properly parses the list of visits', () => {
       expect(normalizeVisits(visits)).toEqual([
         {
+          userAgent: 'Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:47.0) Gecko/20100101 Firefox/47.0',
           browser: 'Firefox',
           os: 'Windows',
           referer: 'google.com',
@@ -190,6 +191,7 @@ describe('VisitsParser', () => {
           potentialBot: false,
         },
         {
+          userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X x.y; rv:42.0) Gecko/20100101 Firefox/42.0',
           browser: 'Firefox',
           os: 'macOS',
           referer: 'google.com',
@@ -201,6 +203,7 @@ describe('VisitsParser', () => {
           potentialBot: false,
         },
         {
+          userAgent: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36',
           browser: 'Chrome',
           os: 'Linux',
           referer: 'Direct',
@@ -213,6 +216,7 @@ describe('VisitsParser', () => {
           visitedUrl: 'foo',
         },
         {
+          userAgent: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36',
           browser: 'Chrome',
           os: 'Linux',
           referer: 'm.facebook.com',
@@ -225,6 +229,7 @@ describe('VisitsParser', () => {
           visitedUrl: 'foo',
         },
         {
+          userAgent: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.106 Safari/537.36 OPR/38.0.2220.41',
           browser: 'Opera',
           os: 'Linux',
           referer: 'Direct',
@@ -241,6 +246,7 @@ describe('VisitsParser', () => {
     it('properly parses the list of orphan visits', () => {
       expect(normalizeVisits(orphanVisits)).toEqual([
         {
+          userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X x.y; rv:42.0) Gecko/20100101 Firefox/42.0',
           browser: 'Firefox',
           os: 'macOS',
           referer: 'google.com',
@@ -254,6 +260,7 @@ describe('VisitsParser', () => {
           potentialBot: false,
         },
         {
+          userAgent: undefined,
           type: 'regular_404',
           visitedUrl: 'bar',
           browser: 'Others',
@@ -267,6 +274,7 @@ describe('VisitsParser', () => {
           potentialBot: true,
         },
         {
+          userAgent: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36',
           browser: 'Chrome',
           os: 'Linux',
           referer: 'm.facebook.com',


### PR DESCRIPTION
Closes #435 

Add switch control to visits table to toggle between displaying the browser and OS that was parsed from the user agent, or the user agent itself.

Search is applied to the visible rows, so you cannot search in the user agent field if it is not actively displayed.

The table order is reset when the switch value changes, to avoid a list which is ordered by a no-longer-visible column.

https://github.com/user-attachments/assets/210922a3-10f0-4f9e-bdd9-a6271ac05bb4

