### PR TITLE
Simplify url deletion reducer type with a status discriminator prop

### DIFF
--- a/src/short-urls/helpers/DeleteShortUrlModal.tsx
+++ b/src/short-urls/helpers/DeleteShortUrlModal.tsx
@@ -19,7 +19,8 @@ export const DeleteShortUrlModal = ({ shortUrl, onClose, isOpen }: DeleteShortUr
     };
   }, [resetDeleteShortUrl]);
 
-  const { loading, error, deleted, errorData } = shortUrlDeletion;
+  const { status } = shortUrlDeletion;
+  const deleting = status === 'deleting';
   const close = useCallback(() => {
     resetDeleteShortUrl();
     onClose();
@@ -34,11 +35,11 @@ export const DeleteShortUrlModal = ({ shortUrl, onClose, isOpen }: DeleteShortUr
       open={isOpen}
       title="Delete short URL"
       variant="danger"
-      confirmText={loading ? 'Deleting...' : 'Delete'}
-      confirmDisabled={inputValue !== DELETION_PATTERN || loading}
+      confirmText={deleting ? 'Deleting...' : 'Delete'}
+      confirmDisabled={inputValue !== DELETION_PATTERN || deleting}
       onConfirm={handleDeleteUrl}
       onClose={close}
-      onClosed={() => deleted && shortUrlDeleted(shortUrl)}
+      onClosed={() => status === 'deleted' && shortUrlDeleted(shortUrl)}
     >
       <div className="flex flex-col gap-y-2">
         <p><b className="text-danger">Caution!</b> You are about to delete a short URL.</p>
@@ -53,9 +54,9 @@ export const DeleteShortUrlModal = ({ shortUrl, onClose, isOpen }: DeleteShortUr
           onKeyDown={(e) => e.key === 'Enter' && handleDeleteUrl()}
         />
 
-        {error && (
-          <Result variant={isInvalidDeletionError(errorData) ? 'warning' : 'error'} size="sm" className="mt-2">
-            <ShlinkApiError errorData={errorData} fallbackMessage="Something went wrong while deleting the URL :(" />
+        {status === 'error' && (
+          <Result variant={isInvalidDeletionError(shortUrlDeletion.error) ? 'warning' : 'error'} size="sm" className="mt-2">
+            <ShlinkApiError errorData={shortUrlDeletion.error} fallbackMessage="Something went wrong while deleting the URL :(" />
           </Result>
         )}
       </div>

--- a/test/short-urls/reducers/shortUrlDeletion.test.ts
+++ b/test/short-urls/reducers/shortUrlDeletion.test.ts
@@ -14,40 +14,25 @@ describe('shortUrlDeletionReducer', () => {
   describe('reducer', () => {
     it('returns loading on DELETE_SHORT_URL_START', () =>
       expect(reducer(undefined, deleteShortUrl.pending('', { shortCode: '', apiClientFactory }))).toEqual({
-        shortCode: '',
-        loading: true,
-        error: false,
-        deleted: false,
+        status: 'deleting',
       }));
 
-    it('returns default on RESET_DELETE_SHORT_URL', () =>
-      expect(reducer(undefined, resetDeleteShortUrl())).toEqual({
-        shortCode: '',
-        loading: false,
-        error: false,
-        deleted: false,
-      }));
+    it('returns default on RESET_DELETE_SHORT_URL', () => {
+      expect(reducer(undefined, resetDeleteShortUrl())).toEqual({ status: 'idle' });
+    });
 
     it('returns shortCode on SHORT_URL_DELETED', () =>
       expect(reducer(undefined, deleteShortUrl.fulfilled({ shortCode: 'foo' }, '', {
         shortCode: 'foo',
         apiClientFactory,
-      }))).toEqual({
-        shortCode: 'foo',
-        loading: false,
-        error: false,
-        deleted: true,
-      }));
+      }))).toEqual({ shortCode: 'foo', status: 'deleted' }));
 
     it('returns errorData on DELETE_SHORT_URL_ERROR', () => {
-      const errorData = problemDetailsError;
+      const error = problemDetailsError;
 
-      expect(reducer(undefined, deleteShortUrl.rejected(errorData, '', { shortCode: '', apiClientFactory }))).toEqual({
-        shortCode: '',
-        loading: false,
-        error: true,
-        deleted: false,
-        errorData,
+      expect(reducer(undefined, deleteShortUrl.rejected(error, '', { shortCode: '', apiClientFactory }))).toEqual({
+        status: 'error',
+        error,
       });
     });
   });


### PR DESCRIPTION
Part of https://github.com/shlinkio/shlink-web-component/issues/874

Replace the multiple boolean flags that determine the status of the url deletion reducer, with a single status discriminator prop that is less error prone and easier to reason about.