### PR TITLE
Filters short URLs by domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 ### Added
 * [#491](https://github.com/shlinkio/shlink-web-component/issues/491) Add support for colors in QR code configurator.
-* [#515](https://github.com/shlinkio/shlink-web-component/issues/515) Add support for geolocation redirect conditions when using Shlink 4.3 or newer.
+* [#515](https://github.com/shlinkio/shlink-web-component/issues/515) Add support for geolocation redirect conditions, when using Shlink 4.3 or newer.
+* [#514](https://github.com/shlinkio/shlink-web-component/issues/514) Allow filtering short URLs list by domain, when using Shlink 4.3 or newer.
 
 ### Changed
 * *Nothing*

--- a/src/domains/data/index.ts
+++ b/src/domains/data/index.ts
@@ -5,3 +5,5 @@ export type DomainStatus = 'validating' | 'valid' | 'invalid';
 export interface Domain extends ShlinkDomain {
   status: DomainStatus;
 }
+
+export const DEFAULT_DOMAIN = 'DEFAULT';

--- a/src/domains/helpers/DomainDropdown.tsx
+++ b/src/domains/helpers/DomainDropdown.tsx
@@ -9,9 +9,9 @@ import type { FC } from 'react';
 import { Link } from 'react-router-dom';
 import { DropdownItem } from 'reactstrap';
 import { useRoutesPrefix } from '../../utils/routesPrefix';
-import { DEFAULT_DOMAIN } from '../../visits/reducers/domainVisits';
 import { useVisitsComparisonContext } from '../../visits/visits-comparison/VisitsComparisonContext';
 import type { Domain } from '../data';
+import { DEFAULT_DOMAIN } from '../data';
 import type { EditDomainRedirects } from '../reducers/domainRedirects';
 import { EditDomainRedirectsModal } from './EditDomainRedirectsModal';
 

--- a/src/short-urls/ShortUrlsFilteringBar.tsx
+++ b/src/short-urls/ShortUrlsFilteringBar.tsx
@@ -15,7 +15,6 @@ import { DateRangeSelector } from '../utils/dates/DateRangeSelector';
 import { formatIsoDate } from '../utils/dates/helpers/date';
 import type { DateInterval, DateRange } from '../utils/dates/helpers/dateIntervals';
 import { datesToDateRange } from '../utils/dates/helpers/dateIntervals';
-import { useFeature } from '../utils/features';
 import type { ShortUrlsOrder, ShortUrlsOrderableFields } from './data';
 import { SHORT_URLS_ORDERABLE_FIELDS } from './data';
 import type { ExportShortUrlsBtnProps } from './helpers/ExportShortUrlsBtn';
@@ -53,7 +52,6 @@ const ShortUrlsFilteringBar: FCWithDeps<ShortUrlsFilteringConnectProps, ShortUrl
     excludePastValidUntil,
     tagsMode = 'any',
   }, toFirstPage] = useShortUrlsQuery();
-  const supportsDisabledFiltering = useFeature('filterDisabledUrls');
   const visitsSettings = useSetting('visits');
 
   const [activeInterval, setActiveInterval] = useState<DateInterval>();
@@ -119,7 +117,6 @@ const ShortUrlsFilteringBar: FCWithDeps<ShortUrlsFilteringConnectProps, ShortUrl
                 excludePastValidUntil,
               }}
               onChange={toFirstPage}
-              supportsDisabledFiltering={supportsDisabledFiltering}
             />
           </div>
         </div>

--- a/src/short-urls/ShortUrlsFilteringBar.tsx
+++ b/src/short-urls/ShortUrlsFilteringBar.tsx
@@ -8,6 +8,7 @@ import { useCallback, useState } from 'react';
 import { Button, InputGroup, Row, UncontrolledTooltip } from 'reactstrap';
 import type { FCWithDeps } from '../container/utils';
 import { componentFactory, useDependencies } from '../container/utils';
+import type { DomainsList } from '../domains/reducers/domainsList';
 import { useSetting } from '../settings';
 import type { TagsSelectorProps } from '../tags/helpers/TagsSelector';
 import type { TagsList } from '../tags/reducers/tagsList';
@@ -31,6 +32,7 @@ export type ShortUrlsFilteringBarProps = {
 
 type ShortUrlsFilteringConnectProps = ShortUrlsFilteringBarProps & {
   tagsList: TagsList;
+  domainsList: DomainsList;
 };
 
 type ShortUrlsFilteringBarDeps = {
@@ -39,7 +41,7 @@ type ShortUrlsFilteringBarDeps = {
 };
 
 const ShortUrlsFilteringBar: FCWithDeps<ShortUrlsFilteringConnectProps, ShortUrlsFilteringBarDeps> = (
-  { className, shortUrlsAmount, order, handleOrderBy, tagsList },
+  { className, shortUrlsAmount, order, handleOrderBy, tagsList, domainsList },
 ) => {
   const { ExportShortUrlsBtn, TagsSelector } = useDependencies(ShortUrlsFilteringBar);
   const [{
@@ -50,6 +52,7 @@ const ShortUrlsFilteringBar: FCWithDeps<ShortUrlsFilteringConnectProps, ShortUrl
     excludeBots,
     excludeMaxVisitsReached,
     excludePastValidUntil,
+    domain,
     tagsMode = 'any',
   }, toFirstPage] = useShortUrlsQuery();
   const visitsSettings = useSetting('visits');
@@ -115,8 +118,10 @@ const ShortUrlsFilteringBar: FCWithDeps<ShortUrlsFilteringConnectProps, ShortUrl
                 excludeBots: excludeBots ?? visitsSettings?.excludeBots,
                 excludeMaxVisitsReached,
                 excludePastValidUntil,
+                domain,
               }}
               onChange={toFirstPage}
+              domains={domainsList.loading ? undefined : domainsList.domains}
             />
           </div>
         </div>

--- a/src/short-urls/ShortUrlsList.tsx
+++ b/src/short-urls/ShortUrlsList.tsx
@@ -57,6 +57,7 @@ const ShortUrlsList: FCWithDeps<ShortUrlsListProps, ShortUrlsListDeps> = boundTo
     excludeBots,
     excludePastValidUntil,
     excludeMaxVisitsReached,
+    domain,
   }, toFirstPage] = useShortUrlsQuery();
   const settings = useSettings();
   const [actualOrderBy, setActualOrderBy] = useState(
@@ -101,6 +102,7 @@ const ShortUrlsList: FCWithDeps<ShortUrlsListProps, ShortUrlsListDeps> = boundTo
       tagsMode,
       excludePastValidUntil,
       excludeMaxVisitsReached,
+      domain,
     });
   }, [
     listShortUrls,
@@ -114,6 +116,7 @@ const ShortUrlsList: FCWithDeps<ShortUrlsListProps, ShortUrlsListDeps> = boundTo
     tagsMode,
     excludePastValidUntil,
     excludeMaxVisitsReached,
+    domain,
   ]);
 
   return (

--- a/src/short-urls/data/index.ts
+++ b/src/short-urls/data/index.ts
@@ -39,4 +39,5 @@ export type ShortUrlsFilter = {
   excludeBots?: boolean;
   excludeMaxVisitsReached?: boolean;
   excludePastValidUntil?: boolean;
+  domain?: string;
 };

--- a/src/short-urls/helpers/ShortUrlsFilterDropdown.tsx
+++ b/src/short-urls/helpers/ShortUrlsFilterDropdown.tsx
@@ -1,17 +1,18 @@
 import { DropdownBtn } from '@shlinkio/shlink-frontend-kit';
 import { DropdownItem } from 'reactstrap';
+import { useFeature } from '../../utils/features';
 import type { ShortUrlsFilter } from '../data';
 
 interface ShortUrlsFilterDropdownProps {
   onChange: (filters: ShortUrlsFilter) => void;
-  supportsDisabledFiltering: boolean;
   selected?: ShortUrlsFilter;
   className?: string;
 }
 
 export const ShortUrlsFilterDropdown = (
-  { onChange, selected = {}, className, supportsDisabledFiltering }: ShortUrlsFilterDropdownProps,
+  { onChange, selected = {}, className }: ShortUrlsFilterDropdownProps,
 ) => {
+  const supportsDisabledFiltering = useFeature('filterDisabledUrls');
   const { excludeBots = false, excludeMaxVisitsReached = false, excludePastValidUntil = false } = selected;
   const onFilterClick = (key: keyof ShortUrlsFilter) => () => onChange({ ...selected, [key]: !selected?.[key] });
 

--- a/src/short-urls/helpers/ShortUrlsFilterDropdown.tsx
+++ b/src/short-urls/helpers/ShortUrlsFilterDropdown.tsx
@@ -88,8 +88,9 @@ export const ShortUrlsFilterDropdown = (
           excludePastValidUntil: undefined,
           domain: undefined,
         })}
+        className="fst-italic"
       >
-        <i>Reset to defaults</i>
+        Reset to defaults
       </DropdownItem>
     </DropdownBtn>
   );

--- a/src/short-urls/helpers/ShortUrlsFilterDropdown.tsx
+++ b/src/short-urls/helpers/ShortUrlsFilterDropdown.tsx
@@ -2,8 +2,8 @@ import { DropdownBtn } from '@shlinkio/shlink-frontend-kit';
 import { useCallback } from 'react';
 import { DropdownItem } from 'reactstrap';
 import type { Domain } from '../../domains/data';
+import { DEFAULT_DOMAIN } from '../../domains/data';
 import { useFeature } from '../../utils/features';
-import { DEFAULT_DOMAIN } from '../../visits/reducers/domainVisits';
 import type { ShortUrlsFilter } from '../data';
 
 interface ShortUrlsFilterDropdownProps {

--- a/src/short-urls/helpers/ShortUrlsFilterDropdown.tsx
+++ b/src/short-urls/helpers/ShortUrlsFilterDropdown.tsx
@@ -1,36 +1,76 @@
 import { DropdownBtn } from '@shlinkio/shlink-frontend-kit';
+import { useCallback } from 'react';
 import { DropdownItem } from 'reactstrap';
+import type { Domain } from '../../domains/data';
 import { useFeature } from '../../utils/features';
+import { DEFAULT_DOMAIN } from '../../visits/reducers/domainVisits';
 import type { ShortUrlsFilter } from '../data';
 
 interface ShortUrlsFilterDropdownProps {
   onChange: (filters: ShortUrlsFilter) => void;
   selected?: ShortUrlsFilter;
   className?: string;
+  /**
+   * List of domains supported by the Shlink server.
+   * It is `undefined` while the domains are being loaded.
+   */
+  domains?: Domain[];
 }
 
 export const ShortUrlsFilterDropdown = (
-  { onChange, selected = {}, className }: ShortUrlsFilterDropdownProps,
+  { onChange, selected = {}, className, domains }: ShortUrlsFilterDropdownProps,
 ) => {
   const supportsDisabledFiltering = useFeature('filterDisabledUrls');
-  const { excludeBots = false, excludeMaxVisitsReached = false, excludePastValidUntil = false } = selected;
-  const onFilterClick = (key: keyof ShortUrlsFilter) => () => onChange({ ...selected, [key]: !selected?.[key] });
+  const supportsFilterByDomain = useFeature('filterShortUrlsByDomain');
+  const { excludeBots = false, excludeMaxVisitsReached = false, excludePastValidUntil = false, domain } = selected;
+
+  const partialUpdate = useCallback(
+    (update: Partial<ShortUrlsFilter>) => onChange({ ...selected, ...update }),
+    [onChange, selected],
+  );
+  const toggleFilter = useCallback(
+    (key: keyof ShortUrlsFilter) => partialUpdate({ [key]: !selected?.[key] }),
+    [partialUpdate, selected],
+  );
 
   return (
     <DropdownBtn text="Filters" dropdownClassName={className} end minWidth={250}>
       <DropdownItem header aria-hidden>Visits:</DropdownItem>
-      <DropdownItem active={excludeBots} onClick={onFilterClick('excludeBots')}>Ignore visits from bots</DropdownItem>
+      <DropdownItem active={excludeBots} onClick={() => toggleFilter('excludeBots')}>
+        Ignore visits from bots
+      </DropdownItem>
 
       {supportsDisabledFiltering && (
         <>
           <DropdownItem divider tag="hr" />
           <DropdownItem header aria-hidden>Short URLs:</DropdownItem>
-          <DropdownItem active={excludeMaxVisitsReached} onClick={onFilterClick('excludeMaxVisitsReached')}>
+          <DropdownItem active={excludeMaxVisitsReached} onClick={() => toggleFilter('excludeMaxVisitsReached')}>
             Exclude with visits reached
           </DropdownItem>
-          <DropdownItem active={excludePastValidUntil} onClick={onFilterClick('excludePastValidUntil')}>
+          <DropdownItem active={excludePastValidUntil} onClick={() => toggleFilter('excludePastValidUntil')}>
             Exclude enabled in the past
           </DropdownItem>
+        </>
+      )}
+
+      {supportsFilterByDomain && (
+        <>
+          <DropdownItem divider tag="hr"/>
+          <DropdownItem header aria-hidden>Domain: {!domains && <i>loading...</i>}</DropdownItem>
+          {domains?.map((d) => {
+            const value = d.isDefault ? DEFAULT_DOMAIN : d.domain;
+            const isSelected = domain === value;
+
+            return (
+              <DropdownItem
+                key={d.domain}
+                active={isSelected}
+                onClick={() => partialUpdate({ domain: isSelected ? undefined : value })}
+              >
+                {d.domain}
+              </DropdownItem>
+            );
+          })}
         </>
       )}
 
@@ -40,10 +80,14 @@ export const ShortUrlsFilterDropdown = (
           selected.excludeBots === undefined
           && selected.excludeMaxVisitsReached === undefined
           && selected.excludePastValidUntil === undefined
+          && selected.domain === undefined
         }
-        onClick={() => onChange(
-          { excludeBots: undefined, excludeMaxVisitsReached: undefined, excludePastValidUntil: undefined },
-        )}
+        onClick={() => onChange({
+          excludeBots: undefined,
+          excludeMaxVisitsReached: undefined,
+          excludePastValidUntil: undefined,
+          domain: undefined,
+        })}
       >
         <i>Reset to defaults</i>
       </DropdownItem>

--- a/src/short-urls/helpers/hooks.ts
+++ b/src/short-urls/helpers/hooks.ts
@@ -21,6 +21,7 @@ type ShortUrlsRawQuery = Record<string, unknown> & ShortUrlsQueryCommon & {
   excludeBots?: BooleanString;
   excludeMaxVisitsReached?: BooleanString;
   excludePastValidUntil?: BooleanString;
+  domain?: string;
 };
 
 type ShortUrlsQuery = ShortUrlsQueryCommon & {
@@ -29,6 +30,7 @@ type ShortUrlsQuery = ShortUrlsQueryCommon & {
   excludeBots?: boolean;
   excludeMaxVisitsReached?: boolean;
   excludePastValidUntil?: boolean;
+  domain?: string;
 };
 
 type ToFirstPage = (extra: Partial<ShortUrlsQuery>) => void;

--- a/src/short-urls/helpers/index.ts
+++ b/src/short-urls/helpers/index.ts
@@ -1,7 +1,7 @@
 import type { ShlinkCreateShortUrlData, ShlinkShortUrl } from '../../api-contract';
+import { DEFAULT_DOMAIN } from '../../domains/data';
 import type { ShortUrlCreationSettings } from '../../settings';
 import type { OptionalString } from '../../utils/helpers';
-import { DEFAULT_DOMAIN } from '../../visits/reducers/domainVisits';
 import type { ShortUrlIdentifier } from '../data';
 
 export const shortUrlMatches = (shortUrl: ShlinkShortUrl, shortCode: string, domain: OptionalString): boolean => {

--- a/src/short-urls/services/provideServices.ts
+++ b/src/short-urls/services/provideServices.ts
@@ -55,7 +55,7 @@ export const provideServices = (bottle: Bottle, connect: ConnectDecorator) => {
   bottle.factory('ExportShortUrlsBtn', ExportShortUrlsBtnFactory);
 
   bottle.factory('ShortUrlsFilteringBar', ShortUrlsFilteringBarFactory);
-  bottle.decorator('ShortUrlsFilteringBar', connect(['tagsList']));
+  bottle.decorator('ShortUrlsFilteringBar', connect(['tagsList', 'domainsList']));
 
   // Reducers
   bottle.serviceFactory(

--- a/src/utils/features.ts
+++ b/src/utils/features.ts
@@ -13,6 +13,7 @@ const supportedFeatures = {
   urlValidation: { maxVersion: '3.*.*' },
   ipRedirectCondition: { minVersion: '4.2.0' },
   geolocationRedirectCondition: { minVersion: '4.3.0' },
+  filterShortUrlsByDomain: { minVersion: '4.3.0' },
 } as const satisfies Record<string, Versions>;
 
 Object.freeze(supportedFeatures);
@@ -35,6 +36,7 @@ const getFeaturesForVersion = (serverVersion: SemVerOrLatest): Record<Feature, b
   urlValidation: isFeatureEnabledForVersion('urlValidation', serverVersion),
   ipRedirectCondition: isFeatureEnabledForVersion('ipRedirectCondition', serverVersion),
   geolocationRedirectCondition: isFeatureEnabledForVersion('geolocationRedirectCondition', serverVersion),
+  filterShortUrlsByDomain: isFeatureEnabledForVersion('filterShortUrlsByDomain', serverVersion),
 });
 
 const FeaturesContext = createContext(getFeaturesForVersion('0.0.0'));

--- a/src/visits/reducers/domainVisits.ts
+++ b/src/visits/reducers/domainVisits.ts
@@ -6,6 +6,7 @@ import type { LoadVisits, VisitsInfo } from './types';
 
 const REDUCER_PREFIX = 'shlink/domainVisits';
 
+// TODO Move to a generic module
 export const DEFAULT_DOMAIN = 'DEFAULT';
 
 interface WithDomain {

--- a/src/visits/reducers/domainVisits.ts
+++ b/src/visits/reducers/domainVisits.ts
@@ -6,9 +6,6 @@ import type { LoadVisits, VisitsInfo } from './types';
 
 const REDUCER_PREFIX = 'shlink/domainVisits';
 
-// TODO Move to a generic module
-export const DEFAULT_DOMAIN = 'DEFAULT';
-
 interface WithDomain {
   domain: string;
 }

--- a/test/short-urls/ShortUrlsFilteringBar.test.tsx
+++ b/test/short-urls/ShortUrlsFilteringBar.test.tsx
@@ -32,7 +32,12 @@ describe('<ShortUrlsFilteringBar />', () => {
         <SettingsProvider value={fromPartial({ visits: {} })}>
           <FeaturesProvider value={fromPartial({ filterDisabledUrls: true })}>
             <RoutesPrefixProvider value={routesPrefix}>
-              <ShortUrlsFilteringBar order={{}} handleOrderBy={handleOrderBy} tagsList={fromPartial({ tags: [] })} />
+              <ShortUrlsFilteringBar
+                order={{}}
+                handleOrderBy={handleOrderBy}
+                tagsList={fromPartial({ tags: [] })}
+                domainsList={fromPartial({})}
+              />
             </RoutesPrefixProvider>
           </FeaturesProvider>
         </SettingsProvider>

--- a/test/short-urls/helpers/ShortUrlsFilterDropdown.test.tsx
+++ b/test/short-urls/helpers/ShortUrlsFilterDropdown.test.tsx
@@ -1,12 +1,16 @@
 import { screen, waitFor } from '@testing-library/react';
 import type { UserEvent } from '@testing-library/user-event';
+import { fromPartial } from '@total-typescript/shoehorn';
 import { ShortUrlsFilterDropdown } from '../../../src/short-urls/helpers/ShortUrlsFilterDropdown';
+import { FeaturesProvider } from '../../../src/utils/features';
 import { checkAccessibility } from '../../__helpers__/accessibility';
 import { renderWithEvents } from '../../__helpers__/setUpTest';
 
 describe('<ShortUrlsFilterDropdown />', () => {
   const setUp = (supportsDisabledFiltering: boolean) => renderWithEvents(
-    <ShortUrlsFilterDropdown onChange={vi.fn()} supportsDisabledFiltering={supportsDisabledFiltering} />,
+    <FeaturesProvider value={fromPartial({ filterDisabledUrls: supportsDisabledFiltering })}>
+      <ShortUrlsFilterDropdown onChange={vi.fn()} />
+    </FeaturesProvider>,
   );
   const openMenu = (user: UserEvent) => user.click(screen.getByRole('button', { name: 'Filters' }));
 

--- a/test/short-urls/helpers/ShortUrlsFilterDropdown.test.tsx
+++ b/test/short-urls/helpers/ShortUrlsFilterDropdown.test.tsx
@@ -2,10 +2,10 @@ import { screen, waitFor } from '@testing-library/react';
 import type { UserEvent } from '@testing-library/user-event';
 import { fromPartial } from '@total-typescript/shoehorn';
 import type { Domain } from '../../../src/domains/data';
+import { DEFAULT_DOMAIN } from '../../../src/domains/data';
 import type { ShortUrlsFilter } from '../../../src/short-urls/data';
 import { ShortUrlsFilterDropdown } from '../../../src/short-urls/helpers/ShortUrlsFilterDropdown';
 import { FeaturesProvider } from '../../../src/utils/features';
-import { DEFAULT_DOMAIN } from '../../../src/visits/reducers/domainVisits';
 import { checkAccessibility } from '../../__helpers__/accessibility';
 import { renderWithEvents } from '../../__helpers__/setUpTest';
 

--- a/test/short-urls/helpers/ShortUrlsFilterDropdown.test.tsx
+++ b/test/short-urls/helpers/ShortUrlsFilterDropdown.test.tsx
@@ -1,39 +1,99 @@
 import { screen, waitFor } from '@testing-library/react';
 import type { UserEvent } from '@testing-library/user-event';
 import { fromPartial } from '@total-typescript/shoehorn';
+import type { Domain } from '../../../src/domains/data';
+import type { ShortUrlsFilter } from '../../../src/short-urls/data';
 import { ShortUrlsFilterDropdown } from '../../../src/short-urls/helpers/ShortUrlsFilterDropdown';
 import { FeaturesProvider } from '../../../src/utils/features';
+import { DEFAULT_DOMAIN } from '../../../src/visits/reducers/domainVisits';
 import { checkAccessibility } from '../../__helpers__/accessibility';
 import { renderWithEvents } from '../../__helpers__/setUpTest';
 
+type SetUpOptions = {
+  filterDisabledUrls?: boolean;
+  filterShortUrlsByDomain?: boolean;
+  selected?: ShortUrlsFilter;
+};
+
 describe('<ShortUrlsFilterDropdown />', () => {
-  const setUp = (supportsDisabledFiltering: boolean) => renderWithEvents(
-    <FeaturesProvider value={fromPartial({ filterDisabledUrls: supportsDisabledFiltering })}>
-      <ShortUrlsFilterDropdown onChange={vi.fn()} />
+  const domains: Domain[] = [
+    fromPartial({ domain: 's.test', isDefault: true }),
+    fromPartial({ domain: 's2.test', isDefault: false }),
+    fromPartial({ domain: 's3.test', isDefault: false }),
+  ] as const;
+  const onChange = vi.fn();
+  const setUp = ({
+    filterDisabledUrls = false,
+    filterShortUrlsByDomain = false,
+    selected,
+  }: SetUpOptions = {}) => renderWithEvents(
+    <FeaturesProvider value={fromPartial({ filterDisabledUrls, filterShortUrlsByDomain })}>
+      <ShortUrlsFilterDropdown onChange={onChange} domains={domains} selected={selected} />
     </FeaturesProvider>,
   );
   const openMenu = (user: UserEvent) => user.click(screen.getByRole('button', { name: 'Filters' }));
 
-  it.each([
-    [() => setUp(true)],
-    // TODO Enable back once https://github.com/reactstrap/reactstrap/issues/2759 is fixed
-    // [async () => {
-    //   const { user, container } = setUp(true);
-    //   await openMenu(user);
-    //
-    //   return { container };
-    // }],
-  ])('passes a11y checks', (setUp) => checkAccessibility(setUp()));
-
-  it.each([
-    [true, 3],
-    [false, 1],
-  ])('displays proper amount of menu items', async (supportsDisabledFiltering, expectedItems) => {
-    const { user } = setUp(supportsDisabledFiltering);
+  const setUpOpened = async (options?: SetUpOptions) => {
+    const { user, ...rest } = setUp(options);
 
     await openMenu(user);
     await waitFor(() => expect(screen.getByRole('menu')).toBeInTheDocument());
 
+    return { user, ...rest };
+  };
+
+  it.each([
+    [() => setUp({ filterDisabledUrls: true })],
+    [() => setUp({ filterShortUrlsByDomain: true })],
+    [() => setUp({ filterDisabledUrls: true, filterShortUrlsByDomain: true })],
+    // TODO Enable back once https://github.com/reactstrap/reactstrap/issues/2759 is fixed
+    // [() => setUpOpened({ filterDisabledUrls: true, filterShortUrlsByDomain: true })],
+  ])('passes a11y checks', (setUp) => checkAccessibility(setUp()));
+
+  it.each([
+    { filterDisabledUrls: false, filterShortUrlsByDomain: false, expectedItems: 1 },
+    { filterDisabledUrls: true, filterShortUrlsByDomain: false, expectedItems: 3 },
+    { filterDisabledUrls: true, filterShortUrlsByDomain: true, expectedItems: 3 + domains.length },
+  ])('displays proper amount of menu items', async ({ filterDisabledUrls, filterShortUrlsByDomain, expectedItems }) => {
+    await setUpOpened({ filterDisabledUrls, filterShortUrlsByDomain });
     expect(screen.getAllByRole('menuitem')).toHaveLength(expectedItems);
+  });
+
+  it.each([
+    { domain: DEFAULT_DOMAIN, expectedSelectedIndex: 0 },
+    { domain: domains[1].domain, expectedSelectedIndex: 1 },
+    { domain: domains[2].domain, expectedSelectedIndex: 2 },
+  ])('selects the right domain', async ({ domain, expectedSelectedIndex }) => {
+    await setUpOpened({
+      filterShortUrlsByDomain: true,
+      selected: { domain },
+    });
+
+    const menuItems = screen.getAllByRole('menuitem');
+    menuItems.forEach((menuItem, index) => {
+      // Add one to expected index, as there's one item rendered before the domains
+      if (index === expectedSelectedIndex + 1) {
+        expect(menuItem).toHaveClass('active');
+      } else {
+        expect(menuItem).not.toHaveClass('active');
+      }
+    });
+  });
+
+  it.each([
+    { clickedDomain: domains[0].domain, expectedDomain: DEFAULT_DOMAIN },
+    { clickedDomain: domains[1].domain, expectedDomain: undefined }, // Selected one. Will be deselected
+    { clickedDomain: domains[2].domain, expectedDomain: domains[2].domain },
+  ])('selects or deselects a domain when clicked', async ({ clickedDomain, expectedDomain }) => {
+    const { user } = await setUpOpened({
+      filterShortUrlsByDomain: true,
+      selected: { domain: domains[1].domain },
+    });
+
+    await user.click(screen.getByText(clickedDomain));
+
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({
+      domain: expectedDomain,
+    }));
   });
 });

--- a/test/short-urls/helpers/ShortUrlsFilterDropdown.test.tsx
+++ b/test/short-urls/helpers/ShortUrlsFilterDropdown.test.tsx
@@ -60,6 +60,44 @@ describe('<ShortUrlsFilterDropdown />', () => {
   });
 
   it.each([
+    {
+      clickedItem: 'Ignore visits from bots',
+      selected: {},
+      expectedSelection: { excludeBots: true },
+    },
+    {
+      clickedItem: 'Ignore visits from bots',
+      selected: { excludeBots: true },
+      expectedSelection: { excludeBots: false },
+    },
+    {
+      clickedItem: 'Exclude with visits reached',
+      selected: {},
+      expectedSelection: { excludeMaxVisitsReached: true },
+    },
+    {
+      clickedItem: 'Exclude with visits reached',
+      selected: { excludeMaxVisitsReached: true },
+      expectedSelection: { excludeMaxVisitsReached: false },
+    },
+    {
+      clickedItem: 'Exclude enabled in the past',
+      selected: {},
+      expectedSelection: { excludePastValidUntil: true },
+    },
+    {
+      clickedItem: 'Exclude enabled in the past',
+      selected: { excludePastValidUntil: true },
+      expectedSelection: { excludePastValidUntil: false },
+    },
+  ])('selects proper filters when options are clicked', async ({ clickedItem, selected, expectedSelection }) => {
+    const { user } = await setUpOpened({ filterDisabledUrls: true, selected });
+
+    await user.click(screen.getByText(clickedItem));
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining(expectedSelection));
+  });
+
+  it.each([
     { domain: DEFAULT_DOMAIN, expectedSelectedIndex: 0 },
     { domain: domains[1].domain, expectedSelectedIndex: 1 },
     { domain: domains[2].domain, expectedSelectedIndex: 2 },
@@ -95,5 +133,24 @@ describe('<ShortUrlsFilterDropdown />', () => {
     expect(onChange).toHaveBeenCalledWith(expect.objectContaining({
       domain: expectedDomain,
     }));
+  });
+
+  it('disables reset button when no selection is set', async () => {
+    await setUpOpened();
+    expect(screen.getByText('Reset to defaults')).toBeDisabled();
+  });
+
+  it('resets selection when rest button is clicked', async () => {
+    const { user } = await setUpOpened({
+      selected: { excludeBots: true },
+    });
+
+    await user.click(screen.getByText('Reset to defaults'));
+    expect(onChange).toHaveBeenCalledWith({
+      excludeBots: undefined,
+      excludeMaxVisitsReached: undefined,
+      excludePastValidUntil: undefined,
+      domain: undefined,
+    });
   });
 });

--- a/test/short-urls/helpers/index.test.ts
+++ b/test/short-urls/helpers/index.test.ts
@@ -1,5 +1,6 @@
 import { fromPartial } from '@total-typescript/shoehorn';
 import type { ShlinkShortUrl } from '../../../src/api-contract';
+import { DEFAULT_DOMAIN } from '../../../src/domains/data';
 import {
   queryToShortUrl,
   shortUrlDataFromShortUrl,
@@ -7,7 +8,6 @@ import {
   urlDecodeShortCode,
   urlEncodeShortCode,
 } from '../../../src/short-urls/helpers';
-import { DEFAULT_DOMAIN } from '../../../src/visits/reducers/domainVisits';
 
 describe('helpers', () => {
   describe('shortUrlDataFromShortUrl', () => {

--- a/test/visits/reducers/domainVisits.test.ts
+++ b/test/visits/reducers/domainVisits.test.ts
@@ -2,12 +2,12 @@ import { fromPartial } from '@total-typescript/shoehorn';
 import { addDays, formatISO, subDays } from 'date-fns';
 import type { ShlinkApiClient, ShlinkShortUrl, ShlinkVisit, ShlinkVisitsList } from '../../../src/api-contract';
 import type { RootState } from '../../../src/container/store';
+import { DEFAULT_DOMAIN } from '../../../src/domains/data';
 import { formatIsoDate } from '../../../src/utils/dates/helpers/date';
 import type { DateInterval } from '../../../src/utils/dates/helpers/dateIntervals';
 import { rangeOf } from '../../../src/utils/helpers';
 import type { DomainVisits, LoadDomainVisits } from '../../../src/visits/reducers/domainVisits';
 import {
-  DEFAULT_DOMAIN,
   domainVisitsReducerCreator,
   getDomainVisits as getDomainVisitsCreator,
 } from '../../../src/visits/reducers/domainVisits';

--- a/test/visits/visits-comparison/ShortUrlVisitsComparison.test.tsx
+++ b/test/visits/visits-comparison/ShortUrlVisitsComparison.test.tsx
@@ -1,10 +1,10 @@
 import { cleanup, render, screen } from '@testing-library/react';
 import { fromPartial } from '@total-typescript/shoehorn';
 import { MemoryRouter } from 'react-router-dom';
+import { DEFAULT_DOMAIN } from '../../../src/domains/data';
 import type { MercureInfo } from '../../../src/mercure/reducers/mercureInfo';
 import type { ShortUrlIdentifier } from '../../../src/short-urls/data';
 import { queryToShortUrl, shortUrlToQuery } from '../../../src/short-urls/helpers';
-import { DEFAULT_DOMAIN } from '../../../src/visits/reducers/domainVisits';
 import { ShortUrlVisitsComparison } from '../../../src/visits/visits-comparison/ShortUrlVisitsComparison';
 import { checkAccessibility } from '../../__helpers__/accessibility';
 


### PR DESCRIPTION
Closes #514 

Add the list of domains to the short URLs filters, so that it is possible to filter by one of them.

![Captura desde 2024-11-27 08-55-33](https://github.com/user-attachments/assets/e83b74f1-e4a4-4ef7-bc87-384bc0e8720b)

Domains are displayed there only if Shlink 4.3 is consumed.