### PR TITLE
Ensure non-bot values are printed if value is zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [Unreleased]
+### Added
+* *Nothing*
+
+### Changed
+* *Nothing*
+
+### Deprecated
+* *Nothing*
+
+### Removed
+* *Nothing*
+
+### Fixed
+* Fix bots visits displayed in overview cards even if bots are excluded, if the amount of non-bot visits is zero.
+
+
 ## [0.12.0] - 2024-12-05
 ### Added
 * *Nothing*

--- a/src/overview/helpers/VisitsHighlightCard.tsx
+++ b/src/overview/helpers/VisitsHighlightCard.tsx
@@ -20,7 +20,7 @@ export const VisitsHighlightCard: FC<VisitsHighlightCardProps> = ({ loading, exc
     {...rest}
   >
     {loading ? 'Loading...' : prettify(
-      excludeBots && visitsSummary.nonBots ? visitsSummary.nonBots : visitsSummary.total,
+      excludeBots && visitsSummary.nonBots !== undefined ? visitsSummary.nonBots : visitsSummary.total,
     )}
   </HighlightCard>
 );

--- a/test/overview/helpers/VisitsHighlightCard.test.tsx
+++ b/test/overview/helpers/VisitsHighlightCard.test.tsx
@@ -51,6 +51,10 @@ describe('<VisitsHighlightCard />', () => {
       expect(screen.getByText('20')).toBeInTheDocument();
       expect(screen.queryByText('50')).not.toBeInTheDocument();
     }],
+    [true, 0, () => {
+      expect(screen.getByText('0')).toBeInTheDocument();
+      expect(screen.queryByText('50')).not.toBeInTheDocument();
+    }],
     [true, undefined, () => {
       expect(screen.getByText('50')).toBeInTheDocument();
       expect(screen.queryByText('20')).not.toBeInTheDocument();


### PR DESCRIPTION
Do an explicit `undefined` check for `nonBots` when evaluating if the bots or non-bots visits should be displayed in overview visits cards, to make sure the value is displayed when it's zero.