### PR TITLE
Update to react-router 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [0.12.0] - 2024-12-05
+### Added
+* *Nothing*
+
+### Changed
+* Update to react-router 7.
+
+### Deprecated
+* *Nothing*
+
+### Removed
+* Remove support for react-router 6.
+
+### Fixed
+* *Nothing*
+
+
 ## [0.11.0] - 2024-11-30
 ### Added
 * [#491](https://github.com/shlinkio/shlink-web-component/issues/491) Add support for colors in QR code configurator.

--- a/README.md
+++ b/README.md
@@ -81,13 +81,13 @@ export function App() {
 
 ### Routes prefix
 
-Sections are handled via client-side routing with `react-router-dom`. `ShlinkWebComponent` will add its own `<BrowserRouter />` unless already rendered inside a router.
+Sections are handled via client-side routing with `react-router`. `ShlinkWebComponent` will add its own `<BrowserRouter />` unless already rendered inside a router.
 
 If you render it inside a router, make sure you pass the prefix for all routes handled by this component.
 
 ```tsx
 import { ShlinkWebComponent } from '@shlinkio/shlink-web-component';
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { BrowserRouter, Routes, Route } from 'react-router';
 
 export function App() {
   return (

--- a/dev/App.tsx
+++ b/dev/App.tsx
@@ -3,7 +3,7 @@ import { FetchHttpClient } from '@shlinkio/shlink-js-sdk/browser';
 import type { FC } from 'react';
 import { useCallback } from 'react';
 import { useEffect, useMemo, useState } from 'react';
-import { BrowserRouter, Link, Route, Routes } from 'react-router-dom';
+import { BrowserRouter, Link, Navigate, Route, Routes } from 'react-router';
 import { ShlinkWebComponent } from '../src';
 import type { Settings } from '../src/settings';
 import { ShlinkWebSettings } from '../src/settings';
@@ -50,18 +50,21 @@ export const App: FC = () => {
       </header>
       <div className="wrapper">
         <Routes>
-          <Route
-            path="/settings/*"
-            element={(
-              <div className="container pt-4">
-                <ShlinkWebSettings
-                  settings={settings}
-                  updateSettings={setSettings}
-                  defaultShortUrlsListOrdering={{}}
-                />
-              </div>
-            )}
-          />
+          <Route path="/settings">
+            <Route
+              path="*"
+              element={(
+                <div className="container pt-4">
+                  <ShlinkWebSettings
+                    settings={settings}
+                    updateSettings={setSettings}
+                    defaultShortUrlsListOrdering={{}}
+                  />
+                </div>
+              )}
+            />
+            <Route path="" element={<Navigate replace to="general" />} />
+          </Route>
           <Route
             path={routesPrefix ? `${routesPrefix}*` : '*'}
             element={apiClient && serverVersion ? (

--- a/package-lock.json
+++ b/package-lock.json
@@ -1214,9 +1214,9 @@
       }
     },
     "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
       "dev": true,
       "engines": {
         "node": ">=12"
@@ -5362,9 +5362,9 @@
       }
     },
     "node_modules/flat-cache": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.1.1.tgz",
-      "integrity": "sha512-/qM2b3LUIaIgviBQovTLvijfyOQXPtSRnRK26ksj2J7rzPIecePUIpJsZ4T02Qg+xiAEKIs5K8dsHEd+VaKa/Q==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+      "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
       "dev": true,
       "dependencies": {
         "flatted": "^3.2.9",
@@ -5372,7 +5372,7 @@
         "rimraf": "^3.0.2"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": "^10.12.0 || >=12.0.0"
       }
     },
     "node_modules/flatted": {
@@ -9466,12 +9466,12 @@
       "dev": true
     },
     "node_modules/stylelint/node_modules/file-entry-cache": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-7.0.1.tgz",
-      "integrity": "sha512-uLfFktPmRetVCbHe5UPuekWrQ6hENufnA46qEGbfACkK5drjTTdQYUragRgMjHldcbYG+nslUerqMPjbBSHXjQ==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-7.0.2.tgz",
+      "integrity": "sha512-TfW7/1iI4Cy7Y8L6iqNdZQVvdXn0f8B4QcIXmkIbtTIe/Okm/nSlHb4IwGzRVOd3WfSieCgvf5cMzEfySAIl0g==",
       "dev": true,
       "dependencies": {
-        "flat-cache": "^3.1.1"
+        "flat-cache": "^3.2.0"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -9552,15 +9552,15 @@
       }
     },
     "node_modules/table/node_modules/ajv": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
         "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -10448,9 +10448,9 @@
       }
     },
     "node_modules/wrap-ansi/node_modules/ansi-regex": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
       "dev": true,
       "engines": {
         "node": ">=12"

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,12 +63,12 @@
         "@fortawesome/free-solid-svg-icons": "^6.4.2",
         "@fortawesome/react-fontawesome": "^0.2.0",
         "@reduxjs/toolkit": "^2.0.1",
-        "@shlinkio/shlink-frontend-kit": "^0.6.0",
+        "@shlinkio/shlink-frontend-kit": "^0.7.0",
         "@shlinkio/shlink-js-sdk": "^1.3.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-redux": "^9.0.1",
-        "react-router-dom": "^6.20.1",
+        "react-router": "^7.0.2",
         "reactstrap": "^9.2.0"
       },
       "peerDependenciesMeta": {
@@ -1791,15 +1791,6 @@
         }
       }
     },
-    "node_modules/@remix-run/router": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.13.1.tgz",
-      "integrity": "sha512-so+DHzZKsoOcoXrILB4rqDkMDy7NLMErRdOxvzvOKb507YINKUP4Di+shbTZDhSE/pBZ+vr7XGIpcOO0VLSA+Q==",
-      "peer": true,
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@rollup/pluginutils": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.0.tgz",
@@ -2175,9 +2166,10 @@
       }
     },
     "node_modules/@shlinkio/shlink-frontend-kit": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@shlinkio/shlink-frontend-kit/-/shlink-frontend-kit-0.6.0.tgz",
-      "integrity": "sha512-nfROKrm9tLDRPzUIxFfl3oFe1MIV0zgjFHT/ImwyskALeh/WHQLXII5eVBI8sd/SaeJFLWJvQA8GPtvU/WBYRw==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@shlinkio/shlink-frontend-kit/-/shlink-frontend-kit-0.7.0.tgz",
+      "integrity": "sha512-FJyO71B+RCqoqEUT/KrySgJYhaA/33ddTm4UtQYw129TLrpXOSDAg7JCKNTHzL4yTwh17gXeOG7mi0YAiL6qng==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "clsx": "^2.1.1"
@@ -2188,7 +2180,7 @@
         "@fortawesome/react-fontawesome": "^0.2.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-router-dom": "^6.14.2",
+        "react-router": "^7.0.2",
         "reactstrap": "^9.2.0"
       }
     },
@@ -2427,6 +2419,13 @@
       "dependencies": {
         "@babel/types": "^7.20.7"
       }
+    },
+    "node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/d3-array": {
       "version": "3.2.1",
@@ -4148,6 +4147,16 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/cosmiconfig": {
       "version": "8.2.0",
@@ -7734,35 +7743,28 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.20.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.20.1.tgz",
-      "integrity": "sha512-ccvLrB4QeT5DlaxSFFYi/KR8UMQ4fcD8zBcR71Zp1kaYTC5oJKYAp1cbavzGrogwxca+ubjkd7XjFZKBW8CxPA==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.0.2.tgz",
+      "integrity": "sha512-m5AcPfTRUcjwmhBzOJGEl6Y7+Crqyju0+TgTQxoS4SO+BkWbhOrcfZNq6wSWdl2BBbJbsAoBUb8ZacOFT+/JlA==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@remix-run/router": "1.13.1"
+        "@types/cookie": "^0.6.0",
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0",
+        "turbo-stream": "2.4.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "6.20.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.20.1.tgz",
-      "integrity": "sha512-npzfPWcxfQN35psS7rJgi/EW0Gx6EsNjfdJSAk73U/HqMEJZ2k/8puxfwHFgDQhBGmS3+sjnGbMdMSV45axPQw==",
-      "peer": true,
-      "dependencies": {
-        "@remix-run/router": "1.13.1",
-        "react-router": "6.20.1"
+        "react": ">=18",
+        "react-dom": ">=18"
       },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-smooth": {
@@ -8236,6 +8238,13 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -9772,6 +9781,13 @@
       "peerDependencies": {
         "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
       }
+    },
+    "node_modules/turbo-stream": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.4.0.tgz",
+      "integrity": "sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g==",
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -46,12 +46,12 @@
     "@fortawesome/free-solid-svg-icons": "^6.4.2",
     "@fortawesome/react-fontawesome": "^0.2.0",
     "@reduxjs/toolkit": "^2.0.1",
-    "@shlinkio/shlink-frontend-kit": "^0.6.0",
+    "@shlinkio/shlink-frontend-kit": "^0.7.0",
     "@shlinkio/shlink-js-sdk": "^1.3.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-redux": "^9.0.1",
-    "react-router-dom": "^6.20.1",
+    "react-router": "^7.0.2",
     "reactstrap": "^9.2.0"
   },
   "peerDependenciesMeta": {

--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -4,7 +4,7 @@ import { useToggle } from '@shlinkio/shlink-frontend-kit';
 import { clsx } from 'clsx';
 import type { FC, ReactNode } from 'react';
 import { useEffect } from 'react';
-import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
+import { Navigate, Route, Routes, useLocation } from 'react-router';
 import { AsideMenu } from './common/AsideMenu';
 import type { FCWithDeps } from './container/utils';
 import { componentFactory, useDependencies } from './container/utils';
@@ -79,17 +79,27 @@ const Main: FCWithDeps<MainProps, MainDeps> = ({ createNotFound }) => {
                 <Route path="/overview" element={<Overview />} />
                 <Route path="/list-short-urls/:page" element={<ShortUrlsList />} />
                 <Route path="/create-short-url" element={<CreateShortUrl />} />
-                <Route path="/short-code/:shortCode/visits/*" element={<ShortUrlVisits />} />
+                <Route path="/short-code/:shortCode/visits">
+                  {['', '*'].map((path) => <Route key={path} path={path} element={<ShortUrlVisits />} />)}
+                </Route>
                 <Route path="/short-code/:shortCode/edit" element={<EditShortUrl />} />
                 {supportsRedirectRules && (
                   <Route path="/short-code/:shortCode/redirect-rules" element={<ShortUrlRedirectRules />} />
                 )}
                 <Route path="/short-urls/compare-visits" element={<ShortUrlVisitsComparison />} />
-                <Route path="/tag/:tag/visits/*" element={<TagVisits />} />
+                <Route path="/tag/:tag/visits">
+                  {['', '*'].map((path) => <Route key={path} path={path} element={<TagVisits />} />)}
+                </Route>
                 <Route path="/tags/compare-visits" element={<TagVisitsComparison />} />
-                <Route path="/domain/:domain/visits/*" element={<DomainVisits />} />
-                <Route path="/orphan-visits/*" element={<OrphanVisits />} />
-                <Route path="/non-orphan-visits/*" element={<NonOrphanVisits />} />
+                <Route path="/domain/:domain/visits">
+                  {['', '*'].map((path) => <Route key={path} path={path} element={<DomainVisits />} />)}
+                </Route>
+                <Route path="/orphan-visits">
+                  {['', '*'].map((path) => <Route key={path} path={path} element={<OrphanVisits />} />)}
+                </Route>
+                <Route path="/non-orphan-visits">
+                  {['', '*'].map((path) => <Route key={path} path={path} element={<NonOrphanVisits />} />)}
+                </Route>
                 <Route path="/manage-tags" element={<TagsList />} />
                 <Route path="/manage-domains" element={<ManageDomains />} />
                 <Route path="/domains/compare-visits" element={<DomainVisitsComparison />} />

--- a/src/ShlinkWebComponent.tsx
+++ b/src/ShlinkWebComponent.tsx
@@ -3,7 +3,7 @@ import type Bottle from 'bottlejs';
 import type { FC, ReactNode } from 'react';
 import { Fragment, useEffect, useMemo, useRef, useState } from 'react';
 import { Provider as ReduxStoreProvider } from 'react-redux';
-import { BrowserRouter, useInRouterContext } from 'react-router-dom';
+import { BrowserRouter, useInRouterContext } from 'react-router';
 import type { ShlinkApiClient } from './api-contract';
 import type { Settings } from './settings';
 import { SettingsProvider } from './settings';

--- a/src/common/AsideMenu.tsx
+++ b/src/common/AsideMenu.tsx
@@ -8,8 +8,8 @@ import {
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { clsx } from 'clsx';
 import type { FC } from 'react';
-import type { NavLinkProps } from 'react-router-dom';
-import { NavLink, useLocation } from 'react-router-dom';
+import type { NavLinkProps } from 'react-router';
+import { NavLink, useLocation } from 'react-router';
 import './AsideMenu.scss';
 
 export interface AsideMenuProps {

--- a/src/domains/helpers/DomainDropdown.tsx
+++ b/src/domains/helpers/DomainDropdown.tsx
@@ -7,7 +7,7 @@ import {
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { RowDropdownBtn, useToggle } from '@shlinkio/shlink-frontend-kit';
 import type { FC } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { DropdownItem } from 'reactstrap';
 import { useFeature } from '../../utils/features';
 import { useRoutesPrefix } from '../../utils/routesPrefix';

--- a/src/mercure/helpers/boundToMercureHub.tsx
+++ b/src/mercure/helpers/boundToMercureHub.tsx
@@ -1,6 +1,6 @@
 import type { FC } from 'react';
 import { useEffect } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import type { CreateVisit } from '../../visits/types';
 import type { MercureInfo } from '../reducers/mercureInfo';
 import { bindToMercureTopic } from './index';

--- a/src/overview/Overview.tsx
+++ b/src/overview/Overview.tsx
@@ -1,6 +1,6 @@
 import type { FC, ReactNode } from 'react';
 import { useEffect } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router';
 import { Card, CardBody, CardHeader, Row } from 'reactstrap';
 import type { ShlinkShortUrlsListParams } from '../api-contract';
 import type { FCWithDeps } from '../container/utils';

--- a/src/overview/helpers/HighlightCard.tsx
+++ b/src/overview/helpers/HighlightCard.tsx
@@ -2,7 +2,7 @@ import { faArrowAltCircleRight as linkIcon } from '@fortawesome/free-regular-svg
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useElementRef } from '@shlinkio/shlink-frontend-kit';
 import type { FC, PropsWithChildren, ReactNode } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Card, CardText, CardTitle, UncontrolledTooltip } from 'reactstrap';
 import './HighlightCard.scss';
 

--- a/src/settings/components/ShlinkWebSettings.tsx
+++ b/src/settings/components/ShlinkWebSettings.tsx
@@ -3,7 +3,7 @@ import { NavPillItem, NavPills } from '@shlinkio/shlink-frontend-kit';
 import type { FC, PropsWithChildren } from 'react';
 import { Children } from 'react';
 import { useCallback } from 'react';
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router';
 import type { DeepPartial } from '../../utils/types';
 import { SettingsProvider } from '..';
 import type { RealTimeUpdatesSettings, Settings, ShortUrlsListSettings } from '../types';
@@ -48,9 +48,9 @@ export const ShlinkWebSettings: FC<ShlinkWebSettingsProps> = (
   return (
     <SettingsProvider value={settings}>
       <NavPills className="mb-3">
-        <NavPillItem to="general">General</NavPillItem>
-        <NavPillItem to="short-urls">Short URLs</NavPillItem>
-        <NavPillItem to="other-items">Other items</NavPillItem>
+        <NavPillItem to="../general">General</NavPillItem>
+        <NavPillItem to="../short-urls">Short URLs</NavPillItem>
+        <NavPillItem to="../other-items">Other items</NavPillItem>
       </NavPills>
 
       <Routes>
@@ -87,7 +87,7 @@ export const ShlinkWebSettings: FC<ShlinkWebSettingsProps> = (
             </SettingsSections>
           )}
         />
-        <Route path="*" element={<Navigate replace to="general" />} />
+        <Route path="*" element={<Navigate replace to="../general" />} />
       </Routes>
     </SettingsProvider>
   );

--- a/src/short-urls/Paginator.tsx
+++ b/src/short-urls/Paginator.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Pagination, PaginationItem, PaginationLink } from 'reactstrap';
 import type { ShlinkPaginator } from '../api-contract';
 import type {

--- a/src/short-urls/ShortUrlsList.tsx
+++ b/src/short-urls/ShortUrlsList.tsx
@@ -3,7 +3,7 @@ import { determineOrderDir } from '@shlinkio/shlink-frontend-kit';
 import { clsx } from 'clsx';
 import type { FC } from 'react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useLocation, useParams } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router';
 import { Card } from 'reactstrap';
 import type { ShlinkShortUrlsListParams, ShlinkShortUrlsOrder } from '../api-contract';
 import type { FCWithDeps } from '../container/utils';

--- a/src/short-urls/helpers/ShortUrlDetailLink.tsx
+++ b/src/short-urls/helpers/ShortUrlDetailLink.tsx
@@ -1,5 +1,5 @@
 import type { FC, PropsWithChildren } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import type { ShlinkShortUrl } from '../../api-contract';
 import { useRoutesPrefix } from '../../utils/routesPrefix';
 import { urlEncodeShortCode } from './index';

--- a/src/short-urls/helpers/hooks.ts
+++ b/src/short-urls/helpers/hooks.ts
@@ -1,6 +1,6 @@
 import { orderToString, stringifyQueryParams, stringToOrder, useParsedQuery } from '@shlinkio/shlink-frontend-kit';
 import { useCallback, useMemo } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router';
 import type { TagsFilteringMode } from '../../api-contract';
 import type { BooleanString } from '../../utils/helpers';
 import { parseOptionalBooleanToString } from '../../utils/helpers';

--- a/src/tags/TagsTableRow.tsx
+++ b/src/tags/TagsTableRow.tsx
@@ -6,7 +6,7 @@ import {
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { RowDropdownBtn, useToggle } from '@shlinkio/shlink-frontend-kit';
 import type { FC } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { DropdownItem } from 'reactstrap';
 import type { FCWithDeps } from '../container/utils';
 import { componentFactory, useDependencies } from '../container/utils';

--- a/src/utils/helpers/hooks.ts
+++ b/src/utils/helpers/hooks.ts
@@ -4,7 +4,7 @@ import {
   useParsedQuery,
 } from '@shlinkio/shlink-frontend-kit';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useSwipeable as useReactSwipeable } from 'react-swipeable';
 import type { MediaMatcher } from '../types';
 

--- a/src/visits/DomainVisits.tsx
+++ b/src/visits/DomainVisits.tsx
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import type { FCWithDeps } from '../container/utils';
 import { componentFactory, useDependencies } from '../container/utils';
 import type { MercureBoundProps } from '../mercure/helpers/boundToMercureHub';

--- a/src/visits/TagVisits.tsx
+++ b/src/visits/TagVisits.tsx
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import type { FCWithDeps } from '../container/utils';
 import { componentFactory, useDependencies } from '../container/utils';
 import type { MercureBoundProps } from '../mercure/helpers/boundToMercureHub';

--- a/src/visits/VisitsStats.tsx
+++ b/src/visits/VisitsStats.tsx
@@ -12,7 +12,7 @@ import { NavPillItem, NavPills, SimpleCard } from '@shlinkio/shlink-frontend-kit
 import { clsx } from 'clsx';
 import type { FC, PropsWithChildren } from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
+import { Navigate, Route, Routes, useLocation } from 'react-router';
 import { Button, Row } from 'reactstrap';
 import { useSetting } from '../settings';
 import { ExportBtn } from '../utils/components/ExportBtn';
@@ -110,7 +110,7 @@ export const VisitsStats: FC<VisitsStatsProps> = (props) => {
   const [highlightedLabel, setHighlightedLabel] = useState<string | undefined>();
   const isFirstLoad = useRef(true);
   const { search } = useLocation();
-  const buildSectionUrl = useCallback((subPath?: string) => (!subPath ? search : `${subPath}${search}`), [search]);
+  const buildSectionUrl = useCallback((subPath?: string) => (!subPath ? search : `../${subPath}${search}`), [search]);
 
   const normalizedVisits = useMemo(() => normalizeVisits(visits), [visits]);
   const normalizedPrevVisits = useMemo(() => prevVisits && normalizeVisits(prevVisits), [prevVisits]);

--- a/src/visits/helpers/hooks.ts
+++ b/src/visits/helpers/hooks.ts
@@ -1,7 +1,7 @@
 import { mergeDeepRight } from '@shlinkio/data-manipulation';
 import { stringifyQueryParams, useParsedQuery } from '@shlinkio/shlink-frontend-kit';
 import { useCallback, useMemo } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import type { ShlinkOrphanVisitType } from '../../api-contract';
 import { formatIsoDate } from '../../utils/dates/helpers/date';
 import type { DateRange } from '../../utils/dates/helpers/dateIntervals';

--- a/src/visits/visits-comparison/VisitsComparisonCollector.tsx
+++ b/src/visits/visits-comparison/VisitsComparisonCollector.tsx
@@ -4,7 +4,7 @@ import { SimpleCard } from '@shlinkio/shlink-frontend-kit';
 import { clsx } from 'clsx';
 import type { FC } from 'react';
 import { useMemo } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Button } from 'reactstrap';
 import { UnstyledButton } from '../../utils/components/UnstyledButton';
 import { useRoutesPrefix } from '../../utils/routesPrefix';

--- a/test/Main.test.tsx
+++ b/test/Main.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { fromPartial } from '@total-typescript/shoehorn';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import type { MainProps } from '../src/Main';
 import { MainFactory } from '../src/Main';
 import { FeaturesProvider } from '../src/utils/features';

--- a/test/__helpers__/MemoryRouterWithParams.tsx
+++ b/test/__helpers__/MemoryRouterWithParams.tsx
@@ -1,6 +1,6 @@
 import type { FC, PropsWithChildren } from 'react';
 import { useMemo } from 'react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 
 export type MemoryRouterWithParamsProps = PropsWithChildren<{
   params: Record<string, string>;

--- a/test/domains/DomainRow.test.tsx
+++ b/test/domains/DomainRow.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { fromPartial } from '@total-typescript/shoehorn';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import type { ShlinkDomainRedirects } from '../../src/api-contract';
 import type { Domain } from '../../src/domains/data';
 import { DomainRow } from '../../src/domains/DomainRow';

--- a/test/domains/ManageDomains.test.tsx
+++ b/test/domains/ManageDomains.test.tsx
@@ -1,6 +1,6 @@
 import { screen, waitFor } from '@testing-library/react';
 import { fromPartial } from '@total-typescript/shoehorn';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import type { ProblemDetailsError, ShlinkDomain } from '../../src/api-contract';
 import { ManageDomains } from '../../src/domains/ManageDomains';
 import type { DomainsList } from '../../src/domains/reducers/domainsList';

--- a/test/domains/helpers/DomainDropdown.test.tsx
+++ b/test/domains/helpers/DomainDropdown.test.tsx
@@ -1,7 +1,7 @@
 import { screen, waitForElementToBeRemoved } from '@testing-library/react';
 import type { UserEvent } from '@testing-library/user-event';
 import { fromPartial } from '@total-typescript/shoehorn';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import type { Domain } from '../../../src/domains/data';
 import { DEFAULT_DOMAIN } from '../../../src/domains/data';
 import { DomainDropdown } from '../../../src/domains/helpers/DomainDropdown';

--- a/test/overview/Overview.test.tsx
+++ b/test/overview/Overview.test.tsx
@@ -1,6 +1,6 @@
 import { screen, waitFor } from '@testing-library/react';
 import { fromPartial } from '@total-typescript/shoehorn';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import type { MercureInfo } from '../../src/mercure/reducers/mercureInfo';
 import { OverviewFactory } from '../../src/overview/Overview';
 import { SettingsProvider } from '../../src/settings';

--- a/test/overview/helpers/HighlightCard.test.tsx
+++ b/test/overview/helpers/HighlightCard.test.tsx
@@ -1,6 +1,6 @@
 import { screen, waitFor } from '@testing-library/react';
 import type { PropsWithChildren } from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import type { HighlightCardProps } from '../../../src/overview/helpers/HighlightCard';
 import { HighlightCard } from '../../../src/overview/helpers/HighlightCard';
 import { checkAccessibility } from '../../__helpers__/accessibility';

--- a/test/redirect-rules/ShortUrlRedirectRules.test.tsx
+++ b/test/redirect-rules/ShortUrlRedirectRules.test.tsx
@@ -1,7 +1,7 @@
 import type { ShlinkShortUrl } from '@shlinkio/shlink-js-sdk/api-contract';
 import { cleanup, screen, waitFor } from '@testing-library/react';
 import { fromPartial } from '@total-typescript/shoehorn';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import type { ProblemDetailsError } from '../../src/api-contract';
 import { ShortUrlRedirectRules } from '../../src/redirect-rules/ShortUrlRedirectRules';
 import { checkAccessibility } from '../__helpers__/accessibility';

--- a/test/settings/components/ShlinkWebSettings.test.tsx
+++ b/test/settings/components/ShlinkWebSettings.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
-import { Router } from 'react-router-dom';
+import { Router } from 'react-router';
 import { ShlinkWebSettings } from '../../../src/settings';
 import { checkAccessibility } from '../../__helpers__/accessibility';
 

--- a/test/short-urls/Paginator.test.tsx
+++ b/test/short-urls/Paginator.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { fromPartial } from '@total-typescript/shoehorn';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import type { ShlinkPaginator } from '../../src/api-contract';
 import { Paginator } from '../../src/short-urls/Paginator';
 import { ELLIPSIS } from '../../src/utils/helpers/pagination';

--- a/test/short-urls/ShortUrlsFilteringBar.test.tsx
+++ b/test/short-urls/ShortUrlsFilteringBar.test.tsx
@@ -4,7 +4,7 @@ import { fromPartial } from '@total-typescript/shoehorn';
 import { formatISO, parseISO } from 'date-fns';
 import type { MemoryHistory } from 'history';
 import { createMemoryHistory } from 'history';
-import { Router } from 'react-router-dom';
+import { Router } from 'react-router';
 import { SettingsProvider } from '../../src/settings';
 import { ShortUrlsFilteringBarFactory } from '../../src/short-urls/ShortUrlsFilteringBar';
 import { FeaturesProvider } from '../../src/utils/features';

--- a/test/short-urls/ShortUrlsList.test.tsx
+++ b/test/short-urls/ShortUrlsList.test.tsx
@@ -2,7 +2,7 @@ import { screen } from '@testing-library/react';
 import { fromPartial } from '@total-typescript/shoehorn';
 import type { MemoryHistory } from 'history';
 import { createMemoryHistory } from 'history';
-import { Router } from 'react-router-dom';
+import { Router } from 'react-router';
 import type { MercureBoundProps } from '../../src/mercure/helpers/boundToMercureHub';
 import type { Settings } from '../../src/settings';
 import { SettingsProvider } from '../../src/settings';

--- a/test/short-urls/helpers/ExportShortUrlsBtn.test.tsx
+++ b/test/short-urls/helpers/ExportShortUrlsBtn.test.tsx
@@ -1,6 +1,6 @@
 import { screen } from '@testing-library/react';
 import { fromPartial } from '@total-typescript/shoehorn';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import type { ShlinkShortUrl } from '../../../src/api-contract';
 import { ExportShortUrlsBtnFactory } from '../../../src/short-urls/helpers/ExportShortUrlsBtn';
 import type { ReportExporter } from '../../../src/utils/services/ReportExporter';

--- a/test/short-urls/helpers/ShortUrlDetailLink.test.tsx
+++ b/test/short-urls/helpers/ShortUrlDetailLink.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { fromPartial } from '@total-typescript/shoehorn';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import type { ShlinkShortUrl } from '../../../src/api-contract';
 import type { LinkSuffix, ShortUrlDetailLinkProps } from '../../../src/short-urls/helpers/ShortUrlDetailLink';
 import { ShortUrlDetailLink } from '../../../src/short-urls/helpers/ShortUrlDetailLink';

--- a/test/short-urls/helpers/ShortUrlsRow.test.tsx
+++ b/test/short-urls/helpers/ShortUrlsRow.test.tsx
@@ -1,7 +1,7 @@
 import { screen } from '@testing-library/react';
 import { fromPartial } from '@total-typescript/shoehorn';
 import { addDays, formatISO, subDays } from 'date-fns';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import type { ShlinkShortUrl, ShlinkShortUrlMeta } from '../../../src/api-contract';
 import type { Settings } from '../../../src/settings';
 import { SettingsProvider } from '../../../src/settings';

--- a/test/short-urls/helpers/ShortUrlsRowMenu.test.tsx
+++ b/test/short-urls/helpers/ShortUrlsRowMenu.test.tsx
@@ -1,6 +1,6 @@
 import { screen, waitFor } from '@testing-library/react';
 import { fromPartial } from '@total-typescript/shoehorn';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import type { ShlinkShortUrl } from '../../../src/api-contract';
 import type { ShortUrlsListSettings } from '../../../src/settings';
 import { SettingsProvider } from '../../../src/settings';

--- a/test/tags/TagsTable.test.tsx
+++ b/test/tags/TagsTable.test.tsx
@@ -1,6 +1,6 @@
 import { screen } from '@testing-library/react';
 import { fromPartial } from '@total-typescript/shoehorn';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { TagsTableFactory } from '../../src/tags/TagsTable';
 import type { TagsTableRowProps } from '../../src/tags/TagsTableRow';
 import { rangeOf } from '../../src/utils/helpers';

--- a/test/tags/TagsTableRow.test.tsx
+++ b/test/tags/TagsTableRow.test.tsx
@@ -1,7 +1,7 @@
 import { screen } from '@testing-library/react';
 import type { UserEvent } from '@testing-library/user-event';
 import { fromPartial } from '@total-typescript/shoehorn';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import type { ModalProps } from 'reactstrap';
 import { TagsTableRowFactory } from '../../src/tags/TagsTableRow';
 import { RoutesPrefixProvider } from '../../src/utils/routesPrefix';

--- a/test/visits/NonOrphanVisits.test.tsx
+++ b/test/visits/NonOrphanVisits.test.tsx
@@ -1,7 +1,7 @@
 import { screen } from '@testing-library/react';
 import { fromPartial } from '@total-typescript/shoehorn';
 import { formatISO } from 'date-fns';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import type { MercureBoundProps } from '../../src/mercure/helpers/boundToMercureHub';
 import { SettingsProvider } from '../../src/settings';
 import { NonOrphanVisitsFactory } from '../../src/visits/NonOrphanVisits';

--- a/test/visits/OrphanVisits.test.tsx
+++ b/test/visits/OrphanVisits.test.tsx
@@ -1,7 +1,7 @@
 import { screen } from '@testing-library/react';
 import { fromPartial } from '@total-typescript/shoehorn';
 import { formatISO } from 'date-fns';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import type { MercureBoundProps } from '../../src/mercure/helpers/boundToMercureHub';
 import { SettingsProvider } from '../../src/settings';
 import { FeaturesProvider } from '../../src/utils/features';

--- a/test/visits/ShortUrlVisits.test.tsx
+++ b/test/visits/ShortUrlVisits.test.tsx
@@ -2,7 +2,7 @@ import type { ShlinkShortUrl } from '@shlinkio/shlink-js-sdk/api-contract';
 import { screen } from '@testing-library/react';
 import { fromPartial } from '@total-typescript/shoehorn';
 import { formatISO } from 'date-fns';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { now } from 'tinybench';
 import type { MercureBoundProps } from '../../src/mercure/helpers/boundToMercureHub';
 import { SettingsProvider } from '../../src/settings';

--- a/test/visits/ShortUrlVisitsHeader.test.tsx
+++ b/test/visits/ShortUrlVisitsHeader.test.tsx
@@ -2,7 +2,7 @@ import type { ShlinkShortUrl } from '@shlinkio/shlink-js-sdk/api-contract';
 import { screen, waitFor } from '@testing-library/react';
 import { fromPartial } from '@total-typescript/shoehorn';
 import { formatDistance, parseISO } from 'date-fns';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import type { ShortUrlVisits } from '../../src/visits/reducers/shortUrlVisits';
 import { ShortUrlVisitsHeader } from '../../src/visits/ShortUrlVisitsHeader';
 import { checkAccessibility } from '../__helpers__/accessibility';

--- a/test/visits/TagVisitsHeader.test.tsx
+++ b/test/visits/TagVisitsHeader.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { fromPartial } from '@total-typescript/shoehorn';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import type { TagVisits } from '../../src/visits/reducers/tagVisits';
 import { TagVisitsHeader } from '../../src/visits/TagVisitsHeader';
 import { checkAccessibility } from '../__helpers__/accessibility';

--- a/test/visits/VisitsHeader.test.tsx
+++ b/test/visits/VisitsHeader.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { fromPartial } from '@total-typescript/shoehorn';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import type { ShlinkVisit } from '../../src/api-contract';
 import { VisitsHeader } from '../../src/visits/VisitsHeader';
 import { checkAccessibility } from '../__helpers__/accessibility';

--- a/test/visits/VisitsStats.test.tsx
+++ b/test/visits/VisitsStats.test.tsx
@@ -1,7 +1,7 @@
 import { screen, waitFor } from '@testing-library/react';
 import { fromPartial } from '@total-typescript/shoehorn';
 import { createMemoryHistory } from 'history';
-import { Router } from 'react-router-dom';
+import { Router } from 'react-router';
 import type { ShlinkVisit } from '../../src/api-contract';
 import type { Settings } from '../../src/settings';
 import { SettingsProvider } from '../../src/settings';

--- a/test/visits/visits-comparison/DomainVisitsComparison.test.tsx
+++ b/test/visits/visits-comparison/DomainVisitsComparison.test.tsx
@@ -1,6 +1,6 @@
 import { cleanup, render, screen } from '@testing-library/react';
 import { fromPartial } from '@total-typescript/shoehorn';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import type { MercureInfo } from '../../../src/mercure/reducers/mercureInfo';
 import { DomainVisitsComparison } from '../../../src/visits/visits-comparison/DomainVisitsComparison';
 import { checkAccessibility } from '../../__helpers__/accessibility';

--- a/test/visits/visits-comparison/ShortUrlVisitsComparison.test.tsx
+++ b/test/visits/visits-comparison/ShortUrlVisitsComparison.test.tsx
@@ -1,6 +1,6 @@
 import { cleanup, render, screen } from '@testing-library/react';
 import { fromPartial } from '@total-typescript/shoehorn';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { DEFAULT_DOMAIN } from '../../../src/domains/data';
 import type { MercureInfo } from '../../../src/mercure/reducers/mercureInfo';
 import type { ShortUrlIdentifier } from '../../../src/short-urls/data';

--- a/test/visits/visits-comparison/TagVisitsComparison.test.tsx
+++ b/test/visits/visits-comparison/TagVisitsComparison.test.tsx
@@ -1,6 +1,6 @@
 import { cleanup, render, screen } from '@testing-library/react';
 import { fromPartial } from '@total-typescript/shoehorn';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import type { MercureInfo } from '../../../src/mercure/reducers/mercureInfo';
 import { TagVisitsComparisonFactory } from '../../../src/visits/visits-comparison/TagVisitsComparison';
 import { checkAccessibility } from '../../__helpers__/accessibility';

--- a/test/visits/visits-comparison/VisitsComparison.test.tsx
+++ b/test/visits/visits-comparison/VisitsComparison.test.tsx
@@ -2,7 +2,7 @@ import type { ShlinkVisit } from '@shlinkio/shlink-js-sdk/api-contract';
 import { cleanup, screen } from '@testing-library/react';
 import { fromPartial } from '@total-typescript/shoehorn';
 import { endOfDay, formatISO, startOfDay, subDays } from 'date-fns';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import type { LoadVisitsForComparison } from '../../../src/visits/visits-comparison/reducers/types';
 import { VisitsComparison } from '../../../src/visits/visits-comparison/VisitsComparison';
 import { checkAccessibility } from '../../__helpers__/accessibility';

--- a/test/visits/visits-comparison/VisitsComparisonCollector.test.tsx
+++ b/test/visits/visits-comparison/VisitsComparisonCollector.test.tsx
@@ -1,6 +1,6 @@
 import { screen } from '@testing-library/react';
 import { fromPartial } from '@total-typescript/shoehorn';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { rangeOf } from '../../../src/utils/helpers';
 import { VisitsComparisonCollector } from '../../../src/visits/visits-comparison/VisitsComparisonCollector';
 import type {


### PR DESCRIPTION
Following the [migration guide](https://reactrouter.com/upgrading/v6#upgrading-from-v6), update the project to react-router 7

It also updates to `@shlinkio/shlink-frontend-kit` 0.7, since that version supports react-router 7