### PR TITLE
Simplify short URL creation reducer type with a status discriminator prop

### DIFF
--- a/src/short-urls/CreateShortUrl.tsx
+++ b/src/short-urls/CreateShortUrl.tsx
@@ -45,7 +45,7 @@ const CreateShortUrl: FCWithDeps<CreateShortUrlProps, CreateShortUrlDeps> = ({
     <>
       <ShortUrlForm
         initialState={initialState}
-        saving={shortUrlCreation.saving}
+        saving={shortUrlCreation.status === 'saving'}
         basicMode={basicMode}
         onSave={async (data) => {
           resetCreateShortUrl();

--- a/src/short-urls/helpers/CreateShortUrlResult.tsx
+++ b/src/short-urls/helpers/CreateShortUrlResult.tsx
@@ -13,13 +13,13 @@ export type CreateShortUrlResultProps = {
 export const CreateShortUrlResult: FC<CreateShortUrlResultProps> = (
   { creation, resetCreateShortUrl, canBeClosed = false }: CreateShortUrlResultProps,
 ) => {
-  const { error, saved } = creation;
+  const { status } = creation;
 
   useEffect(() => {
     resetCreateShortUrl();
   }, [resetCreateShortUrl]);
 
-  if (error) {
+  if (status === 'error') {
     return (
       <Result variant="error" className="mt-4 relative">
         {canBeClosed && (
@@ -27,12 +27,12 @@ export const CreateShortUrlResult: FC<CreateShortUrlResultProps> = (
             <CloseButton onClick={resetCreateShortUrl} />
           </div>
         )}
-        <ShlinkApiError errorData={creation.errorData} fallbackMessage="An error occurred while creating the URL :(" />
+        <ShlinkApiError errorData={creation.error} fallbackMessage="An error occurred while creating the URL :(" />
       </Result>
     );
   }
 
-  if (!saved) {
+  if (status !== 'saved') {
     return null;
   }
 

--- a/src/short-urls/reducers/shortUrlCreation.ts
+++ b/src/short-urls/reducers/shortUrlCreation.ts
@@ -8,31 +8,18 @@ import { createAsyncThunk, useApiClientFactory } from '../../store/helpers';
 
 const REDUCER_PREFIX = 'shlink/shortUrlCreation';
 
-// TODO Migrate this to `status: 'idle' | 'saving' | 'saved' | 'error'`
 export type ShortUrlCreation = {
-  saving: false;
-  saved: false;
-  error: false;
+  status: 'idle' | 'saving';
 } | {
-  saving: true;
-  saved: false;
-  error: false;
-} | {
-  saving: false;
-  saved: false;
-  error: true;
-  errorData?: ProblemDetailsError;
-} | {
+  status: 'saved';
   result: ShlinkShortUrl;
-  saving: false;
-  saved: true;
-  error: false;
+} | {
+  status: 'error';
+  error?: ProblemDetailsError;
 };
 
 const initialState: ShortUrlCreation = {
-  saving: false,
-  saved: false,
-  error: false,
+  status: 'idle',
 };
 
 export const createShortUrlThunk = createAsyncThunk(
@@ -49,15 +36,12 @@ const { reducer, actions } = createSlice({
     resetCreateShortUrl: () => initialState,
   },
   extraReducers: (builder) => {
-    builder.addCase(createShortUrlThunk.pending, () => ({ saving: true, saved: false, error: false }));
+    builder.addCase(createShortUrlThunk.pending, () => ({ status: 'saving' }));
     builder.addCase(
       createShortUrlThunk.rejected,
-      (_, { error }) => ({ saving: false, saved: false, error: true, errorData: parseApiError(error) }),
+      (_, { error }) => ({ status: 'error', error: parseApiError(error) }),
     );
-    builder.addCase(
-      createShortUrlThunk.fulfilled,
-      (_, { payload: result }) => ({ result, saving: false, saved: true, error: false }),
-    );
+    builder.addCase(createShortUrlThunk.fulfilled, (_, { payload: result }) => ({ result, status: 'saved' }));
   },
 });
 

--- a/test/short-urls/helpers/CreateShortUrlResult.test.tsx
+++ b/test/short-urls/helpers/CreateShortUrlResult.test.tsx
@@ -11,34 +11,32 @@ describe('<CreateShortUrlResult />', () => {
   );
 
   it('passes a11y checks', () => checkAccessibility(setUp(
-    { result: fromPartial({ shortUrl: 'https://s.test/abc123' }), saving: false, saved: true, error: false },
+    { result: fromPartial({ shortUrl: 'https://s.test/abc123' }), status: 'saved' },
     true,
   )));
 
   it('renders an error when error is true', () => {
-    setUp({ error: true, saved: false, saving: false });
+    setUp({ status: 'error' });
     expect(screen.getByText('An error occurred while creating the URL :(')).toBeInTheDocument();
   });
 
-  it.each([[true], [false]])('renders nothing when not saved yet', (saving) => {
-    const { container } = setUp({ error: false, saved: false, saving });
+  it.each(['saving' as const, 'idle' as const])('renders nothing when not saved yet', (status) => {
+    const { container } = setUp({ status });
     expect(container.firstChild).toBeNull();
   });
 
   it('renders a result message when result is provided', () => {
-    setUp(
-      { result: fromPartial({ shortUrl: 'https://s.test/abc123' }), saving: false, saved: true, error: false },
-    );
+    setUp({ result: fromPartial({ shortUrl: 'https://s.test/abc123' }), status: 'saved' });
     expect(screen.getByText(/The short URL is/)).toHaveTextContent('Great! The short URL is https://s.test/abc123');
   });
 
   it.each([
     [
-      { result: fromPartial({ shortUrl: 'https://s.test/abc123' }), saving: false, saved: true, error: false },
+      { result: fromPartial({ shortUrl: 'https://s.test/abc123' }), status: 'saved' },
       'success-close-button',
       'error-close-button',
     ],
-    [{ error: true, saved: false, saving: false }, 'error-close-button', 'success-close-button'],
+    [{ status: 'error' }, 'error-close-button', 'success-close-button'],
   ])('displays close button if the result can be closed', (data, foundElement, notFoundElement) => {
     setUp(data as any, true);
 

--- a/test/short-urls/reducers/shortUrlCreation.test.ts
+++ b/test/short-urls/reducers/shortUrlCreation.test.ts
@@ -13,36 +13,22 @@ describe('shortUrlCreationReducer', () => {
 
   describe('reducer', () => {
     it('returns loading on CREATE_SHORT_URL_START', () => {
-      expect(reducer(undefined, createShortUrl.pending('', fromPartial({})))).toEqual({
-        saving: true,
-        saved: false,
-        error: false,
-      });
+      expect(reducer(undefined, createShortUrl.pending('', fromPartial({})))).toEqual({ status: 'saving' });
     });
 
     it('returns error on CREATE_SHORT_URL_ERROR', () => {
-      expect(reducer(undefined, createShortUrl.rejected(null, '', fromPartial({})))).toEqual({
-        saving: false,
-        saved: false,
-        error: true,
-      });
+      expect(reducer(undefined, createShortUrl.rejected(null, '', fromPartial({})))).toEqual({ status: 'error' });
     });
 
     it('returns result on CREATE_SHORT_URL', () => {
       expect(reducer(undefined, createShortUrl.fulfilled(shortUrl, '', fromPartial({})))).toEqual({
         result: shortUrl,
-        saving: false,
-        saved: true,
-        error: false,
+        status: 'saved',
       });
     });
 
     it('returns default state on RESET_CREATE_SHORT_URL', () => {
-      expect(reducer(undefined, resetCreateShortUrl())).toEqual({
-        saving: false,
-        saved: false,
-        error: false,
-      });
+      expect(reducer(undefined, resetCreateShortUrl())).toEqual({ status: 'idle' });
     });
   });
 


### PR DESCRIPTION
Part of https://github.com/shlinkio/shlink-web-component/issues/874

Replace the multiple boolean flags that determine the status of the short URL creation reducer, with a single `status` discriminator prop that is less error prone and easier to reason about.