### PR TITLE
Simplify mercure info reducer type with a status discriminator prop

### DIFF
--- a/src/mercure/helpers/index.ts
+++ b/src/mercure/helpers/index.ts
@@ -7,9 +7,9 @@ export const bindToMercureTopic = <T>(
   onMessage: (message: T) => void,
   onTokenExpired: () => void,
 ) => {
-  const { mercureHubUrl, token, loading, error } = mercureInfo;
+  const { status } = mercureInfo;
 
-  if (loading || error || !mercureHubUrl) {
+  if (status !== 'loaded' || !mercureInfo.mercureHubUrl) {
     return undefined;
   }
 
@@ -17,12 +17,12 @@ export const bindToMercureTopic = <T>(
   const onEventSourceError = ({ status }: { status: number }) => status === 401 && onTokenExpired();
 
   const subscriptions = topics.map((topic) => {
-    const hubUrl = new URL(mercureHubUrl);
+    const hubUrl = new URL(mercureInfo.mercureHubUrl);
 
     hubUrl.searchParams.append('topic', topic);
     const es = new EventSource(hubUrl, {
       headers: {
-        Authorization: `Bearer ${token}`,
+        Authorization: `Bearer ${mercureInfo.token}`,
       },
     });
 

--- a/src/mercure/reducers/mercureInfo.ts
+++ b/src/mercure/reducers/mercureInfo.ts
@@ -8,14 +8,14 @@ import { createAsyncThunk, useApiClientFactory } from '../../store/helpers';
 
 const REDUCER_PREFIX = 'shlink/mercure';
 
-export type MercureInfo = Partial<ShlinkMercureInfo> & {
-  loading: boolean;
-  error: boolean;
-};
+export type MercureInfo = {
+  status: 'loading' | 'error';
+} | (ShlinkMercureInfo & {
+  status: 'loaded';
+});
 
 const initialState: MercureInfo = {
-  loading: true,
-  error: false,
+  status: 'loading',
 };
 
 export const loadMercureInfo = createAsyncThunk(
@@ -31,12 +31,12 @@ export const loadMercureInfo = createAsyncThunk(
 
 const { reducer } = createSlice({
   name: REDUCER_PREFIX,
-  initialState,
+  initialState: initialState as MercureInfo,
   reducers: {},
   extraReducers: (builder) => {
-    builder.addCase(loadMercureInfo.pending, (state) => ({ ...state, loading: true, error: false }));
-    builder.addCase(loadMercureInfo.rejected, (state) => ({ ...state, loading: false, error: true }));
-    builder.addCase(loadMercureInfo.fulfilled, (_, { payload }) => ({ ...payload, loading: false, error: false }));
+    builder.addCase(loadMercureInfo.pending, () => initialState);
+    builder.addCase(loadMercureInfo.rejected, () => ({ status: 'error' }));
+    builder.addCase(loadMercureInfo.fulfilled, (_, { payload }) => ({ ...payload, status: 'loaded' }));
   },
 });
 

--- a/test/mercure/helpers/index.test.tsx
+++ b/test/mercure/helpers/index.test.tsx
@@ -13,11 +13,9 @@ describe('helpers', () => {
     const onTokenExpired = vi.fn();
 
     it.each([
-      [fromPartial<MercureInfo>({ loading: true, error: false, mercureHubUrl: 'foo' })],
-      [fromPartial<MercureInfo>({ loading: false, error: true, mercureHubUrl: 'foo' })],
-      [fromPartial<MercureInfo>({ loading: true, error: true, mercureHubUrl: 'foo' })],
-      [fromPartial<MercureInfo>({ loading: false, error: false, mercureHubUrl: undefined })],
-      [fromPartial<MercureInfo>({ loading: true, error: true, mercureHubUrl: undefined })],
+      [fromPartial<MercureInfo>({ status: 'error' })],
+      [fromPartial<MercureInfo>({ status: 'loading' })],
+      [fromPartial<MercureInfo>({ status: 'loaded', mercureHubUrl: undefined })],
     ])('does not bind an EventSource when loading, error or no hub URL', (mercureInfo) => {
       bindToMercureTopic(mercureInfo, [''], noop, noop);
 
@@ -35,8 +33,7 @@ describe('helpers', () => {
       hubUrl.searchParams.append('topic', topic);
 
       const callback = bindToMercureTopic({
-        loading: false,
-        error: false,
+        status: 'loaded',
         mercureHubUrl,
         token,
       }, [topic], onMessage, onTokenExpired);

--- a/test/mercure/reducers/mercureInfo.test.ts
+++ b/test/mercure/reducers/mercureInfo.test.ts
@@ -14,22 +14,16 @@ describe('mercureInfoReducer', () => {
 
   describe('reducer', () => {
     it('returns loading on GET_MERCURE_INFO_START', () => {
-      expect(reducer(undefined, loadMercureInfo.pending('', { apiClientFactory }))).toEqual({
-        loading: true,
-        error: false,
-      });
+      expect(reducer(undefined, loadMercureInfo.pending('', { apiClientFactory }))).toEqual({ status: 'loading' });
     });
 
     it('returns error on GET_MERCURE_INFO_ERROR', () => {
-      expect(reducer(undefined, loadMercureInfo.rejected(null, '', { apiClientFactory }))).toEqual({
-        loading: false,
-        error: true,
-      });
+      expect(reducer(undefined, loadMercureInfo.rejected(null, '', { apiClientFactory }))).toEqual({ status: 'error' });
     });
 
     it('returns mercure info on GET_MERCURE_INFO', () => {
       expect(reducer(undefined, loadMercureInfo.fulfilled(mercureInfo, '', { apiClientFactory }))).toEqual(
-        expect.objectContaining({ ...mercureInfo, loading: false, error: false }),
+        expect.objectContaining({ ...mercureInfo, status: 'loaded' }),
       );
     });
   });

--- a/test/short-urls/ShortUrlsList.test.tsx
+++ b/test/short-urls/ShortUrlsList.test.tsx
@@ -51,7 +51,7 @@ describe('<ShortUrlsList />', () => {
       {
         initialState: {
           shortUrlsList: fromPartial<ShortUrlsListModel>({ shortUrls: shortUrlsApiResponse }),
-          mercureInfo: fromPartial({ loading: true }),
+          mercureInfo: fromPartial({ status: 'loading' }),
         },
         apiClientFactory,
       },


### PR DESCRIPTION
Part of https://github.com/shlinkio/shlink-web-component/issues/874

Replace the multiple boolean flags that determine the status of the mercure info reducer, with a single status discriminator prop that is less error prone and easier to reason about.