### PR TITLE
Use calendar days/weeks/months when calculating dots for line charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org).
 
 
+## [0.10.1] - 2024-10-19
+### Added
+* *Nothing*
+
+### Changed
+* *Nothing*
+
+### Deprecated
+* *Nothing*
+
+### Removed
+* *Nothing*
+
+### Fixed
+* [#475](https://github.com/shlinkio/shlink-web-component/issues/475) Fix incorrect amount of dots being displayed in line charts when the difference in days/weeks/months is rounded up.
+
+
 ## [0.10.0] - 2024-10-19
 ### Added
 * *Nothing*

--- a/src/visits/charts/LineChartCard.tsx
+++ b/src/visits/charts/LineChartCard.tsx
@@ -15,10 +15,10 @@ import { clsx } from 'clsx';
 import type { Duration } from 'date-fns';
 import {
   add,
-  differenceInDays,
+  differenceInCalendarDays,
+  differenceInCalendarMonths,
+  differenceInCalendarWeeks,
   differenceInHours,
-  differenceInMonths,
-  differenceInWeeks,
   endOfISOWeek,
   format,
   max,
@@ -75,9 +75,9 @@ const STEP_TO_DURATION_MAP: Record<Step, (amount: number) => Duration> = {
 
 const STEP_TO_DIFF_FUNC_MAP: Record<Step, (dateLeft: Date, dateRight: Date) => number> = {
   hourly: differenceInHours,
-  daily: differenceInDays,
-  weekly: differenceInWeeks,
-  monthly: differenceInMonths,
+  daily: differenceInCalendarDays,
+  weekly: differenceInCalendarWeeks,
+  monthly: differenceInCalendarMonths,
 };
 
 const STEP_TO_DATE_FORMAT: Record<Step, (date: Date) => string> = {
@@ -102,9 +102,9 @@ const determineInitialStep = (visitsGroups: Record<string, NormalizedVisit[]>): 
   const lastDates = nonEmptyVisitsLists.map((visits) => parseISO(visits[visits.length - 1].date));
   const oldestDate = max(lastDates);
   const conditions: [() => boolean, Step][] = [
-    [() => differenceInDays(now, oldestDate) <= 2, 'hourly'], // Less than 2 days
-    [() => differenceInMonths(now, oldestDate) <= 1, 'daily'], // Between 2 days and 1 month
-    [() => differenceInMonths(now, oldestDate) <= 6, 'weekly'], // Between 1 and 6 months
+    [() => differenceInCalendarDays(now, oldestDate) <= 2, 'hourly'], // Less than 2 days
+    [() => differenceInCalendarMonths(now, oldestDate) <= 1, 'daily'], // Between 2 days and 1 month
+    [() => differenceInCalendarMonths(now, oldestDate) <= 6, 'weekly'], // Between 1 and 6 months
   ];
 
   return conditions.find(([matcher]) => matcher())?.[1] ?? 'monthly';


### PR DESCRIPTION
Closes #475 

Use `differenceInCalendarDays`, `differenceInCalendarMonths` and `differenceInCalendarWeeks` to calculate the dots in line/time charts, instead of `differenceInDays`, `differenceInMonths` and `differenceInWeeks`.

The latter can cause results to be rounded when there is a non-absolute number of days/weeks/months between provided dates, and if the number is rounded down, all visits in the last day/week/month will not be represented in the chart.

The "calendar" variations calculate the difference by ignoring the time part of the date, so if the dates are `2024-10-02T22:00:00` and `2024-10-12T01:00:00` the difference in calendar days is 10, but the difference in days is 9.

We need to represent 10 dots to make sure all visits in the interval are represented.

![image](https://github.com/user-attachments/assets/b02fdfc0-5abe-4ea5-b169-f943a064c1f2)

![image](https://github.com/user-attachments/assets/13bd3462-878c-4063-8651-1f70c85c4b39)

> Refs: 
> - https://date-fns.org/v4.1.0/docs/differenceInCalendarDays
> - https://date-fns.org/v4.1.0/docs/differenceInDays