### PR TITLE
When short URLs are created with new domains, add them to store

### DIFF
--- a/src/domains/reducers/domainRedirects.ts
+++ b/src/domains/reducers/domainRedirects.ts
@@ -18,3 +18,5 @@ export const editDomainRedirects = (
     return { domain, redirects };
   },
 );
+
+export type EditDomainRedirectsThunk = ReturnType<typeof editDomainRedirects>;

--- a/src/domains/services/provideServices.ts
+++ b/src/domains/services/provideServices.ts
@@ -17,6 +17,7 @@ export const provideServices = (bottle: Bottle, connect: ConnectDecorator) => {
     domainsListReducerCreator,
     'apiClientFactory',
     'editDomainRedirects',
+    'createShortUrl',
   );
   bottle.serviceFactory('domainsListReducer', (obj) => obj.reducer, 'domainsListReducerCreator');
 

--- a/src/short-urls/reducers/shortUrlCreation.ts
+++ b/src/short-urls/reducers/shortUrlCreation.ts
@@ -36,7 +36,9 @@ export const createShortUrl = (apiClientFactory: () => ShlinkApiClient) => creat
   (data: ShlinkCreateShortUrlData): Promise<ShlinkShortUrl> => apiClientFactory().createShortUrl(data),
 );
 
-export const shortUrlCreationReducerCreator = (createShortUrlThunk: ReturnType<typeof createShortUrl>) => {
+export type CreateShortUrlThunk = ReturnType<typeof createShortUrl>;
+
+export const shortUrlCreationReducerCreator = (createShortUrlThunk: CreateShortUrlThunk) => {
   const { reducer, actions } = createSlice({
     name: REDUCER_PREFIX,
     initialState: initialState as ShortUrlCreation, // Without this casting it infers type ShortUrlCreationWaiting


### PR DESCRIPTION
Closes #517 

Up until now, domains were loaded once when the app loaded, and never updated again.

This PR makes sure that, when a short URL is created with a new domain, that domain is pushed to the list.