### PR TITLE
Deprecate `updateSettings` prop in `ShlinkWebSettings` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [Unreleased]
+### Added
+* *Nothing*
+
+### Changed
+* *Nothing*
+
+### Deprecated
+* Deprecate `updateSettings` prop in `ShelinkWebSettings`. Use `onUpdateSettings` instead.
+
+### Removed
+* *Nothing*
+
+### Fixed
+* *Nothing*
+
+
 ## [0.13.0] - 2025-02-10
 ### Added
 * *Nothing*

--- a/dev/App.tsx
+++ b/dev/App.tsx
@@ -3,7 +3,7 @@ import { FetchHttpClient } from '@shlinkio/shlink-js-sdk/fetch';
 import type { FC } from 'react';
 import { useCallback } from 'react';
 import { useEffect, useMemo, useState } from 'react';
-import { BrowserRouter, Link, Navigate, Route, Routes } from 'react-router';
+import { Link, Navigate, Route, Routes, useLocation } from 'react-router';
 import { ShlinkWebComponent } from '../src';
 import type { Settings } from '../src/settings';
 import { ShlinkWebSettings } from '../src/settings';
@@ -27,9 +27,10 @@ export const App: FC = () => {
     [serverInfo],
   );
   const [settings, setSettings] = useState<Settings>({});
+  const location = useLocation();
   const routesPrefix = useMemo(
-    () => (window.location.pathname.startsWith('/sub/route') ? '/sub/route' : undefined),
-    [],
+    () => (location.pathname.startsWith('/sub/route') ? '/sub/route' : undefined),
+    [location],
   );
 
   useEffect(() => {
@@ -39,7 +40,7 @@ export const App: FC = () => {
   }, [apiClient, serverVersion]);
 
   return (
-    <BrowserRouter>
+    <>
       <header className="header fixed-top text-white d-flex justify-content-between">
         <ServerInfoForm serverInfo={serverInfo} onChange={onServerInfoChange} />
         <div className="h-100 text-end pe-3 pt-3 d-flex gap-3">
@@ -57,7 +58,7 @@ export const App: FC = () => {
                 <div className="container pt-4">
                   <ShlinkWebSettings
                     settings={settings}
-                    updateSettings={setSettings}
+                    onUpdateSettings={setSettings}
                     defaultShortUrlsListOrdering={{}}
                   />
                 </div>
@@ -79,6 +80,6 @@ export const App: FC = () => {
           <Route path="*" element={<h3 className="mt-3 text-center">Not found</h3>} />
         </Routes>
       </div>
-    </BrowserRouter>
+    </>
   );
 };

--- a/dev/index.tsx
+++ b/dev/index.tsx
@@ -1,5 +1,10 @@
 import { createRoot } from 'react-dom/client';
+import { BrowserRouter } from 'react-router';
 import { App } from './App';
 import './index.scss';
 
-createRoot(document.getElementById('root')!).render(<App />);
+createRoot(document.getElementById('root')!).render(
+  <BrowserRouter>
+    <App />
+  </BrowserRouter>,
+);

--- a/src/settings/components/ShlinkWebSettings.tsx
+++ b/src/settings/components/ShlinkWebSettings.tsx
@@ -17,7 +17,11 @@ import { VisitsSettings as Visits } from './VisitsSettings';
 export type ShlinkWebSettingsProps = {
   settings: Settings;
   defaultShortUrlsListOrdering: NonNullable<ShortUrlsListSettings['defaultOrdering']>;
-  updateSettings: (settings: Settings) => void;
+  /** Callback invoked every time the settings are updated */
+  onUpdateSettings?: (settings: Settings) => void;
+
+  /** @deprecated Use onUpdateSettings instead */
+  updateSettings?: (settings: Settings) => void;
 };
 
 const SettingsSections: FC<PropsWithChildren> = ({ children }) => Children.map(
@@ -25,12 +29,15 @@ const SettingsSections: FC<PropsWithChildren> = ({ children }) => Children.map(
   (child, index) => <div key={index} className="mb-3">{child}</div>,
 );
 
-export const ShlinkWebSettings: FC<ShlinkWebSettingsProps> = (
-  { settings, updateSettings, defaultShortUrlsListOrdering },
-) => {
+export const ShlinkWebSettings: FC<ShlinkWebSettingsProps> = ({
+  settings,
+  updateSettings,
+  onUpdateSettings = updateSettings,
+  defaultShortUrlsListOrdering,
+}) => {
   const updatePartialSettings = useCallback(
-    (partialSettings: DeepPartial<Settings>) => updateSettings(mergeDeepRight(settings, partialSettings)),
-    [settings, updateSettings],
+    (partialSettings: DeepPartial<Settings>) => onUpdateSettings?.(mergeDeepRight(settings, partialSettings)),
+    [settings, onUpdateSettings],
   );
   const toggleRealTimeUpdates = useCallback(
     (enabled: boolean) => updatePartialSettings({ realTimeUpdates: { enabled } }),

--- a/test/settings/components/ShlinkWebSettings.test.tsx
+++ b/test/settings/components/ShlinkWebSettings.test.tsx
@@ -10,7 +10,7 @@ describe('<ShlinkWebSettings />', () => {
     history.push(activeRoute);
     return render(
       <Router location={history.location} navigator={history}>
-        <ShlinkWebSettings settings={{}} defaultShortUrlsListOrdering={{}} updateSettings={vi.fn()} />
+        <ShlinkWebSettings settings={{}} defaultShortUrlsListOrdering={{}} />
       </Router>,
     );
   };


### PR DESCRIPTION
To more properly follow common practices, define an `onUpdateSettings` prop, and mark `updateSettings` as deprecated and replaced by it.