### PR TITLE
Update dependencies and peer dependencies so that React 19 can be installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [0.13.1]
+### Added
+* *Nothing*
+
+### Changed
+* *Nothing*
+
+### Deprecated
+* *Nothing*
+
+### Removed
+* *Nothing*
+
+### Fixed
+* Support peer dependency versions which in turn support React 19.
+
+
 ## [0.13.0] - 2025-02-10
 ### Added
 * *Nothing*

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "react-external-link": "^2.4.0",
         "react-leaflet": "^4.2.1 || ^5.0",
         "react-swipeable": "^7.0.2",
-        "react-tag-autocomplete": "^7.4.0",
+        "react-tag-autocomplete": "^7.5.0",
         "recharts": "^2.15.1"
       },
       "devDependencies": {
@@ -8108,14 +8108,15 @@
       }
     },
     "node_modules/react-tag-autocomplete": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/react-tag-autocomplete/-/react-tag-autocomplete-7.4.0.tgz",
-      "integrity": "sha512-enQSMyZnxG8Nz0EdUtP2kttyO8HELyAU0GKcSeBtLmZvo93/AZJJJyCOyEMPW5E58jEShyvOeDBkFtUC6AdC1w==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/react-tag-autocomplete/-/react-tag-autocomplete-7.5.0.tgz",
+      "integrity": "sha512-uy6ncusMKr6p3ip7xb4DTYtF22g7cSRyZq0IeFpgmrQipTbKz4RVFDB5QnnqstN6HTs9cdTtIb3vVuOuOdzH3w==",
+      "license": "ISC",
       "engines": {
         "node": ">= 16.12.0"
       },
       "peerDependencies": {
-        "react": "^18.0.0"
+        "react": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-transition-group": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "event-source-polyfill": "^1.0.31",
         "leaflet": "^1.9.4",
         "react-external-link": "^2.4.0",
-        "react-leaflet": "^4.2.1",
+        "react-leaflet": "^4.2.1 || ^5.0",
         "react-swipeable": "^7.0.2",
         "react-tag-autocomplete": "^7.4.0",
         "recharts": "^2.15.1"

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "react-external-link": "^2.4.0",
     "react-leaflet": "^4.2.1 || ^5.0",
     "react-swipeable": "^7.0.2",
-    "react-tag-autocomplete": "^7.4.0",
+    "react-tag-autocomplete": "^7.5.0",
     "recharts": "^2.15.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "event-source-polyfill": "^1.0.31",
     "leaflet": "^1.9.4",
     "react-external-link": "^2.4.0",
-    "react-leaflet": "^4.2.1",
+    "react-leaflet": "^4.2.1 || ^5.0",
     "react-swipeable": "^7.0.2",
     "react-tag-autocomplete": "^7.4.0",
     "recharts": "^2.15.1"


### PR DESCRIPTION
Update some peer dependencies so that none of them blocks the installation of React 19

- [x] react-leaflet
- [x] react-tag-autocomplete (https://github.com/i-like-robots/react-tag-autocomplete/issues/78)
- [ ] react-popper (reactstrap dependency. This is archived and replaced by something else, so reactstrap would need to migrate): https://github.com/reactstrap/reactstrap/issues/2824
- [x] react-smooth (recharts dependency. Latest version states it added React 19 to peer deps, but by checking at the code, that doesn't seem to be the case) (EDIT: recharts 2.15.1 now depends on react-smooth 4.0.4)