### PR TITLE
Ensure confirmDeletions is false only if explicitly set to false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [Unreleased]
+### Added
+* *Nothing*
+
+### Changed
+* *Nothing*
+
+### Deprecated
+* *Nothing*
+
+### Removed
+* *Nothing*
+
+### Fixed
+* Ensure `shortUrlsList.confirmDeletion` setting is `true` in any case, except when explicitly set to `false`.
+
+
 ## [0.8.0] - 2024-10-07
 ### Added
 * Document how `<ShlinkWebSettings />` is used.

--- a/src/short-urls/helpers/ShortUrlsRowMenu.tsx
+++ b/src/short-urls/helpers/ShortUrlsRowMenu.tsx
@@ -45,7 +45,7 @@ const ShortUrlsRowMenu: FCWithDeps<ShortUrlsRowMenuConnectProps, ShortUrlsRowMen
   const [isDeleteModalOpen,, openDeleteModal, closeDeleteModal] = useToggle();
   const visitsComparison = useVisitsComparisonContext();
   const redirectRulesAreSupported = useFeature('shortUrlRedirectRules');
-  const { confirmDeletions } = useSetting('shortUrlsList', { confirmDeletions: true });
+  const { confirmDeletions = true } = useSetting('shortUrlsList', {});
   const doDeleteShortUrl = useCallback(async () => {
     const result = await deleteShortUrl(shortUrl);
     if (!isErrorAction(result)) {


### PR DESCRIPTION
Due to an overlook, the `confirmDeletions` setting could fall back to `undefined` if the `shortUrlsList` settings object is already set (which is the case for any existing installation), instead of defaulting to true.

This PR ensures it is always true unless explicitly set to false.