### PR TITLE
Fix real-time updates interval setting being ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [Unreleased]
+### Added
+* *Nothing*
+
+### Changed
+* *Nothing*
+
+### Deprecated
+* *Nothing*
+
+### Removed
+* *Nothing*
+
+### Fixed
+* [#878](https://github.com/shlinkio/shlink-web-component/issues/878) Fix real-time updates interval setting being ignored.
+
+
 ## [0.17.0] - 2025-11-12
 ### Added
 * [#839](https://github.com/shlinkio/shlink-web-component/issues/839) Allow filtering short URLs by excluded tags when using Shlink >=4.6.0

--- a/src/mercure/helpers/boundToMercureHub.tsx
+++ b/src/mercure/helpers/boundToMercureHub.tsx
@@ -1,6 +1,7 @@
 import type { FC } from 'react';
 import { useEffect } from 'react';
 import { useParams } from 'react-router';
+import { useSetting } from '../../settings';
 import { useVisitCreation } from '../../visits/reducers/visitCreation';
 import type { CreateVisit } from '../../visits/types';
 import { useMercureInfo } from '../reducers/mercureInfo';
@@ -16,10 +17,10 @@ export function boundToMercureHub<T extends object>(
     const { createNewVisits } = useVisitCreation();
     const { loadMercureInfo, mercureInfo } = useMercureInfo();
     const params = useParams();
+    const { interval } = useSetting('realTimeUpdates', { enabled: true });
 
     // Every time mercure info changes, re-bind
     useEffect(() => {
-      const { interval } = mercureInfo;
       const onMessage = (visit: CreateVisit) => (interval ? pendingUpdates.add(visit) : createNewVisits([visit]));
       const topics = getTopicsForParams(params);
       const closeEventSource = bindToMercureTopic(mercureInfo, topics, onMessage, loadMercureInfo);
@@ -37,7 +38,7 @@ export function boundToMercureHub<T extends object>(
         clearInterval(timer);
         closeEventSource?.();
       };
-    }, [createNewVisits, loadMercureInfo, mercureInfo, params]);
+    }, [createNewVisits, interval, loadMercureInfo, mercureInfo, params]);
 
     return <WrappedComponent {...props} />;
   };

--- a/src/mercure/reducers/mercureInfo.ts
+++ b/src/mercure/reducers/mercureInfo.ts
@@ -9,7 +9,6 @@ import { createAsyncThunk, useApiClientFactory } from '../../store/helpers';
 const REDUCER_PREFIX = 'shlink/mercure';
 
 export type MercureInfo = Partial<ShlinkMercureInfo> & {
-  interval?: number;
   loading: boolean;
   error: boolean;
 };


### PR DESCRIPTION
Closes #878

Change the `boundToMercureHub` HOC so that it reads the interval configuration from the settings rather than the reducer, since it's ever set in the later.