### PR TITLE
Fix line chart selection triggering after clicking a dot in the chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org).
 
-## [Unreleased]
+## [0.16.1] - 2025-08-08
 ### Added
 * [#755](https://github.com/shlinkio/shlink-web-component/issues/755) Add support for `any-value-query-param` and `valueless-query-param` redirect conditions when using Shlink >=4.5.0.
 * [#756](https://github.com/shlinkio/shlink-web-component/issues/756) Add support for desktop device types on device redirect conditions, when using Shlink >=4.5.0.
@@ -23,7 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * *Nothing*
 
 ### Fixed
-* *Nothing*
+* [#698](https://github.com/shlinkio/shlink-web-component/issues/698) Fix line chart selection triggering after clicking a dot in the chart. It now works only when dragging while the mouse is clicked.
 
 
 ## [0.16.0] - 2025-07-28

--- a/src/visits/charts/LineChartCard.tsx
+++ b/src/visits/charts/LineChartCard.tsx
@@ -285,6 +285,7 @@ export const LineChartCard: FC<LineChartCardProps> = (
   }, [chartData, selectionStart]);
   const updateDateRange = useCallback(() => {
     if (!selectionStart || !selectionEnd) {
+      resetSelection();
       return;
     }
 


### PR DESCRIPTION
Closes #698 

The mouseUp event in the chart now resets the selectionStart an selectionENd, preventing a click in the chart to leave the selection "started", causing to continue selecting when moving the mouse afterwards, without any button pressed. 