### PR TITLE
Support color and background color in QR codes modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [Unreleased]
+### Added
+* [#491](https://github.com/shlinkio/shlink-web-component/issues/491) Add support for colors in QR code configurator.
+
+### Changed
+* *Nothing*
+
+### Deprecated
+* *Nothing*
+
+### Removed
+* *Nothing*
+
+### Fixed
+* *Nothing*
+
+
 ## [0.10.1] - 2024-10-19
 ### Added
 * *Nothing*

--- a/src/short-urls/helpers/QrCodeModal.scss
+++ b/src/short-urls/helpers/QrCodeModal.scss
@@ -1,0 +1,7 @@
+@import '../../../node_modules/@shlinkio/shlink-frontend-kit/dist/base';
+
+.qr-code-modal__controls {
+  @media (min-width: $lgMin) {
+    width: 16rem;
+  }
+}

--- a/src/short-urls/helpers/QrCodeModal.tsx
+++ b/src/short-urls/helpers/QrCodeModal.tsx
@@ -66,13 +66,13 @@ const QrCodeModal: FCWithDeps<ShortUrlModalProps, QrCodeModalDeps> = (
             min={0}
             max={100}
           />
-          <QrFormatDropdown format={format} onChange={setFormat}/>
-          <QrErrorCorrectionDropdown errorCorrection={errorCorrection} onChange={setErrorCorrection}/>
+          <QrFormatDropdown format={format} onChange={setFormat} />
+          <QrErrorCorrectionDropdown errorCorrection={errorCorrection} onChange={setErrorCorrection} />
 
           {qrCodeColorsSupported && (
             <>
-              <QrColorControl name="color" initialColor="#000000" color={color} onChange={setColor}/>
-              <QrColorControl name="background" initialColor="#ffffff" color={bgColor} onChange={setBgColor}/>
+              <QrColorControl name="color" initialColor="#000000" color={color} onChange={setColor} />
+              <QrColorControl name="background" initialColor="#ffffff" color={bgColor} onChange={setBgColor} />
             </>
           )}
 
@@ -85,7 +85,7 @@ const QrCodeModal: FCWithDeps<ShortUrlModalProps, QrCodeModalDeps> = (
                 });
               }}
             >
-              Download <FontAwesomeIcon icon={downloadIcon} className="ms-1"/>
+              Download <FontAwesomeIcon icon={downloadIcon} className="ms-1" />
             </Button>
           </div>
         </div>
@@ -95,8 +95,8 @@ const QrCodeModal: FCWithDeps<ShortUrlModalProps, QrCodeModalDeps> = (
         style={{ backgroundColor: 'var(--primary-color)', zIndex: '1' }}
       >
         <div className="text-center">
-          <ExternalLink href={qrCodeUrl}/>
-          <CopyToClipboardIcon text={qrCodeUrl}/>
+          <ExternalLink href={qrCodeUrl} />
+          <CopyToClipboardIcon text={qrCodeUrl} />
         </div>
       </ModalFooter>
     </Modal>

--- a/src/short-urls/helpers/QrCodeModal.tsx
+++ b/src/short-urls/helpers/QrCodeModal.tsx
@@ -1,9 +1,8 @@
 import { faFileDownload as downloadIcon } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import type { SyntheticEvent } from 'react';
-import { useCallback, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { ExternalLink } from 'react-external-link';
-import { Button, FormGroup, Modal, ModalBody, ModalHeader, Row } from 'reactstrap';
+import { Button, Modal, ModalBody, ModalFooter, ModalHeader } from 'reactstrap';
 import type { FCWithDeps } from '../../container/utils';
 import { componentFactory, useDependencies } from '../../container/utils';
 import { CopyToClipboardIcon } from '../../utils/components/CopyToClipboardIcon';
@@ -31,76 +30,56 @@ const QrCodeModal: FCWithDeps<ShortUrlModalProps, QrCodeModalDeps> = (
     () => buildQrCodeUrl(shortUrl, { size, format, margin, errorCorrection }),
     [shortUrl, size, format, margin, errorCorrection],
   );
-  const [modalSize, setModalSize] = useState<'lg' | 'xl'>();
-  const onImageLoad = useCallback((e: SyntheticEvent<HTMLImageElement>) => {
-    const image = e.target as HTMLImageElement;
-    const { naturalWidth } = image;
-
-    if (naturalWidth < 500) {
-      setModalSize(undefined);
-    } else {
-      setModalSize(naturalWidth < 800 ? 'lg' : 'xl');
-    }
-  }, []);
 
   return (
-    <Modal isOpen={isOpen} toggle={toggle} centered size={modalSize}>
+    <Modal isOpen={isOpen} toggle={toggle} centered size="lg">
       <ModalHeader toggle={toggle}>
         QR code for <ExternalLink href={shortUrl}>{shortUrl}</ExternalLink>
       </ModalHeader>
-      <ModalBody>
-        <Row>
+      <ModalBody className="d-flex flex-column-reverse flex-lg-row gap-3">
+        <div className="flex-grow-1 d-flex align-items-center justify-content-around text-center">
+          <img src={qrCodeUrl} alt="QR code" className="shadow-lg" style={{ maxWidth: '100%' }} />
+        </div>
+        <div className="d-flex flex-column gap-2">
           <QrDimensionControl
-            className="col-sm-6"
             name="size"
             value={size}
+            onChange={setSize}
             step={10}
             min={50}
             max={1000}
             initial={300}
-            onChange={setSize}
           />
           <QrDimensionControl
-            className="col-sm-6"
             name="margin"
             value={margin}
+            onChange={setMargin}
             step={1}
             min={0}
             max={100}
-            onChange={setMargin}
           />
-          <FormGroup className="d-grid col-sm-6">
-            <QrFormatDropdown format={format} onChange={setFormat} />
-          </FormGroup>
-          <FormGroup className="col-sm-6">
-            <QrErrorCorrectionDropdown errorCorrection={errorCorrection} onChange={setErrorCorrection} />
-          </FormGroup>
-        </Row>
-        <div className="text-center">
-          <div className="mb-3">
-            <ExternalLink href={qrCodeUrl} />
-            <CopyToClipboardIcon text={qrCodeUrl} />
-          </div>
-          <img
-            src={qrCodeUrl}
-            alt="QR code"
-            className="shadow-lg"
-            style={{ maxWidth: '100%' }}
-            onLoad={onImageLoad}
-          />
-          <div className="mt-3">
+          <QrFormatDropdown format={format} onChange={setFormat}/>
+          <QrErrorCorrectionDropdown errorCorrection={errorCorrection} onChange={setErrorCorrection}/>
+
+          <div className="mt-auto">
             <Button
               block
               color="primary"
               onClick={() => {
-                imageDownloader.saveImage(qrCodeUrl, `${shortCode}-qr-code.${format}`).catch(() => {});
+                imageDownloader.saveImage(qrCodeUrl, `${shortCode}-qr-code.${format ?? 'png'}`).catch(() => {});
               }}
             >
-              Download <FontAwesomeIcon icon={downloadIcon} className="ms-1" />
+              Download <FontAwesomeIcon icon={downloadIcon} className="ms-1"/>
             </Button>
           </div>
         </div>
       </ModalBody>
+      <ModalFooter className="sticky-bottom justify-content-around" style={{ backgroundColor: 'var(--primary-color)' }}>
+        <div>
+          <ExternalLink href={qrCodeUrl}/>
+          <CopyToClipboardIcon text={qrCodeUrl}/>
+        </div>
+      </ModalFooter>
     </Modal>
   );
 };

--- a/src/short-urls/helpers/qr-codes/QrColorControl.tsx
+++ b/src/short-urls/helpers/qr-codes/QrColorControl.tsx
@@ -1,0 +1,49 @@
+import { faArrowRotateLeft } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import type { FC } from 'react';
+import type { ButtonProps } from 'reactstrap';
+import { Button } from 'reactstrap';
+import { ColorInput } from '../../../utils/components/ColorInput';
+
+export type QrColorControlProps = {
+  name: string;
+  color?: string;
+  /** Initial color to set when transitioning from default to custom */
+  initialColor: string;
+  onChange: (newColor?: string) => void;
+};
+
+const SubtleButton: FC<Omit<ButtonProps, 'outline' | 'color' | 'style'>> = (props) => (
+  <Button
+    outline
+    color="link"
+    style={{ color: 'var(--input-text-color)', borderColor: 'var(--border-color)' }}
+    {...props}
+  />
+);
+
+export const QrColorControl: FC<QrColorControlProps> = ({ name, color, initialColor, onChange }) => {
+  return (
+    <>
+      {color === undefined ? (
+        <SubtleButton
+          className="text-start fst-italic w-100"
+          onClick={() => onChange(initialColor)}
+        >
+          <span className="indivisible">Customize {name}</span>
+        </SubtleButton>
+      ) : (
+        <div className="d-flex gap-1 w-100">
+          <ColorInput color={color} onChange={onChange}/>
+          <SubtleButton
+            aria-label={`Default ${name}`}
+            title={`Default ${name}`}
+            onClick={() => onChange(undefined)}
+          >
+            <FontAwesomeIcon icon={faArrowRotateLeft}/>
+          </SubtleButton>
+        </div>
+      )}
+    </>
+  );
+};

--- a/src/short-urls/helpers/qr-codes/QrColorControl.tsx
+++ b/src/short-urls/helpers/qr-codes/QrColorControl.tsx
@@ -34,13 +34,13 @@ export const QrColorControl: FC<QrColorControlProps> = ({ name, color, initialCo
         </SubtleButton>
       ) : (
         <div className="d-flex gap-1 w-100">
-          <ColorInput color={color} onChange={onChange}/>
+          <ColorInput color={color} onChange={onChange} name={name} />
           <SubtleButton
             aria-label={`Default ${name}`}
             title={`Default ${name}`}
             onClick={() => onChange(undefined)}
           >
-            <FontAwesomeIcon icon={faArrowRotateLeft}/>
+            <FontAwesomeIcon icon={faArrowRotateLeft} />
           </SubtleButton>
         </div>
       )}

--- a/src/short-urls/helpers/qr-codes/QrColorControl.tsx
+++ b/src/short-urls/helpers/qr-codes/QrColorControl.tsx
@@ -1,9 +1,8 @@
 import { faArrowRotateLeft } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import type { FC } from 'react';
-import type { ButtonProps } from 'reactstrap';
-import { Button } from 'reactstrap';
 import { ColorInput } from '../../../utils/components/ColorInput';
+import { SubtleButton } from '../../../utils/components/SubtleButton';
 
 export type QrColorControlProps = {
   name: string;
@@ -13,37 +12,19 @@ export type QrColorControlProps = {
   onChange: (newColor?: string) => void;
 };
 
-const SubtleButton: FC<Omit<ButtonProps, 'outline' | 'color' | 'style'>> = (props) => (
-  <Button
-    outline
-    color="link"
-    style={{ color: 'var(--input-text-color)', borderColor: 'var(--border-color)' }}
-    {...props}
-  />
-);
-
-export const QrColorControl: FC<QrColorControlProps> = ({ name, color, initialColor, onChange }) => {
-  return (
-    <>
-      {color === undefined ? (
-        <SubtleButton
-          className="text-start fst-italic w-100"
-          onClick={() => onChange(initialColor)}
-        >
-          <span className="indivisible">Customize {name}</span>
+export const QrColorControl: FC<QrColorControlProps> = ({ name, color, initialColor, onChange }) => (
+  <>
+    {color === undefined ? (
+      <SubtleButton className="text-start fst-italic w-100" onClick={() => onChange(initialColor)}>
+        <span className="indivisible">Customize {name}</span>
+      </SubtleButton>
+    ) : (
+      <div className="d-flex gap-1 w-100">
+        <ColorInput color={color} onChange={onChange} name={name} />
+        <SubtleButton label={`Default ${name}`} onClick={() => onChange(undefined)}>
+          <FontAwesomeIcon icon={faArrowRotateLeft} />
         </SubtleButton>
-      ) : (
-        <div className="d-flex gap-1 w-100">
-          <ColorInput color={color} onChange={onChange} name={name} />
-          <SubtleButton
-            aria-label={`Default ${name}`}
-            title={`Default ${name}`}
-            onClick={() => onChange(undefined)}
-          >
-            <FontAwesomeIcon icon={faArrowRotateLeft} />
-          </SubtleButton>
-        </div>
-      )}
-    </>
-  );
-};
+      </div>
+    )}
+  </>
+);

--- a/src/short-urls/helpers/qr-codes/QrDimensionControl.tsx
+++ b/src/short-urls/helpers/qr-codes/QrDimensionControl.tsx
@@ -2,7 +2,7 @@ import { faArrowRotateLeft } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import type { FC } from 'react';
 import { useId } from 'react';
-import { Button } from 'reactstrap';
+import { Button, type ButtonProps } from 'reactstrap';
 
 export type QrCodeDimensionControlProps = {
   name: string;
@@ -14,26 +14,31 @@ export type QrCodeDimensionControlProps = {
   onChange: (newValue?: number) => void;
 };
 
+const SubtleButton: FC<Omit<ButtonProps, 'outline' | 'color' | 'style'>> = (props) => (
+  <Button
+    outline
+    color="link"
+    style={{ color: 'var(--input-text-color)', borderColor: 'var(--border-color)' }}
+    {...props}
+  />
+);
+
 export const QrDimensionControl: FC<QrCodeDimensionControlProps> = (
   { name, value, step, min, max, onChange, initial = min },
 ) => {
   const id = useId();
 
   return (
-    <div>
-      {value === undefined && (
-        <Button
-          outline
-          color="link"
+    <>
+      {value === undefined ? (
+        <SubtleButton
           className="text-start fst-italic w-100"
-          style={{ color: 'var(--input-text-color)', borderColor: 'var(--border-color)' }}
           onClick={() => onChange(initial)}
         >
           Customize {name}
-        </Button>
-      )}
-      {value !== undefined && (
-        <div className="d-flex gap-3">
+        </SubtleButton>
+      ) : (
+        <div className="d-flex gap-1 w-100">
           <div className="d-flex flex-column flex-grow-1">
             <label htmlFor={id} className="text-capitalize">{name}: {value}px</label>
             <input
@@ -47,18 +52,15 @@ export const QrDimensionControl: FC<QrCodeDimensionControlProps> = (
               onChange={(e) => onChange(Number(e.target.value))}
             />
           </div>
-          <Button
+          <SubtleButton
             aria-label={`Default ${name}`}
             title={`Default ${name}`}
-            outline
-            color="link"
             onClick={() => onChange(undefined)}
-            style={{ color: 'var(--input-text-color)', borderColor: 'var(--border-color)' }}
           >
             <FontAwesomeIcon icon={faArrowRotateLeft} />
-          </Button>
+          </SubtleButton>
         </div>
       )}
-    </div>
+    </>
   );
 };

--- a/src/short-urls/helpers/qr-codes/QrDimensionControl.tsx
+++ b/src/short-urls/helpers/qr-codes/QrDimensionControl.tsx
@@ -2,7 +2,7 @@ import { faArrowRotateLeft } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import type { FC } from 'react';
 import { useId } from 'react';
-import { Button, type ButtonProps } from 'reactstrap';
+import { SubtleButton } from '../../../utils/components/SubtleButton';
 
 export type QrCodeDimensionControlProps = {
   name: string;
@@ -14,15 +14,6 @@ export type QrCodeDimensionControlProps = {
   onChange: (newValue?: number) => void;
 };
 
-const SubtleButton: FC<Omit<ButtonProps, 'outline' | 'color' | 'style'>> = (props) => (
-  <Button
-    outline
-    color="link"
-    style={{ color: 'var(--input-text-color)', borderColor: 'var(--border-color)' }}
-    {...props}
-  />
-);
-
 export const QrDimensionControl: FC<QrCodeDimensionControlProps> = (
   { name, value, step, min, max, onChange, initial = min },
 ) => {
@@ -31,10 +22,7 @@ export const QrDimensionControl: FC<QrCodeDimensionControlProps> = (
   return (
     <>
       {value === undefined ? (
-        <SubtleButton
-          className="text-start fst-italic w-100"
-          onClick={() => onChange(initial)}
-        >
+        <SubtleButton className="text-start fst-italic w-100" onClick={() => onChange(initial)}>
           Customize {name}
         </SubtleButton>
       ) : (
@@ -52,11 +40,7 @@ export const QrDimensionControl: FC<QrCodeDimensionControlProps> = (
               onChange={(e) => onChange(Number(e.target.value))}
             />
           </div>
-          <SubtleButton
-            aria-label={`Default ${name}`}
-            title={`Default ${name}`}
-            onClick={() => onChange(undefined)}
-          >
+          <SubtleButton label={`Default ${name}`} onClick={() => onChange(undefined)}>
             <FontAwesomeIcon icon={faArrowRotateLeft} />
           </SubtleButton>
         </div>

--- a/src/short-urls/helpers/qr-codes/QrDimensionControl.tsx
+++ b/src/short-urls/helpers/qr-codes/QrDimensionControl.tsx
@@ -2,7 +2,7 @@ import { faArrowRotateLeft } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import type { FC } from 'react';
 import { useId } from 'react';
-import { Button, FormGroup } from 'reactstrap';
+import { Button } from 'reactstrap';
 
 export type QrCodeDimensionControlProps = {
   name: string;
@@ -12,16 +12,15 @@ export type QrCodeDimensionControlProps = {
   max?: number;
   initial?: number;
   onChange: (newValue?: number) => void;
-  className?: string;
 };
 
 export const QrDimensionControl: FC<QrCodeDimensionControlProps> = (
-  { name, value, step, min, max, onChange, className, initial = min },
+  { name, value, step, min, max, onChange, initial = min },
 ) => {
   const id = useId();
 
   return (
-    <FormGroup className={className}>
+    <div>
       {value === undefined && (
         <Button
           outline
@@ -60,6 +59,6 @@ export const QrDimensionControl: FC<QrCodeDimensionControlProps> = (
           </Button>
         </div>
       )}
-    </FormGroup>
+    </div>
   );
 };

--- a/src/short-urls/helpers/qr-codes/QrErrorCorrectionDropdown.tsx
+++ b/src/short-urls/helpers/qr-codes/QrErrorCorrectionDropdown.tsx
@@ -11,7 +11,10 @@ interface QrErrorCorrectionDropdownProps {
 export const QrErrorCorrectionDropdown: FC<QrErrorCorrectionDropdownProps> = (
   { errorCorrection, onChange },
 ) => (
-  <DropdownBtn text={errorCorrection ? `Error correction (${errorCorrection})` : <i>Default error correction</i>}>
+  <DropdownBtn
+    text={errorCorrection ? `Error correction (${errorCorrection})` : <i>Default error correction</i>}
+    dropdownClassName="w-100"
+  >
     <DropdownItem active={!errorCorrection} onClick={() => onChange(undefined)}>Default</DropdownItem>
     <DropdownItem divider tag="hr" />
     <DropdownItem active={errorCorrection === 'L'} onClick={() => onChange('L')}>

--- a/src/short-urls/helpers/qr-codes/QrFormatDropdown.tsx
+++ b/src/short-urls/helpers/qr-codes/QrFormatDropdown.tsx
@@ -9,7 +9,7 @@ interface QrFormatDropdownProps {
 }
 
 export const QrFormatDropdown: FC<QrFormatDropdownProps> = ({ format, onChange }) => (
-  <DropdownBtn text={format ? `Format (${format})` : <i>Default format</i>}>
+  <DropdownBtn text={format ? `Format (${format})` : <i>Default format</i>} dropdownClassName="w-100">
     <DropdownItem active={!format} onClick={() => onChange(undefined)}>Default</DropdownItem>
     <DropdownItem divider tag="hr" />
     <DropdownItem active={format === 'png'} onClick={() => onChange('png')}>PNG</DropdownItem>

--- a/src/tags/helpers/EditTagModal.tsx
+++ b/src/tags/helpers/EditTagModal.tsx
@@ -1,11 +1,10 @@
-import { faPalette as colorIcon } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Result } from '@shlinkio/shlink-frontend-kit';
 import { useCallback, useState } from 'react';
 import { Button, Input, InputGroup, Modal, ModalBody, ModalFooter, ModalHeader } from 'reactstrap';
 import { ShlinkApiError } from '../../common/ShlinkApiError';
 import type { FCWithDeps } from '../../container/utils';
 import { componentFactory, useDependencies } from '../../container/utils';
+import { ColorPicker } from '../../utils/components/ColorPicker';
 import { handleEventPreventingDefault } from '../../utils/helpers';
 import type { ColorGenerator } from '../../utils/services/ColorGenerator';
 import type { TagModalProps } from '../data';
@@ -45,21 +44,7 @@ const EditTagModal: FCWithDeps<EditTagModalProps, EditTagModalDeps> = (
         <ModalHeader toggle={toggle}>Edit tag</ModalHeader>
         <ModalBody>
           <InputGroup>
-            <div
-              className="input-group-text p-0 position-relative"
-              style={{ backgroundColor: color, borderColor: color }}
-            >
-              <FontAwesomeIcon
-                icon={colorIcon}
-                className="position-absolute top-50 start-50 translate-middle text-white"
-              />
-              <Input
-                className="form-control-color opacity-0"
-                type="color"
-                value={color}
-                onChange={(e) => setColor(e.target.value)}
-              />
-            </div>
+            <ColorPicker color={color} onChange={setColor} className="input-group-text" />
             <Input
               value={newTagName}
               placeholder="Tag"

--- a/src/tags/helpers/EditTagModal.tsx
+++ b/src/tags/helpers/EditTagModal.tsx
@@ -44,7 +44,7 @@ const EditTagModal: FCWithDeps<EditTagModalProps, EditTagModalDeps> = (
         <ModalHeader toggle={toggle}>Edit tag</ModalHeader>
         <ModalBody>
           <InputGroup>
-            <ColorPicker color={color} onChange={setColor} className="input-group-text" />
+            <ColorPicker color={color} onChange={setColor} className="input-group-text" name="tag-color" />
             <Input
               value={newTagName}
               placeholder="Tag"

--- a/src/utils/components/ColorInput.tsx
+++ b/src/utils/components/ColorInput.tsx
@@ -4,17 +4,19 @@ import { Input, InputGroup } from 'reactstrap';
 import type { ColorPickerProps } from './ColorPicker';
 import { ColorPicker } from './ColorPicker';
 
-export type ColorInputProps = Omit<ColorPickerProps, 'className'> & {
-  name: string;
-};
-
-export const ColorInput: FC<ColorInputProps> = ({ color, onChange, name }) => {
+export const ColorInput: FC<Omit<ColorPickerProps, 'className'>> = ({ color, onChange, name }) => {
   const colorPickerRef = useElementRef<HTMLInputElement>();
 
   return (
     <InputGroup>
       <ColorPicker name={name} color={color} onChange={onChange} className="input-group-text" ref={colorPickerRef} />
-      <Input value={color} readOnly onClick={() => colorPickerRef.current?.click()} />
+      <Input
+        readOnly
+        value={color}
+        onClick={() => colorPickerRef.current?.click()}
+        aria-label={name}
+        data-testid="text-input"
+      />
     </InputGroup>
   );
 };

--- a/src/utils/components/ColorInput.tsx
+++ b/src/utils/components/ColorInput.tsx
@@ -1,0 +1,16 @@
+import { useElementRef } from '@shlinkio/shlink-frontend-kit';
+import type { FC } from 'react';
+import { Input, InputGroup } from 'reactstrap';
+import type { ColorPickerProps } from './ColorPicker';
+import { ColorPicker } from './ColorPicker';
+
+export const ColorInput: FC<Omit<ColorPickerProps, 'className'>> = ({ color, onChange }) => {
+  const colorPickerRef = useElementRef<HTMLInputElement>();
+
+  return (
+    <InputGroup>
+      <ColorPicker color={color} onChange={onChange} className="input-group-text" ref={colorPickerRef} />
+      <Input value={color} readOnly onClick={() => colorPickerRef.current?.click()} />
+    </InputGroup>
+  );
+};

--- a/src/utils/components/ColorInput.tsx
+++ b/src/utils/components/ColorInput.tsx
@@ -4,12 +4,16 @@ import { Input, InputGroup } from 'reactstrap';
 import type { ColorPickerProps } from './ColorPicker';
 import { ColorPicker } from './ColorPicker';
 
-export const ColorInput: FC<Omit<ColorPickerProps, 'className'>> = ({ color, onChange }) => {
+export type ColorInputProps = Omit<ColorPickerProps, 'className'> & {
+  name: string;
+};
+
+export const ColorInput: FC<ColorInputProps> = ({ color, onChange, name }) => {
   const colorPickerRef = useElementRef<HTMLInputElement>();
 
   return (
     <InputGroup>
-      <ColorPicker color={color} onChange={onChange} className="input-group-text" ref={colorPickerRef} />
+      <ColorPicker name={name} color={color} onChange={onChange} className="input-group-text" ref={colorPickerRef} />
       <Input value={color} readOnly onClick={() => colorPickerRef.current?.click()} />
     </InputGroup>
   );

--- a/src/utils/components/ColorPicker.tsx
+++ b/src/utils/components/ColorPicker.tsx
@@ -5,27 +5,31 @@ import { forwardRef } from 'react';
 import { Input } from 'reactstrap';
 
 export type ColorPickerProps = {
+  name: string;
   color: string;
   onChange: (newColor: string) => void;
   className?: string;
 };
 
-export const ColorPicker = forwardRef<HTMLInputElement, ColorPickerProps>(({ color, onChange, className }, ref) => (
-  <div
-    className={clsx('p-0 position-relative', className)}
-    style={{ backgroundColor: color, borderColor: color }}
-  >
-    <FontAwesomeIcon
-      icon={colorIcon}
-      // Text color should be dynamically calculated to keep contrast
-      className="position-absolute top-50 start-50 translate-middle text-white"
-    />
-    <Input
-      className="form-control-color opacity-0"
-      type="color"
-      value={color}
-      onChange={(e) => onChange(e.target.value)}
-      innerRef={ref}
-    />
-  </div>
-));
+export const ColorPicker = forwardRef<HTMLInputElement, ColorPickerProps>(
+  ({ name, color, onChange, className }, ref) => (
+    <div
+      className={clsx('p-0 position-relative', className)}
+      style={{ backgroundColor: color, borderColor: color }}
+    >
+      <FontAwesomeIcon
+        icon={colorIcon}
+        // Text color should be dynamically calculated to keep contrast
+        className="position-absolute top-50 start-50 translate-middle text-white"
+      />
+      <Input
+        className="form-control-color opacity-0"
+        type="color"
+        value={color}
+        onChange={(e) => onChange(e.target.value)}
+        innerRef={ref}
+        name={name}
+      />
+    </div>
+  ),
+);

--- a/src/utils/components/ColorPicker.tsx
+++ b/src/utils/components/ColorPicker.tsx
@@ -31,6 +31,7 @@ export const ColorPicker = forwardRef<HTMLInputElement, ColorPickerProps>(
         onChange={(e) => onChange(e.target.value)}
         innerRef={ref}
         name={name}
+        aria-label={name}
       />
     </div>
   ),

--- a/src/utils/components/ColorPicker.tsx
+++ b/src/utils/components/ColorPicker.tsx
@@ -1,0 +1,31 @@
+import { faPalette as colorIcon } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { clsx } from 'clsx';
+import { forwardRef } from 'react';
+import { Input } from 'reactstrap';
+
+export type ColorPickerProps = {
+  color: string;
+  onChange: (newColor: string) => void;
+  className?: string;
+};
+
+export const ColorPicker = forwardRef<HTMLInputElement, ColorPickerProps>(({ color, onChange, className }, ref) => (
+  <div
+    className={clsx('p-0 position-relative', className)}
+    style={{ backgroundColor: color, borderColor: color }}
+  >
+    <FontAwesomeIcon
+      icon={colorIcon}
+      // Text color should be dynamically calculated to keep contrast
+      className="position-absolute top-50 start-50 translate-middle text-white"
+    />
+    <Input
+      className="form-control-color opacity-0"
+      type="color"
+      value={color}
+      onChange={(e) => onChange(e.target.value)}
+      innerRef={ref}
+    />
+  </div>
+));

--- a/src/utils/components/ColorPicker.tsx
+++ b/src/utils/components/ColorPicker.tsx
@@ -3,6 +3,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { clsx } from 'clsx';
 import { forwardRef } from 'react';
 import { Input } from 'reactstrap';
+import { isLightColor } from '../helpers/color';
 
 export type ColorPickerProps = {
   name: string;
@@ -19,8 +20,9 @@ export const ColorPicker = forwardRef<HTMLInputElement, ColorPickerProps>(
     >
       <FontAwesomeIcon
         icon={colorIcon}
+        className="position-absolute top-50 start-50 translate-middle"
         // Text color should be dynamically calculated to keep contrast
-        className="position-absolute top-50 start-50 translate-middle text-white"
+        style={{ color: isLightColor(color.substring(1)) ? '#000' : 'fff' }}
       />
       <Input
         className="form-control-color opacity-0"

--- a/src/utils/components/SubtleButton.tsx
+++ b/src/utils/components/SubtleButton.tsx
@@ -1,0 +1,22 @@
+import type { FC } from 'react';
+import type { ButtonProps } from 'reactstrap';
+import { Button } from 'reactstrap';
+
+export type SubtleButtonProps = Omit<ButtonProps, 'outline' | 'color' | 'style'> & {
+  /**
+   * Used to set both `aria-label` and `title` props if provided.
+   * You can still provide any of those props explicitly, and they will take precedence.
+   */
+  label?: string;
+};
+
+export const SubtleButton: FC<SubtleButtonProps> = ({ label, ...rest }) => (
+  <Button
+    outline
+    color="link"
+    style={{ color: 'var(--input-text-color)', borderColor: 'var(--border-color)' }}
+    aria-label={label}
+    title={label}
+    {...rest}
+  />
+);

--- a/src/utils/features.ts
+++ b/src/utils/features.ts
@@ -9,6 +9,7 @@ const supportedFeatures = {
   shortUrlVisitsDeletion: { minVersion: '3.6.0' },
   orphanVisitsDeletion: { minVersion: '3.7.0' },
   shortUrlRedirectRules: { minVersion: '4.0.0' },
+  qrCodeColors: { minVersion: '4.0.0' },
   urlValidation: { maxVersion: '3.*.*' },
   ipRedirectCondition: { minVersion: '4.2.*' },
 } as const satisfies Record<string, Versions>;
@@ -18,7 +19,9 @@ Object.freeze(supportedFeatures);
 export type Feature = keyof typeof supportedFeatures;
 
 const isFeatureEnabledForVersion = (feature: Feature, serverVersion: SemVerOrLatest): boolean =>
-  serverVersion === 'latest' || versionMatch(serverVersion, supportedFeatures[feature]);
+  // When serverVersion is `latest`, fall back to a very big version number.
+  // That will disable features with a maxVersion, and keep enabled those with only a minVersion
+  versionMatch(serverVersion === 'latest' ? '999.99.99' : serverVersion, supportedFeatures[feature]);
 
 const getFeaturesForVersion = (serverVersion: SemVerOrLatest): Record<Feature, boolean> => ({
   excludeBotsOnShortUrls: isFeatureEnabledForVersion('excludeBotsOnShortUrls', serverVersion),
@@ -27,6 +30,7 @@ const getFeaturesForVersion = (serverVersion: SemVerOrLatest): Record<Feature, b
   shortUrlVisitsDeletion: isFeatureEnabledForVersion('shortUrlVisitsDeletion', serverVersion),
   orphanVisitsDeletion: isFeatureEnabledForVersion('orphanVisitsDeletion', serverVersion),
   shortUrlRedirectRules: isFeatureEnabledForVersion('shortUrlRedirectRules', serverVersion),
+  qrCodeColors: isFeatureEnabledForVersion('qrCodeColors', serverVersion),
   urlValidation: isFeatureEnabledForVersion('urlValidation', serverVersion),
   ipRedirectCondition: isFeatureEnabledForVersion('ipRedirectCondition', serverVersion),
 });

--- a/src/utils/helpers/color.ts
+++ b/src/utils/helpers/color.ts
@@ -1,0 +1,24 @@
+import { rangeOf } from './index';
+
+const HEX_COLOR_LENGTH = 6;
+const HEX_DIGITS = '0123456789ABCDEF';
+const LIGHTNESS_BREAKPOINT = 128;
+
+export function buildRandomColor(): string {
+  return `#${rangeOf(HEX_COLOR_LENGTH, () => HEX_DIGITS[Math.floor(Math.random() * HEX_DIGITS.length)]).join('')}`;
+}
+
+/**
+ * Returns the perceived lightness of an RGB color, as a number from 0 to 256.
+ * The lower the number, the darker is the color perceived.
+ *
+ * HSP by Darel Rex Finley https://alienryderflex.com/hsp.html
+ */
+function perceivedLightness (r: number, g: number, b: number): number {
+  return Math.round(Math.sqrt(0.299 * r ** 2 + 0.587 * g ** 2 + 0.114 * b ** 2));
+}
+
+export function isLightColor(colorHex: string): boolean {
+  const [r, g, b] = (colorHex.match(/../g) ?? []).map((hex) => parseInt(hex, 16) || 0);
+  return perceivedLightness(r, g, b) >= LIGHTNESS_BREAKPOINT;
+}

--- a/src/utils/helpers/qrCodes.ts
+++ b/src/utils/helpers/qrCodes.ts
@@ -4,16 +4,20 @@ export type QrCodeFormat = 'svg' | 'png';
 
 export type QrErrorCorrection = 'L' | 'M' | 'Q' | 'H';
 
-export interface QrCodeOptions {
+export type QrCodeOptions = {
   size?: number;
   format?: QrCodeFormat;
   margin?: number;
   errorCorrection?: QrErrorCorrection;
-}
+  color?: string;
+  bgColor?: string;
+};
 
-export const buildQrCodeUrl = (shortUrl: string, options: QrCodeOptions): string => {
+const normalizeColor = (color?: string) => color && color.startsWith('#') ? color.substring(1) : color;
+
+export const buildQrCodeUrl = (shortUrl: string, { color, bgColor, ...rest }: QrCodeOptions): string => {
   const baseUrl = `${shortUrl}/qr-code`;
-  const query = stringifyQueryParams({ ...options });
+  const query = stringifyQueryParams({ ...rest, color: normalizeColor(color), bgColor: normalizeColor(bgColor) });
 
   return `${baseUrl}${!query ? '' : `?${query}`}`;
 };

--- a/src/utils/services/ColorGenerator.ts
+++ b/src/utils/services/ColorGenerator.ts
@@ -1,19 +1,8 @@
 import type { CSSProperties } from 'react';
-import { rangeOf } from '../helpers';
+import { buildRandomColor, isLightColor } from '../helpers/color';
 import type { TagColorsStorage } from './TagColorsStorage';
 
-const HEX_COLOR_LENGTH = 6;
-const HEX_DIGITS = '0123456789ABCDEF';
-const LIGHTNESS_BREAKPOINT = 128;
-
-const { floor, random, sqrt, round } = Math;
-const buildRandomColor = () =>
-  `#${rangeOf(HEX_COLOR_LENGTH, () => HEX_DIGITS[floor(random() * HEX_DIGITS.length)]).join('')}`;
 const normalizeKey = (key: string) => key.toLowerCase().trim();
-const hexColorToRgbArray = (colorHex: string): number[] =>
-  (colorHex.match(/../g) ?? []).map((hex) => parseInt(hex, 16) || 0);
-// HSP by Darel Rex Finley https://alienryderflex.com/hsp.html
-const perceivedLightness = (r = 0, g = 0, b = 0) => round(sqrt(0.299 * r ** 2 + 0.587 * g ** 2 + 0.114 * b ** 2));
 
 export class ColorGenerator {
   private readonly colors: Record<string, string>;
@@ -57,8 +46,7 @@ export class ColorGenerator {
     const colorHex = color.substring(1);
 
     if (this.lights[colorHex] === undefined) {
-      const rgb = hexColorToRgbArray(colorHex);
-      this.lights[colorHex] = perceivedLightness(...rgb) >= LIGHTNESS_BREAKPOINT;
+      this.lights[colorHex] = isLightColor(colorHex);
     }
 
     return this.lights[colorHex];

--- a/test/short-urls/helpers/QrCodeModal.test.tsx
+++ b/test/short-urls/helpers/QrCodeModal.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import { fromPartial } from '@total-typescript/shoehorn';
 import { QrCodeModalFactory } from '../../../src/short-urls/helpers/QrCodeModal';
 import type { ImageDownloader } from '../../../src/utils/services/ImageDownloader';
@@ -37,43 +37,6 @@ describe('<QrCodeModal />', () => {
 
     expect(screen.getByRole('img')).toHaveAttribute('src', expectedUrl);
     expect(screen.getByText(expectedUrl)).toHaveAttribute('href', expectedUrl);
-  });
-
-  it.each([
-    [530, 0, 'lg'],
-    [200, 0, undefined],
-    [830, 0, 'xl'],
-    [430, 80, 'lg'],
-    [200, 50, undefined],
-    [720, 100, 'xl'],
-  ])('renders expected size', async (size, margin, modalSize) => {
-    const { user } = setUp();
-
-    // Switch to sliders
-    await user.click(screen.getByRole('button', { name: 'Customize size' }));
-    await user.click(screen.getByRole('button', { name: 'Customize margin' }));
-
-    const [sizeInput, marginInput] = screen.getAllByRole('slider');
-    if (!sizeInput || !marginInput) {
-      throw new Error('Sliders not found');
-    }
-
-    fireEvent.change(sizeInput, { target: { value: `${size}` } });
-    fireEvent.change(marginInput, { target: { value: `${margin}` } });
-
-    expect(screen.getByText(`size: ${size}px`)).toBeInTheDocument();
-    expect(screen.getByText(`margin: ${margin}px`)).toBeInTheDocument();
-
-    // Fake the images load event with a width that matches the size+margin
-    const image = screen.getByAltText('QR code');
-    Object.defineProperty(image, 'naturalWidth', {
-      get: () => size + margin,
-    });
-    image.dispatchEvent(new Event('load'));
-
-    if (modalSize) {
-      await waitFor(() => expect(screen.getByRole('document')).toHaveClass(`modal-${modalSize}`));
-    }
   });
 
   it('shows expected buttons', () => {

--- a/test/short-urls/helpers/QrCodeModal.test.tsx
+++ b/test/short-urls/helpers/QrCodeModal.test.tsx
@@ -1,6 +1,7 @@
-import { screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import { fromPartial } from '@total-typescript/shoehorn';
 import { QrCodeModalFactory } from '../../../src/short-urls/helpers/QrCodeModal';
+import { FeaturesProvider } from '../../../src/utils/features';
 import type { ImageDownloader } from '../../../src/utils/services/ImageDownloader';
 import { checkAccessibility } from '../../__helpers__/accessibility';
 import { renderWithEvents } from '../../__helpers__/setUpTest';
@@ -11,15 +12,20 @@ describe('<QrCodeModal />', () => {
     ImageDownloader: fromPartial<ImageDownloader>({ saveImage }),
   }));
   const shortUrl = 'https://s.test/abc123';
-  const setUp = () => renderWithEvents(
-    <QrCodeModal
-      isOpen
-      shortUrl={fromPartial({ shortUrl })}
-      toggle={() => {}}
-    />,
+  const setUp = ({ qrCodeColors = false }: { qrCodeColors?: boolean } = {}) => renderWithEvents(
+    <FeaturesProvider value={fromPartial({ qrCodeColors })}>
+      <QrCodeModal
+        isOpen
+        shortUrl={fromPartial({ shortUrl })}
+        toggle={() => {}}
+      />
+    </FeaturesProvider>,
   );
 
-  it('passes a11y checks', () => checkAccessibility(setUp()));
+  it.each([{ qrCodeColors: false }, { qrCodeColors: true }])(
+    'passes a11y checks',
+    ({ qrCodeColors }) => checkAccessibility(setUp({ qrCodeColors })),
+  );
 
   it('shows an external link to the URL in the header', () => {
     setUp();
@@ -31,19 +37,48 @@ describe('<QrCodeModal />', () => {
   });
 
   it('displays an image with the QR code of the URL', async () => {
-    setUp();
+    const { user } = setUp({ qrCodeColors: true });
+    const assertUrl = (url: string) => {
+      expect(screen.getByRole('img')).toHaveAttribute('src', url);
+      expect(screen.getByText(url)).toHaveAttribute('href', url);
+    };
 
-    const expectedUrl = `${shortUrl}/qr-code`;
+    // Initially, no arguments are appended
+    assertUrl(`${shortUrl}/qr-code`);
 
-    expect(screen.getByRole('img')).toHaveAttribute('src', expectedUrl);
-    expect(screen.getByText(expectedUrl)).toHaveAttribute('href', expectedUrl);
+    // Switch to sliders
+    await user.click(screen.getByRole('button', { name: 'Customize size' }));
+    await user.click(screen.getByRole('button', { name: 'Customize margin' }));
+
+    const [sizeInput, marginInput] = screen.getAllByRole('slider');
+    if (!sizeInput || !marginInput) {
+      throw new Error('Sliders not found');
+    }
+
+    // Setting size and margin should reflect in the QR code URL
+    fireEvent.change(sizeInput, { target: { value: '560' } });
+    fireEvent.change(marginInput, { target: { value: '20' } });
+    assertUrl(`${shortUrl}/qr-code?size=560&margin=20`);
+
+    // Unset margin and select error correction
+    await user.click(screen.getByRole('button', { name: 'Default margin' }));
+    await user.click(screen.getByRole('button', { name: 'Default error correction' }));
+    await user.click(screen.getByRole('menuitem', { name: /uartile/ }));
+    assertUrl(`${shortUrl}/qr-code?size=560&errorCorrection=Q`);
+
+    // Set custom color
+    await user.click(screen.getByRole('button', { name: 'Customize color' }));
+    assertUrl(`${shortUrl}/qr-code?size=560&errorCorrection=Q&color=000000`);
   });
 
-  it('shows expected buttons', () => {
-    setUp();
+  it.each([
+    { qrCodeColors: false, expectedButtons: 4 },
+    { qrCodeColors: true, expectedButtons: 6 },
+  ])('shows expected buttons', ({ expectedButtons, qrCodeColors }) => {
+    setUp({ qrCodeColors });
 
     // Add three because of the close, download and copy-to-clipboard buttons
-    expect(screen.getAllByRole('button')).toHaveLength(4 + 3);
+    expect(screen.getAllByRole('button')).toHaveLength(expectedButtons + 3);
   });
 
   it('saves the QR code image when clicking the Download button', async () => {

--- a/test/short-urls/helpers/qr-codes/QrColorControl.test.tsx
+++ b/test/short-urls/helpers/qr-codes/QrColorControl.test.tsx
@@ -1,0 +1,30 @@
+import { screen } from '@testing-library/react';
+import { QrColorControl } from '../../../../src/short-urls/helpers/qr-codes/QrColorControl';
+import { checkAccessibility } from '../../../__helpers__/accessibility';
+import { renderWithEvents } from '../../../__helpers__/setUpTest';
+
+describe('<QrColorControl />', () => {
+  const setUp = (color?: string) => renderWithEvents(
+    <QrColorControl name="foo" color={color} initialColor="#ff0000" onChange={vi.fn()} />,
+  );
+
+  it.each([
+    [setUp],
+    [() => setUp('#000000')],
+  ])('passes a11y checks', (setUp) => checkAccessibility(setUp()));
+
+  it.each([
+    { color: undefined, hasColorPicker: false },
+    { color: '#0000ff', hasColorPicker: true },
+  ])('shows a color picker when the value is set', ({ color, hasColorPicker }) => {
+    const { container } = setUp(color);
+
+    if (hasColorPicker) {
+      expect(container.querySelector('input[type="color"]')).toBeInTheDocument();
+      expect(screen.queryByText('Customize foo')).not.toBeInTheDocument();
+    } else {
+      expect(container.querySelector('input[type="color"]')).not.toBeInTheDocument();
+      expect(screen.getByText('Customize foo')).toBeInTheDocument();
+    }
+  });
+});

--- a/test/utils/components/ColorInput.test.tsx
+++ b/test/utils/components/ColorInput.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+import { ColorInput } from '../../../src/utils/components/ColorInput';
+import { checkAccessibility } from '../../__helpers__/accessibility';
+
+describe('<ColorInput />', () => {
+  const onChange = vi.fn();
+  const setUp = (color = '#00ff00') => render(<ColorInput name="name" color={color} onChange={onChange} />);
+
+  it.each([['#000000'], ['#ffffff']])('passes a11y checks', (color) => checkAccessibility(setUp(color)));
+
+  it('sets color in text and color inputs', () => {
+    const color = '#010101';
+    setUp(color);
+    const inputs = screen.getAllByLabelText('name');
+
+    expect(inputs).toHaveLength(2);
+    inputs.forEach((input) => {
+      expect(input).toHaveValue(color);
+    });
+  });
+});

--- a/test/utils/components/ColorPicker.test.tsx
+++ b/test/utils/components/ColorPicker.test.tsx
@@ -1,0 +1,22 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ColorPicker } from '../../../src/utils/components/ColorPicker';
+import { checkAccessibility } from '../../__helpers__/accessibility';
+
+describe('<ColorPicker />', () => {
+  const onChange = vi.fn();
+  const setUp = (color = '#00ff00') => render(<ColorPicker name="name" color={color} onChange={onChange} />);
+
+  it.each([['#000000'], ['#ffffff']])('passes a11y checks', (color) => checkAccessibility(setUp(color)));
+
+  it.each([['#000000'], ['#ffffff']])('invokes onChange when the color is changed', (value) => {
+    setUp();
+    fireEvent.change(screen.getByLabelText('name'), { target: { value } });
+
+    expect(onChange).toHaveBeenCalled();
+  });
+
+  it.each([['#000000'], ['#ffffff']])('sets provided color in container styles', (color) => {
+    const { container } = setUp(color);
+    expect(container.firstChild).toHaveStyle({ backgroundColor: color, borderColor: color });
+  });
+});

--- a/test/utils/helpers/qrCodes.test.ts
+++ b/test/utils/helpers/qrCodes.test.ts
@@ -28,6 +28,11 @@ describe('qrCodes', () => {
         { size: 999, format: 'png' as const, errorCorrection: 'Q' as const, margin: 20 },
         'shlink.io/qr-code?size=999&format=png&errorCorrection=Q&margin=20',
       ],
+      [
+        'shlink.io',
+        { color: '#ff0000', bgColor: '001122' },
+        'shlink.io/qr-code?color=ff0000&bgColor=001122',
+      ],
     ])('builds expected URL based in params', (shortUrl, options, expectedUrl) => {
       expect(buildQrCodeUrl(shortUrl, options)).toEqual(expectedUrl);
     });


### PR DESCRIPTION
Closes #491 

When using Shlink 4.0 or higher, display controls to customize QR code colors.

Additionally, rearrange the QR code modal, displaying controls in one side and the generated URL in a sticky footer.

https://github.com/user-attachments/assets/97cae70e-89e8-4f1f-b04b-6ada7cb83c67

- [x] Make color picker icon have a dynamic color with enough contrast with selected color
- [x] Make dropdowns render over card footer