### PR TITLE
Allow redirecting from domains to short URLs filtered by domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * [#491](https://github.com/shlinkio/shlink-web-component/issues/491) Add support for colors in QR code configurator.
 * [#515](https://github.com/shlinkio/shlink-web-component/issues/515) Add support for geolocation redirect conditions, when using Shlink 4.3 or newer.
 * [#514](https://github.com/shlinkio/shlink-web-component/issues/514) Allow filtering short URLs list by domain, when using Shlink 4.3 or newer.
+* [#520](https://github.com/shlinkio/shlink-web-component/issues/520) Allow navigating from domains list to short URLs list filtered by one domain, when using Shlink 4.3 or newer.
+* [#517](https://github.com/shlinkio/shlink-web-component/issues/517) Update list of known domains when a short URL is created with a new domain.
 
 ### Changed
 * *Nothing*

--- a/src/domains/helpers/DomainDropdown.tsx
+++ b/src/domains/helpers/DomainDropdown.tsx
@@ -2,12 +2,14 @@ import {
   faChartLine as lineChartIcon,
   faChartPie as pieChartIcon,
   faEdit as editIcon,
+  faList as listIcon,
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { RowDropdownBtn, useToggle } from '@shlinkio/shlink-frontend-kit';
 import type { FC } from 'react';
 import { Link } from 'react-router-dom';
 import { DropdownItem } from 'reactstrap';
+import { useFeature } from '../../utils/features';
 import { useRoutesPrefix } from '../../utils/routesPrefix';
 import { useVisitsComparisonContext } from '../../visits/visits-comparison/VisitsComparisonContext';
 import type { Domain } from '../data';
@@ -24,6 +26,7 @@ export const DomainDropdown: FC<DomainDropdownProps> = ({ domain, editDomainRedi
   const [isModalOpen, toggleModal] = useToggle();
   const routesPrefix = useRoutesPrefix();
   const visitsComparison = useVisitsComparisonContext();
+  const canFilterShortUrlsByDomain = useFeature('filterShortUrlsByDomain');
 
   return (
     <RowDropdownBtn>
@@ -43,10 +46,18 @@ export const DomainDropdown: FC<DomainDropdownProps> = ({ domain, editDomainRedi
         <FontAwesomeIcon icon={lineChartIcon} fixedWidth /> Compare visits
       </DropdownItem>
 
-      <DropdownItem divider tag="hr" />
+      {canFilterShortUrlsByDomain && (
+        <DropdownItem
+          tag={Link}
+          to={`${routesPrefix}/list-short-urls/1?domain=${domain.isDefault ? DEFAULT_DOMAIN : domain.domain}`}
+        >
+          <FontAwesomeIcon icon={listIcon} fixedWidth /> Short URLs
+        </DropdownItem>
+      )}
 
+      <DropdownItem divider tag="hr" />
       <DropdownItem onClick={toggleModal}>
-        <FontAwesomeIcon fixedWidth icon={editIcon} /> Edit redirects
+        <FontAwesomeIcon icon={editIcon} fixedWidth /> Edit redirects
       </DropdownItem>
 
       <EditDomainRedirectsModal

--- a/test/domains/helpers/DomainDropdown.test.tsx
+++ b/test/domains/helpers/DomainDropdown.test.tsx
@@ -63,6 +63,8 @@ describe('<DomainDropdown />', () => {
     expect(screen.getByText('Edit redirects')).toBeInTheDocument();
     if (filterShortUrlsByDomain) {
       expect(screen.getByText('Short URLs')).toBeInTheDocument();
+    } else {
+      expect(screen.queryByText('Short URLs')).not.toBeInTheDocument();
     }
   });
 


### PR DESCRIPTION
Closes #520 

Add a new option to the domain menu in the list of domains, which allows to navigate to the short URLs list filtering by that particular domain.

The option is displayed only if the Shlink server supports filtering short URLs by domain (>=4.3).