### PR TITLE
Simplify url redirect rules reducer type with a status discriminator prop

### DIFF
--- a/src/redirect-rules/ShortUrlRedirectRules.tsx
+++ b/src/redirect-rules/ShortUrlRedirectRules.tsx
@@ -37,6 +37,7 @@ export const ShortUrlRedirectRules: FC<ShortUrlRedirectRulesProps> = ({
   shortUrlRedirectRulesSaving,
   resetSetRules,
 }) => {
+  const loading = shortUrlRedirectRules.status === 'loading';
   const identifier = useShortUrlIdentifier();
   const { shortUrls } = shortUrlsDetails;
   const shortUrl = identifier && shortUrls?.get(identifier);
@@ -93,12 +94,15 @@ export const ShortUrlRedirectRules: FC<ShortUrlRedirectRulesProps> = ({
     return resetSetRules;
   }, [getShortUrlRedirectRules, getShortUrlsDetails, identifier, resetSetRules]);
 
+  const { redirectRules, defaultLongUrl } = shortUrlRedirectRules.status === 'loaded'
+    ? shortUrlRedirectRules
+    : { defaultLongUrl: '' };
   useEffect(() => {
     // Initialize rules once loaded
-    if (shortUrlRedirectRules.redirectRules) {
-      setRules(shortUrlRedirectRules.redirectRules);
+    if (redirectRules) {
+      setRules(redirectRules);
     }
-  }, [setRules, shortUrlRedirectRules.redirectRules]);
+  }, [setRules, redirectRules]);
 
   return (
     <div className="flex flex-col gap-4">
@@ -117,7 +121,7 @@ export const ShortUrlRedirectRules: FC<ShortUrlRedirectRulesProps> = ({
           <div>
             <p>Configure dynamic conditions that will be checked at runtime.</p>
             <p>
-              If no conditions match, visitors will be redirected to: <ExternalLink href={shortUrlRedirectRules.defaultLongUrl ?? ''} />
+              If no conditions match, visitors will be redirected to: <ExternalLink href={defaultLongUrl} />
             </p>
           </div>
         </SimpleCard>
@@ -128,8 +132,8 @@ export const ShortUrlRedirectRules: FC<ShortUrlRedirectRulesProps> = ({
         </Button>
       </div>
       <form onSubmit={onSubmit}>
-        {shortUrlRedirectRules.loading && <Message loading />}
-        {rules.length === 0 && !shortUrlRedirectRules.loading && (
+        {loading && <Message loading />}
+        {rules.length === 0 && !loading && (
           <SimpleCard className="text-center"><i>This short URL has no dynamic redirect rules</i></SimpleCard>
         )}
         <div className="flex flex-col gap-2" ref={rulesContainerRef}>

--- a/src/redirect-rules/reducers/shortUrlRedirectRules.ts
+++ b/src/redirect-rules/reducers/shortUrlRedirectRules.ts
@@ -1,19 +1,17 @@
 import { createSlice } from '@reduxjs/toolkit';
-import type { ShlinkApiClient, ShlinkRedirectRuleData, ShlinkShortUrlIdentifier } from '../../api-contract';
+import type { ShlinkApiClient, ShlinkRedirectRulesList, ShlinkShortUrlIdentifier } from '../../api-contract';
 import { createAsyncThunk } from '../../store/helpers';
 
 const REDUCER_PREFIX = 'shlink/getShortUrlRedirectRules';
 
 export type ShortUrlRedirectRules = {
-  redirectRules?: ShlinkRedirectRuleData[];
-  defaultLongUrl?: string;
-  loading: boolean;
-  error: boolean;
-};
+  status: 'idle' | 'loading' | 'error';
+} | (ShlinkRedirectRulesList & {
+  status: 'loaded';
+});
 
 const initialState: ShortUrlRedirectRules = {
-  loading: true,
-  error: false,
+  status: 'idle',
 };
 
 export const getShortUrlRedirectRules = (apiClientFactory: () => ShlinkApiClient) => createAsyncThunk(
@@ -27,14 +25,14 @@ export const shortUrlRedirectRulesReducerCreator = (
   getShortUrlRedirectRulesThunk: ReturnType<typeof getShortUrlRedirectRules>,
 ) => createSlice({
   name: REDUCER_PREFIX,
-  initialState,
+  initialState: initialState as ShortUrlRedirectRules,
   reducers: {},
   extraReducers: (builder) => {
-    builder.addCase(getShortUrlRedirectRulesThunk.pending, () => ({ loading: true, error: false }));
-    builder.addCase(getShortUrlRedirectRulesThunk.rejected, () => ({ loading: false, error: true }));
+    builder.addCase(getShortUrlRedirectRulesThunk.pending, () => ({ status: 'loading' }));
+    builder.addCase(getShortUrlRedirectRulesThunk.rejected, () => ({ status: 'error' }));
     builder.addCase(
       getShortUrlRedirectRulesThunk.fulfilled,
-      (_, { payload }) => ({ loading: false, error: false, ...payload }),
+      (_, { payload }) => ({ status: 'loaded', ...payload }),
     );
   },
 });

--- a/test/redirect-rules/ShortUrlRedirectRules.test.tsx
+++ b/test/redirect-rules/ShortUrlRedirectRules.test.tsx
@@ -25,7 +25,8 @@ describe('<ShortUrlRedirectRules />', () => {
       {/* Wrap in Card so that it has the proper background color and passes a11y contrast checks */}
       <Card>
         <ShortUrlRedirectRules
-          shortUrlRedirectRules={fromPartial(loading ? { loading } : {
+          shortUrlRedirectRules={fromPartial(loading ? { status: 'loading' } : {
+            status: 'loaded',
             defaultLongUrl: 'https://shlink.io',
             redirectRules: [
               { longUrl: 'https://example.com/first', conditions: [{ type: 'device' }] },

--- a/test/redirect-rules/reducers/shortUrlRedirectRules.test.ts
+++ b/test/redirect-rules/reducers/shortUrlRedirectRules.test.ts
@@ -18,7 +18,7 @@ describe('shortUrlRedirectRulesReducer', () => {
   describe('reducer', () => {
     it('returns loading on pending', () => {
       const result = reducer(undefined, getShortUrlRedirectRules.pending('', fromPartial({}), undefined));
-      expect(result).toEqual({ loading: true, error: false });
+      expect(result).toEqual({ status: 'loading' });
     });
 
     it('returns error data on rejected', () => {
@@ -27,7 +27,7 @@ describe('shortUrlRedirectRulesReducer', () => {
         undefined,
         getShortUrlRedirectRules.rejected(error, '', fromPartial({}), undefined, undefined),
       );
-      expect(result).toEqual({ loading: false, error: true, errorData: parseApiError(error) });
+      expect(result).toEqual({ status: 'error', error: parseApiError(error) });
     });
 
     it('returns result on fulfilled', () => {
@@ -35,7 +35,7 @@ describe('shortUrlRedirectRulesReducer', () => {
         undefined,
         getShortUrlRedirectRules.fulfilled(fromPartial({}), '', fromPartial({}), undefined),
       );
-      expect(result).toEqual(expect.objectContaining({ loading: false, error: false }));
+      expect(result).toEqual(expect.objectContaining({ status: 'loaded' }));
     });
   });
 


### PR DESCRIPTION
Part of https://github.com/shlinkio/shlink-web-component/issues/874

Replace the multiple boolean flags that determine the status of the url redirect rules reducer, with a single status discriminator prop that is less error prone and easier to reason about.