### PR TITLE
Simplify domains list reducer type with a status discriminator prop

### DIFF
--- a/src/domains/ManageDomains.tsx
+++ b/src/domains/ManageDomains.tsx
@@ -44,11 +44,11 @@ const headers: Array<{ value: string; isHidden: boolean }> = [
 ];
 
 export const ManageDomains: FC<ManageDomainsProps> = ({ domainsList, filterDomains, checkDomainHealth }) => {
-  const { filteredDomains: domains, defaultRedirects, loading, error, errorData } = domainsList;
+  const { filteredDomains: domains, defaultRedirects, status } = domainsList;
   const resolvedDefaultRedirects = defaultRedirects ?? domains.find(({ isDefault }) => isDefault)?.redirects;
   const visitsComparison = useVisitsComparison();
 
-  if (loading) {
+  if (status === 'loading') {
     return <Message loading />;
   }
 
@@ -57,12 +57,11 @@ export const ManageDomains: FC<ManageDomainsProps> = ({ domainsList, filterDomai
       <div className="flex flex-col gap-y-4">
         <SearchInput onChange={filterDomains} />
         <VisitsComparisonCollector type="domains" />
-        {error && (
+        {status === 'error' ? (
           <Result variant="error">
-            <ShlinkApiError errorData={errorData} fallbackMessage="Error loading domains :(" />
+            <ShlinkApiError errorData={domainsList.error} fallbackMessage="Error loading domains :(" />
           </Result>
-        )}
-        {!error && (
+        ) : (
           <SimpleCard className="card">
             <Table header={
               <Table.Row>

--- a/test/domains/ManageDomains.test.tsx
+++ b/test/domains/ManageDomains.test.tsx
@@ -16,11 +16,11 @@ describe('<ManageDomains />', () => {
   );
 
   it('passes a11y checks', () => checkAccessibility(
-    setUp(fromPartial({ loading: false, error: false, filteredDomains: [] })),
+    setUp(fromPartial({ status: 'idle', filteredDomains: [] })),
   ));
 
   it('shows loading message while domains are loading', () => {
-    setUp(fromPartial({ loading: true, filteredDomains: [] }));
+    setUp(fromPartial({ status: 'loading', filteredDomains: [] }));
 
     expect(screen.getByText('Loading...')).toBeInTheDocument();
     expect(screen.queryByText('Error loading domains :(')).not.toBeInTheDocument();
@@ -30,15 +30,15 @@ describe('<ManageDomains />', () => {
     [undefined, 'Error loading domains :('],
     [fromPartial<ProblemDetailsError>({}), 'Error loading domains :('],
     [fromPartial<ProblemDetailsError>({ detail: 'Foo error!!' }), 'Foo error!!'],
-  ])('shows error result when domains loading fails', (errorData, expectedErrorMessage) => {
-    setUp(fromPartial({ loading: false, error: true, errorData, filteredDomains: [] }));
+  ])('shows error result when domains loading fails', (error, expectedErrorMessage) => {
+    setUp(fromPartial({ status: 'error', error, filteredDomains: [] }));
 
     expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
     expect(screen.getByText(expectedErrorMessage)).toBeInTheDocument();
   });
 
   it('filters domains when SearchField changes', async () => {
-    const { user } = setUp(fromPartial({ loading: false, error: false, filteredDomains: [] }));
+    const { user } = setUp(fromPartial({ status: 'idle', filteredDomains: [] }));
 
     expect(filterDomains).not.toHaveBeenCalled();
     await user.type(screen.getByPlaceholderText('Search...'), 'Foo');
@@ -46,7 +46,7 @@ describe('<ManageDomains />', () => {
   });
 
   it('shows expected headers and one row when list of domains is empty', () => {
-    setUp(fromPartial({ loading: false, error: false, filteredDomains: [] }));
+    setUp(fromPartial({ status: 'idle', filteredDomains: [] }));
 
     expect(screen.getAllByRole('columnheader', {
       // Tests are run in a mobile resolution, where table headers are hidden
@@ -61,7 +61,7 @@ describe('<ManageDomains />', () => {
       fromPartial({ domain: 'bar' }),
       fromPartial({ domain: 'baz' }),
     ];
-    setUp(fromPartial({ loading: false, error: false, filteredDomains }));
+    setUp(fromPartial({ status: 'idle', filteredDomains }));
 
     expect(screen.getAllByRole('row')).toHaveLength(filteredDomains.length);
     expect(screen.getByText('foo')).toBeInTheDocument();

--- a/test/domains/reducers/domainsList.test.ts
+++ b/test/domains/reducers/domainsList.test.ts
@@ -30,20 +30,20 @@ describe('domainsListReducer', () => {
   describe('reducer', () => {
     it('returns loading on LIST_DOMAINS_START', () => {
       expect(reducer(undefined, listDomainsAction.pending(''))).toEqual(
-        { domains: [], filteredDomains: [], loading: true, error: false },
+        { domains: [], filteredDomains: [], status: 'loading' },
       );
     });
 
     it('returns error on LIST_DOMAINS_ERROR', () => {
       expect(reducer(undefined, listDomainsAction.rejected(error, ''))).toEqual(
-        { domains: [], filteredDomains: [], loading: false, error: true, errorData: parseApiError(error) },
+        { domains: [], filteredDomains: [], status: 'error', error: parseApiError(error) },
       );
     });
 
     it('returns domains on LIST_DOMAINS', () => {
       expect(
         reducer(undefined, listDomainsAction.fulfilled({ domains }, '')),
-      ).toEqual({ domains, filteredDomains: domains, loading: false, error: false });
+      ).toEqual({ domains, filteredDomains: domains, status: 'idle' });
     });
 
     it('filters domains on FILTER_DOMAINS', () => {


### PR DESCRIPTION
Part of https://github.com/shlinkio/shlink-web-component/issues/874

Replace the multiple boolean flags that determine the status of the domains list reducer, with a single status discriminator prop that is less error prone and easier to reason about.