### PR TITLE
Add support for @shlinkio/shlink-frontend-kit 0.8

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,9 +21,12 @@ updates:
       shlink:
         patterns:
           - '@shlinkio/*'
-      types:
+      react:
         patterns:
-          - '@types/*'
+          - 'react'
+          - 'react-dom'
+          - '@types/react'
+          - '@types/react-dom'
       testing:
         patterns:
           - '@testing-library/*'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org).
 
-## [Unreleased]
+## [0.13.1] - 2025-03-26
 ### Added
-* *Nothing*
+* Add support for `@shlinkio/shlink-frontend-kit` 0.8
 
 ### Changed
-* *Nothing*
+* Update dependencies
 
 ### Deprecated
 * Deprecate `updateSettings` prop in `ShelinkWebSettings`. Use `onUpdateSettings` instead.

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.4.2",
         "@fortawesome/react-fontawesome": "^0.2.2",
         "@reduxjs/toolkit": "^2.5.0",
-        "@shlinkio/shlink-frontend-kit": "^0.7.2",
+        "@shlinkio/shlink-frontend-kit": "^0.7.2 || ^0.8",
         "@shlinkio/shlink-js-sdk": "^2.0.0",
         "react": "^18.3 || ^19.0",
         "react-dom": "^18.3 || ^19.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.4.2",
     "@fortawesome/react-fontawesome": "^0.2.2",
     "@reduxjs/toolkit": "^2.5.0",
-    "@shlinkio/shlink-frontend-kit": "^0.7.2",
+    "@shlinkio/shlink-frontend-kit": "^0.7.2 || ^0.8",
     "@shlinkio/shlink-js-sdk": "^2.0.0",
     "react": "^18.3 || ^19.0",
     "react-dom": "^18.3 || ^19.0",


### PR DESCRIPTION
Add support for `shlinkio/shlink-frontend-kit` v0.8, in preparation for the upcoming release, which is backwards compatible and adds tailwind-based components.