### PR TITLE
Create hook for visit creation reducer module

### DIFF
--- a/src/mercure/helpers/boundToMercureHub.tsx
+++ b/src/mercure/helpers/boundToMercureHub.tsx
@@ -1,22 +1,19 @@
 import type { FC } from 'react';
 import { useEffect } from 'react';
 import { useParams } from 'react-router';
+import { useVisitCreation } from '../../visits/reducers/visitCreation';
 import type { CreateVisit } from '../../visits/types';
 import { useMercureInfo } from '../reducers/mercureInfo';
 import { bindToMercureTopic } from './index';
 
-export interface MercureBoundProps {
-  createNewVisits: (createdVisits: CreateVisit[]) => void;
-}
-
 export function boundToMercureHub<T extends object>(
-  WrappedComponent: FC<MercureBoundProps & T>,
+  WrappedComponent: FC<T>,
   getTopicsForParams: (routeParams: any) => string[],
 ) {
   const pendingUpdates = new Set<CreateVisit>();
 
-  return (props: MercureBoundProps & T) => {
-    const { createNewVisits } = props;
+  return (props: T) => {
+    const { createNewVisits } = useVisitCreation();
     const { loadMercureInfo, mercureInfo } = useMercureInfo();
     const params = useParams();
 

--- a/src/overview/Overview.tsx
+++ b/src/overview/Overview.tsx
@@ -5,7 +5,6 @@ import { Link, useNavigate } from 'react-router';
 import type { ShlinkShortUrlsListParams } from '../api-contract';
 import type { FCWithDeps } from '../container/utils';
 import { componentFactory, useDependencies } from '../container/utils';
-import type { MercureBoundProps } from '../mercure/helpers/boundToMercureHub';
 import { boundToMercureHub } from '../mercure/helpers/boundToMercureHub';
 import { Topics } from '../mercure/helpers/Topics';
 import { useSetting } from '../settings';
@@ -39,7 +38,7 @@ const OverviewCard: FC<OverviewCardProps> = ({ children, titleLinkText, titleLin
   </Card>
 );
 
-type OverviewProps = MercureBoundProps & {
+type OverviewProps = {
   shortUrlsList: ShortUrlsListState;
   listShortUrls: (params: ShlinkShortUrlsListParams) => void;
   tagsList: TagsList;

--- a/src/overview/services/provideServices.ts
+++ b/src/overview/services/provideServices.ts
@@ -6,6 +6,6 @@ export function provideServices(bottle: Bottle, connect: ConnectDecorator) {
   bottle.factory('Overview', OverviewFactory);
   bottle.decorator('Overview', connect(
     ['shortUrlsList', 'tagsList', 'visitsOverview'],
-    ['listShortUrls', 'createNewVisits', 'loadVisitsOverview'],
+    ['listShortUrls', 'loadVisitsOverview'],
   ));
 }

--- a/src/short-urls/ShortUrlsList.tsx
+++ b/src/short-urls/ShortUrlsList.tsx
@@ -7,7 +7,6 @@ import { useLocation, useParams } from 'react-router';
 import type { ShlinkShortUrlsListParams, ShlinkShortUrlsOrder } from '../api-contract';
 import type { FCWithDeps } from '../container/utils';
 import { componentFactory, useDependencies } from '../container/utils';
-import type { MercureBoundProps } from '../mercure/helpers/boundToMercureHub';
 import { boundToMercureHub } from '../mercure/helpers/boundToMercureHub';
 import { Topics } from '../mercure/helpers/Topics';
 import { useSettings } from '../settings';
@@ -24,7 +23,7 @@ import type { ShortUrlsList as ShortUrlsListState } from './reducers/shortUrlsLi
 import type { ShortUrlsFilteringBarProps } from './ShortUrlsFilteringBar';
 import type { ShortUrlsTableType } from './ShortUrlsTable';
 
-type ShortUrlsListProps = MercureBoundProps & {
+type ShortUrlsListProps = {
   shortUrlsList: ShortUrlsListState;
   listShortUrls: (params: ShlinkShortUrlsListParams) => void;
 };

--- a/src/short-urls/services/provideServices.ts
+++ b/src/short-urls/services/provideServices.ts
@@ -18,7 +18,7 @@ import { ShortUrlsTableFactory } from '../ShortUrlsTable';
 export const provideServices = (bottle: Bottle, connect: ConnectDecorator) => {
   // Components
   bottle.factory('ShortUrlsList', ShortUrlsListFactory);
-  bottle.decorator('ShortUrlsList', connect(['shortUrlsList'], ['listShortUrls', 'createNewVisits']));
+  bottle.decorator('ShortUrlsList', connect(['shortUrlsList'], ['listShortUrls']));
 
   bottle.factory('ShortUrlsTable', ShortUrlsTableFactory);
   bottle.factory('ShortUrlsRow', ShortUrlsRowFactory);

--- a/src/tags/TagsList.tsx
+++ b/src/tags/TagsList.tsx
@@ -4,7 +4,6 @@ import { useMemo, useState } from 'react';
 import { ShlinkApiError } from '../common/ShlinkApiError';
 import type { FCWithDeps } from '../container/utils';
 import { componentFactory, useDependencies } from '../container/utils';
-import type { MercureBoundProps } from '../mercure/helpers/boundToMercureHub';
 import { boundToMercureHub } from '../mercure/helpers/boundToMercureHub';
 import { Topics } from '../mercure/helpers/Topics';
 import { useSettings } from '../settings';
@@ -21,13 +20,11 @@ export type TagsListProps = {
   tagsList: TagsListState;
 };
 
-type TagsListActualProps = MercureBoundProps & TagsListProps;
-
 type TagsListDeps = {
   TagsTable: FC<TagsTableProps>;
 };
 
-const TagsList: FCWithDeps<TagsListActualProps, TagsListDeps> = boundToMercureHub(({ filterTags, tagsList }) => {
+const TagsList: FCWithDeps<TagsListProps, TagsListDeps> = boundToMercureHub(({ filterTags, tagsList }) => {
   const { TagsTable } = useDependencies(TagsList);
   const settings = useSettings();
   const [order, setOrder] = useState<TagsOrder>(settings.tags?.defaultOrdering ?? {});

--- a/src/tags/services/provideServices.ts
+++ b/src/tags/services/provideServices.ts
@@ -26,7 +26,7 @@ export const provideServices = (bottle: Bottle, connect: ConnectDecorator) => {
   bottle.factory('TagsTable', TagsTableFactory);
 
   bottle.factory('TagsList', TagsListFactory);
-  bottle.decorator('TagsList', connect(['tagsList'], ['filterTags', 'createNewVisits']));
+  bottle.decorator('TagsList', connect(['tagsList'], ['filterTags']));
 
   // Reducers
   bottle.serviceFactory('tagEditReducerCreator', tagEditReducerCreator, 'editTag');

--- a/src/visits/DomainVisits.tsx
+++ b/src/visits/DomainVisits.tsx
@@ -2,7 +2,6 @@ import { useCallback } from 'react';
 import { useParams } from 'react-router';
 import type { FCWithDeps } from '../container/utils';
 import { componentFactory, useDependencies } from '../container/utils';
-import type { MercureBoundProps } from '../mercure/helpers/boundToMercureHub';
 import { boundToMercureHub } from '../mercure/helpers/boundToMercureHub';
 import { Topics } from '../mercure/helpers/Topics';
 import type { ReportExporter } from '../utils/services/ReportExporter';
@@ -22,7 +21,7 @@ type DomainVisitsDeps = {
   ReportExporter: ReportExporter
 };
 
-const DomainVisits: FCWithDeps<MercureBoundProps & DomainVisitsProps, DomainVisitsDeps> = boundToMercureHub((
+const DomainVisits: FCWithDeps<DomainVisitsProps, DomainVisitsDeps> = boundToMercureHub((
   { getDomainVisits, domainVisits, cancelGetDomainVisits },
 ) => {
   const { ReportExporter: exporter } = useDependencies(DomainVisits);

--- a/src/visits/NonOrphanVisits.tsx
+++ b/src/visits/NonOrphanVisits.tsx
@@ -2,7 +2,6 @@ import { useCallback } from 'react';
 import type { FCWithDeps } from '../container/utils';
 import { componentFactory, useDependencies } from '../container/utils';
 import type { DomainsList } from '../domains/reducers/domainsList';
-import type { MercureBoundProps } from '../mercure/helpers/boundToMercureHub';
 import { boundToMercureHub } from '../mercure/helpers/boundToMercureHub';
 import { Topics } from '../mercure/helpers/Topics';
 import type { ReportExporter } from '../utils/services/ReportExporter';
@@ -22,7 +21,7 @@ type NonOrphanVisitsDeps = {
   ReportExporter: ReportExporter;
 };
 
-const NonOrphanVisits: FCWithDeps<MercureBoundProps & NonOrphanVisitsProps, NonOrphanVisitsDeps> = boundToMercureHub((
+const NonOrphanVisits: FCWithDeps<NonOrphanVisitsProps, NonOrphanVisitsDeps> = boundToMercureHub((
   { getNonOrphanVisits, nonOrphanVisits, cancelGetNonOrphanVisits, domainsList },
 ) => {
   const { ReportExporter: reportExporter } = useDependencies(NonOrphanVisits);

--- a/src/visits/OrphanVisits.tsx
+++ b/src/visits/OrphanVisits.tsx
@@ -2,7 +2,6 @@ import { useCallback, useMemo } from 'react';
 import type { FCWithDeps } from '../container/utils';
 import { componentFactory, useDependencies } from '../container/utils';
 import type { DomainsList } from '../domains/reducers/domainsList';
-import type { MercureBoundProps } from '../mercure/helpers/boundToMercureHub';
 import { boundToMercureHub } from '../mercure/helpers/boundToMercureHub';
 import { Topics } from '../mercure/helpers/Topics';
 import type { ReportExporter } from '../utils/services/ReportExporter';
@@ -26,7 +25,7 @@ type OrphanVisitsDeps = {
   ReportExporter: ReportExporter
 };
 
-const OrphanVisits: FCWithDeps<MercureBoundProps & OrphanVisitsProps, OrphanVisitsDeps> = boundToMercureHub((
+const OrphanVisits: FCWithDeps<OrphanVisitsProps, OrphanVisitsDeps> = boundToMercureHub((
   { getOrphanVisits, orphanVisits, cancelGetOrphanVisits, deleteOrphanVisits, orphanVisitsDeletion, domainsList },
 ) => {
   const { ReportExporter: reportExporter } = useDependencies(OrphanVisits);

--- a/src/visits/ShortUrlVisits.tsx
+++ b/src/visits/ShortUrlVisits.tsx
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useMemo } from 'react';
 import type { ShlinkShortUrlIdentifier } from '../api-contract';
 import type { FCWithDeps } from '../container/utils';
 import { componentFactory, useDependencies } from '../container/utils';
-import type { MercureBoundProps } from '../mercure/helpers/boundToMercureHub';
 import { boundToMercureHub } from '../mercure/helpers/boundToMercureHub';
 import { Topics } from '../mercure/helpers/Topics';
 import { urlDecodeShortCode } from '../short-urls/helpers';
@@ -30,7 +29,7 @@ type ShortUrlVisitsDeps = {
   ReportExporter: ReportExporter
 };
 
-const ShortUrlVisits: FCWithDeps<MercureBoundProps & ShortUrlVisitsProps, ShortUrlVisitsDeps> = boundToMercureHub(({
+const ShortUrlVisits: FCWithDeps<ShortUrlVisitsProps, ShortUrlVisitsDeps> = boundToMercureHub(({
   shortUrlVisits,
   shortUrlVisitsDeletion,
   shortUrlsDetails,

--- a/src/visits/TagVisits.tsx
+++ b/src/visits/TagVisits.tsx
@@ -3,7 +3,6 @@ import { useParams } from 'react-router';
 import type { FCWithDeps } from '../container/utils';
 import { componentFactory, useDependencies } from '../container/utils';
 import type { DomainsList } from '../domains/reducers/domainsList';
-import type { MercureBoundProps } from '../mercure/helpers/boundToMercureHub';
 import { boundToMercureHub } from '../mercure/helpers/boundToMercureHub';
 import { Topics } from '../mercure/helpers/Topics';
 import type { ColorGenerator } from '../utils/services/ColorGenerator';
@@ -26,7 +25,7 @@ type TagVisitsDeps = {
   ReportExporter: ReportExporter;
 };
 
-const TagVisits: FCWithDeps<MercureBoundProps & TagVisitsProps, TagVisitsDeps> = boundToMercureHub((
+const TagVisits: FCWithDeps<TagVisitsProps, TagVisitsDeps> = boundToMercureHub((
   { getTagVisits, tagVisits, cancelGetTagVisits, domainsList },
 ) => {
   const { ColorGenerator: colorGenerator, ReportExporter: reportExporter } = useDependencies(TagVisits);

--- a/src/visits/reducers/visitCreation.ts
+++ b/src/visits/reducers/visitCreation.ts
@@ -1,7 +1,19 @@
 import { createAction } from '@reduxjs/toolkit';
+import { useCallback } from 'react';
+import { useAppDispatch } from '../../store';
 import type { CreateVisit } from '../types';
 
 export const createNewVisits = createAction(
   'shlink/visitCreation/createNewVisits',
   (createdVisits: CreateVisit[]) => ({ payload: { createdVisits } }),
 );
+
+export const useVisitCreation = () => {
+  const dispatch = useAppDispatch();
+  const dispatchCreateNewVisits = useCallback(
+    (createdVisits: CreateVisit[]) => dispatch(createNewVisits(createdVisits)),
+    [dispatch],
+  );
+
+  return { createNewVisits: dispatchCreateNewVisits };
+};

--- a/src/visits/services/provideServices.ts
+++ b/src/visits/services/provideServices.ts
@@ -11,7 +11,6 @@ import { deleteOrphanVisits, orphanVisitsDeletionReducerCreator } from '../reduc
 import { getShortUrlVisits, shortUrlVisitsReducerCreator } from '../reducers/shortUrlVisits';
 import { deleteShortUrlVisits, shortUrlVisitsDeletionReducerCreator } from '../reducers/shortUrlVisitsDeletion';
 import { getTagVisits, tagVisitsReducerCreator } from '../reducers/tagVisits';
-import { createNewVisits } from '../reducers/visitCreation';
 import { loadVisitsOverview, visitsOverviewReducerCreator } from '../reducers/visitsOverview';
 import { ShortUrlVisitsFactory } from '../ShortUrlVisits';
 import { TagVisitsFactory } from '../TagVisits';
@@ -33,11 +32,6 @@ import { TagVisitsComparisonFactory } from '../visits-comparison/TagVisitsCompar
 import * as visitsParser from './VisitsParser';
 
 export const provideServices = (bottle: Bottle, connect: ConnectDecorator) => {
-  const connectWithMercure = (props: string[], actions: string[]) => connect(
-    [...props],
-    [...actions, 'createNewVisits'],
-  );
-
   // Components
   bottle.serviceFactory('MapModal', () => MapModal);
 
@@ -46,32 +40,30 @@ export const provideServices = (bottle: Bottle, connect: ConnectDecorator) => {
     'shortUrlVisits',
     'shortUrlVisitsDeletion',
     'shortUrlsDetails',
-    'mercureInfo',
   ], [
     'getShortUrlVisits',
     'deleteShortUrlVisits',
     'getShortUrlsDetails',
     'cancelGetShortUrlVisits',
-    'createNewVisits',
   ]));
 
   bottle.factory('TagVisits', TagVisitsFactory);
-  bottle.decorator('TagVisits', connectWithMercure(['tagVisits', 'domainsList'], ['getTagVisits', 'cancelGetTagVisits']));
+  bottle.decorator('TagVisits', connect(['tagVisits', 'domainsList'], ['getTagVisits', 'cancelGetTagVisits']));
 
   bottle.factory('TagVisitsComparison', TagVisitsComparisonFactory);
-  bottle.decorator('TagVisitsComparison', connectWithMercure(
+  bottle.decorator('TagVisitsComparison', connect(
     ['tagVisitsComparison'],
     ['getTagVisitsForComparison', 'cancelGetTagVisitsForComparison'],
   ));
 
   bottle.serviceFactory('DomainVisitsComparison', () => DomainVisitsComparison);
-  bottle.decorator('DomainVisitsComparison', connectWithMercure(
+  bottle.decorator('DomainVisitsComparison', connect(
     ['domainVisitsComparison'],
     ['getDomainVisitsForComparison', 'cancelGetDomainVisitsForComparison'],
   ));
 
   bottle.serviceFactory('ShortUrlVisitsComparison', () => ShortUrlVisitsComparison);
-  bottle.decorator('ShortUrlVisitsComparison', connectWithMercure(
+  bottle.decorator('ShortUrlVisitsComparison', connect(
     ['shortUrlVisitsComparison', 'shortUrlsDetails'],
     [
       'getShortUrlVisitsForComparison',
@@ -81,16 +73,16 @@ export const provideServices = (bottle: Bottle, connect: ConnectDecorator) => {
   ));
 
   bottle.factory('DomainVisits', DomainVisitsFactory);
-  bottle.decorator('DomainVisits', connectWithMercure(['domainVisits'], ['getDomainVisits', 'cancelGetDomainVisits']));
+  bottle.decorator('DomainVisits', connect(['domainVisits'], ['getDomainVisits', 'cancelGetDomainVisits']));
 
   bottle.factory('OrphanVisits', OrphanVisitsFactory);
-  bottle.decorator('OrphanVisits', connectWithMercure(
+  bottle.decorator('OrphanVisits', connect(
     ['orphanVisits', 'orphanVisitsDeletion', 'domainsList'],
     ['getOrphanVisits', 'cancelGetOrphanVisits', 'deleteOrphanVisits'],
   ));
 
   bottle.factory('NonOrphanVisits', NonOrphanVisitsFactory);
-  bottle.decorator('NonOrphanVisits', connectWithMercure(
+  bottle.decorator('NonOrphanVisits', connect(
     ['nonOrphanVisits', 'domainsList'],
     ['getNonOrphanVisits', 'cancelGetNonOrphanVisits'],
   ));
@@ -139,7 +131,6 @@ export const provideServices = (bottle: Bottle, connect: ConnectDecorator) => {
   bottle.serviceFactory('getNonOrphanVisits', getNonOrphanVisits, 'apiClientFactory');
   bottle.serviceFactory('cancelGetNonOrphanVisits', (obj) => obj.cancelGetVisits, 'nonOrphanVisitsReducerCreator');
 
-  bottle.serviceFactory('createNewVisits', () => createNewVisits);
   bottle.serviceFactory('loadVisitsOverview', loadVisitsOverview, 'apiClientFactory');
 
   // Reducers

--- a/src/visits/visits-comparison/DomainVisitsComparison.tsx
+++ b/src/visits/visits-comparison/DomainVisitsComparison.tsx
@@ -1,13 +1,13 @@
 import type { FC } from 'react';
 import { useCallback } from 'react';
-import { boundToMercureHub, type MercureBoundProps } from '../../mercure/helpers/boundToMercureHub';
+import { boundToMercureHub } from '../../mercure/helpers/boundToMercureHub';
 import { Topics } from '../../mercure/helpers/Topics';
 import { useArrayQueryParam } from '../../utils/helpers/hooks';
 import type { LoadDomainVisitsForComparison } from './reducers/domainVisitsComparison';
 import type { LoadVisitsForComparison, VisitsComparisonInfo } from './reducers/types';
 import { VisitsComparison } from './VisitsComparison';
 
-type DomainVisitsComparisonProps = MercureBoundProps & {
+type DomainVisitsComparisonProps = {
   getDomainVisitsForComparison: (params: LoadDomainVisitsForComparison) => void;
   domainVisitsComparison: VisitsComparisonInfo;
   cancelGetDomainVisitsComparison: () => void;

--- a/src/visits/visits-comparison/ShortUrlVisitsComparison.tsx
+++ b/src/visits/visits-comparison/ShortUrlVisitsComparison.tsx
@@ -1,7 +1,6 @@
 import type { FC } from 'react';
 import { useCallback, useEffect, useMemo } from 'react';
 import type { ShlinkShortUrlIdentifier,ShlinkVisit } from '../../api-contract';
-import type { MercureBoundProps } from '../../mercure/helpers/boundToMercureHub';
 import { boundToMercureHub } from '../../mercure/helpers/boundToMercureHub';
 import { Topics } from '../../mercure/helpers/Topics';
 import { queryToShortUrl, shortUrlToQuery } from '../../short-urls/helpers';
@@ -11,7 +10,7 @@ import type { LoadShortUrlVisitsForComparison } from './reducers/shortUrlVisitsC
 import type { LoadVisitsForComparison, VisitsComparisonInfo } from './reducers/types';
 import { VisitsComparison } from './VisitsComparison';
 
-type ShortUrlVisitsComparisonProps = MercureBoundProps & {
+type ShortUrlVisitsComparisonProps = {
   getShortUrlVisitsForComparison: (params: LoadShortUrlVisitsForComparison) => void;
   shortUrlVisitsComparison: VisitsComparisonInfo;
   cancelGetShortUrlVisitsComparison: () => void;

--- a/src/visits/visits-comparison/TagVisitsComparison.tsx
+++ b/src/visits/visits-comparison/TagVisitsComparison.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useMemo } from 'react';
 import type { FCWithDeps } from '../../container/utils';
 import { componentFactory, useDependencies } from '../../container/utils';
-import type { MercureBoundProps } from '../../mercure/helpers/boundToMercureHub';
 import { boundToMercureHub } from '../../mercure/helpers/boundToMercureHub';
 import { Topics } from '../../mercure/helpers/Topics';
 import { Tag } from '../../tags/helpers/Tag';
@@ -11,7 +10,7 @@ import type { LoadTagVisitsForComparison } from './reducers/tagVisitsComparison'
 import type { LoadVisitsForComparison, VisitsComparisonInfo } from './reducers/types';
 import { VisitsComparison } from './VisitsComparison';
 
-type TagVisitsComparisonProps = MercureBoundProps & {
+type TagVisitsComparisonProps = {
   getTagVisitsForComparison: (params: LoadTagVisitsForComparison) => void;
   tagVisitsComparison: VisitsComparisonInfo;
   cancelGetTagVisitsComparison: () => void;

--- a/test/overview/Overview.test.tsx
+++ b/test/overview/Overview.test.tsx
@@ -34,7 +34,6 @@ describe('<Overview />', () => {
                 nonOrphanVisits: { total: 3456, bots: 1000, nonBots: 2456 },
                 orphanVisits: { total: 28, bots: 15, nonBots: 13 },
               })}
-              createNewVisits={vi.fn()}
             />
           </RoutesPrefixProvider>
         </SettingsProvider>

--- a/test/short-urls/ShortUrlsList.test.tsx
+++ b/test/short-urls/ShortUrlsList.test.tsx
@@ -4,7 +4,6 @@ import type { MemoryHistory } from 'history';
 import { createMemoryHistory } from 'history';
 import { Router } from 'react-router';
 import { ContainerProvider } from '../../src/container/context';
-import type { MercureBoundProps } from '../../src/mercure/helpers/boundToMercureHub';
 import type { Settings } from '../../src/settings';
 import { SettingsProvider } from '../../src/settings';
 import type { ShortUrlsOrder } from '../../src/short-urls/data';
@@ -50,11 +49,7 @@ describe('<ShortUrlsList />', () => {
       <ContainerProvider value={fromPartial({ apiClientFactory: vi.fn() })}>
         <Router location={history.location} navigator={history}>
           <SettingsProvider value={fromPartial(settings)}>
-            <ShortUrlsList
-              {...fromPartial<MercureBoundProps>({})}
-              listShortUrls={listShortUrlsMock}
-              shortUrlsList={{ ...shortUrlsList, loading }}
-            />
+            <ShortUrlsList listShortUrls={listShortUrlsMock} shortUrlsList={{ ...shortUrlsList, loading }} />
           </SettingsProvider>
         </Router>
       </ContainerProvider>,

--- a/test/tags/TagsList.test.tsx
+++ b/test/tags/TagsList.test.tsx
@@ -1,7 +1,6 @@
 import { screen, waitFor } from '@testing-library/react';
 import { fromPartial } from '@total-typescript/shoehorn';
 import { ContainerProvider } from '../../src/container/context';
-import type { MercureBoundProps } from '../../src/mercure/helpers/boundToMercureHub';
 import { SettingsProvider } from '../../src/settings';
 import type { TagsList } from '../../src/tags/reducers/tagsList';
 import type { TagsListProps } from '../../src/tags/TagsList';
@@ -20,7 +19,6 @@ describe('<TagsList />', () => {
       <SettingsProvider value={fromPartial({ visits: { excludeBots } })}>
         <TagsListComp
           {...fromPartial<TagsListProps>({})}
-          {...fromPartial<MercureBoundProps>({})}
           filterTags={filterTags}
           tagsList={fromPartial({ filteredTags: [], ...tagsList })}
         />

--- a/test/visits/DomainVisits.test.tsx
+++ b/test/visits/DomainVisits.test.tsx
@@ -3,7 +3,6 @@ import { screen } from '@testing-library/react';
 import { fromPartial } from '@total-typescript/shoehorn';
 import { formatISO } from 'date-fns';
 import { ContainerProvider } from '../../src/container/context';
-import type { MercureBoundProps } from '../../src/mercure/helpers/boundToMercureHub';
 import { SettingsProvider } from '../../src/settings';
 import { DomainVisitsFactory } from '../../src/visits/DomainVisits';
 import type { DomainVisits } from '../../src/visits/reducers/domainVisits';
@@ -26,7 +25,6 @@ describe('<DomainVisits />', () => {
           {/* Wrap in Card so that it has the proper background color and passes a11y contrast checks */}
           <Card>
             <DomainVisits
-              {...fromPartial<MercureBoundProps>({})}
               getDomainVisits={getDomainVisits}
               cancelGetDomainVisits={cancelGetDomainVisits}
               domainVisits={domainVisits}

--- a/test/visits/NonOrphanVisits.test.tsx
+++ b/test/visits/NonOrphanVisits.test.tsx
@@ -4,7 +4,6 @@ import { fromPartial } from '@total-typescript/shoehorn';
 import { formatISO } from 'date-fns';
 import { MemoryRouter } from 'react-router';
 import { ContainerProvider } from '../../src/container/context';
-import type { MercureBoundProps } from '../../src/mercure/helpers/boundToMercureHub';
 import { SettingsProvider } from '../../src/settings';
 import { NonOrphanVisitsFactory } from '../../src/visits/NonOrphanVisits';
 import type { VisitsInfo } from '../../src/visits/reducers/types';
@@ -26,7 +25,6 @@ describe('<NonOrphanVisits />', () => {
           {/* Wrap in Card so that it has the proper background color and passes a11y contrast checks */}
           <Card>
             <NonOrphanVisits
-              {...fromPartial<MercureBoundProps>({})}
               getNonOrphanVisits={getNonOrphanVisits}
               cancelGetNonOrphanVisits={cancelGetNonOrphanVisits}
               nonOrphanVisits={nonOrphanVisits}

--- a/test/visits/OrphanVisits.test.tsx
+++ b/test/visits/OrphanVisits.test.tsx
@@ -4,7 +4,6 @@ import { fromPartial } from '@total-typescript/shoehorn';
 import { formatISO } from 'date-fns';
 import { MemoryRouter } from 'react-router';
 import { ContainerProvider } from '../../src/container/context';
-import type { MercureBoundProps } from '../../src/mercure/helpers/boundToMercureHub';
 import { SettingsProvider } from '../../src/settings';
 import { OrphanVisitsFactory } from '../../src/visits/OrphanVisits';
 import type { VisitsInfo } from '../../src/visits/reducers/types';
@@ -25,7 +24,6 @@ describe('<OrphanVisits />', () => {
           {/* Wrap in Card so that it has the proper background color and passes a11y contrast checks */}
           <Card>
             <OrphanVisits
-              {...fromPartial<MercureBoundProps>({})}
               getOrphanVisits={getOrphanVisits}
               orphanVisits={orphanVisits}
               cancelGetOrphanVisits={vi.fn()}

--- a/test/visits/ShortUrlVisits.test.tsx
+++ b/test/visits/ShortUrlVisits.test.tsx
@@ -6,7 +6,6 @@ import { formatISO } from 'date-fns';
 import { MemoryRouter } from 'react-router';
 import { now } from 'tinybench';
 import { ContainerProvider } from '../../src/container/context';
-import type { MercureBoundProps } from '../../src/mercure/helpers/boundToMercureHub';
 import { SettingsProvider } from '../../src/settings';
 import type { ShortUrlVisits as ShortUrlVisitsState } from '../../src/visits/reducers/shortUrlVisits';
 import { ShortUrlVisitsFactory } from '../../src/visits/ShortUrlVisits';
@@ -27,7 +26,6 @@ describe('<ShortUrlVisits />', () => {
           {/* Wrap in Card so that it has the proper background color and passes a11y contrast checks */}
           <Card>
             <ShortUrlVisits
-              {...fromPartial<MercureBoundProps>({})}
               getShortUrlsDetails={vi.fn()}
               getShortUrlVisits={getShortUrlVisitsMock}
               shortUrlVisits={shortUrlVisits}

--- a/test/visits/TagVisits.test.tsx
+++ b/test/visits/TagVisits.test.tsx
@@ -3,7 +3,6 @@ import { screen } from '@testing-library/react';
 import { fromPartial } from '@total-typescript/shoehorn';
 import { formatISO } from 'date-fns';
 import { ContainerProvider } from '../../src/container/context';
-import type { MercureBoundProps } from '../../src/mercure/helpers/boundToMercureHub';
 import { SettingsProvider } from '../../src/settings';
 import type { TagVisits as TagVisitsStats } from '../../src/visits/reducers/tagVisits';
 import { TagVisitsFactory } from '../../src/visits/TagVisits';
@@ -27,7 +26,6 @@ describe('<TagVisits />', () => {
           {/* Wrap in Card so that it has the proper background color and passes a11y contrast checks */}
           <Card>
             <TagVisits
-              {...fromPartial<MercureBoundProps>({})}
               getTagVisits={getTagVisitsMock}
               tagVisits={tagVisits}
               cancelGetTagVisits={() => {}}

--- a/test/visits/visits-comparison/DomainVisitsComparison.test.tsx
+++ b/test/visits/visits-comparison/DomainVisitsComparison.test.tsx
@@ -18,7 +18,6 @@ describe('<DomainVisitsComparison />', () => {
           domainVisitsComparison={fromPartial({
             visitsGroups: Object.fromEntries(domains.map((domain) => [domain, []])),
           })}
-          createNewVisits={vi.fn()}
         />
       </MemoryRouter>
     </ContainerProvider>,

--- a/test/visits/visits-comparison/ShortUrlVisitsComparison.test.tsx
+++ b/test/visits/visits-comparison/ShortUrlVisitsComparison.test.tsx
@@ -39,7 +39,6 @@ describe('<ShortUrlVisitsComparison />', () => {
             )),
             loading: loadingDetails,
           })}
-          createNewVisits={vi.fn()}
         />
       </MemoryRouter>
     </ContainerProvider>,

--- a/test/visits/visits-comparison/TagVisitsComparison.test.tsx
+++ b/test/visits/visits-comparison/TagVisitsComparison.test.tsx
@@ -22,7 +22,6 @@ describe('<TagVisitsComparison />', () => {
           tagVisitsComparison={fromPartial({
             visitsGroups: Object.fromEntries(tags.map((tag) => [tag, []])),
           })}
-          createNewVisits={vi.fn()}
         />
       </MemoryRouter>
     </ContainerProvider>,


### PR DESCRIPTION
Part of https://github.com/shlinkio/shlink-web-component/issues/161

Stop injecting createVisit-related redux actions, and provide a hook wrapping useDispatch instead.