### PR TITLE
Set tini as dev docker entry point

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,15 @@
 FROM mcr.microsoft.com/playwright:v1.51.1-noble
 
 ENV NODE_VERSION 22.14
+ENV TINI_VERSION v0.19.0
 
 # Install Node.js
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.2/install.sh | bash && \
     \. "$HOME/.nvm/nvm.sh" && \
     nvm install ${NODE_VERSION}
+
+# Install tini
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /sbin/tini
+RUN chmod +x /sbin/tini
+# Set tini as the entry point, as node does not properly handle signals
+ENTRYPOINT ["/sbin/tini", "--"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,8 @@ services:
         user: 1000:1000
         build:
             context: .
-        command: /bin/sh -c "cd /shlink-web-component && npm i && npm run dev"
+        working_dir: /shlink-web-component
+        command: /bin/sh -c "npm i && node --run dev"
         volumes:
             - ./:/shlink-web-component
         ports:


### PR DESCRIPTION
Use `tini` as the dev docker entry point, to ensure proper signal handling.