### PR TITLE
Create hook for short URL redirect rules reducer module

### DIFF
--- a/src/redirect-rules/ShortUrlRedirectRules.tsx
+++ b/src/redirect-rules/ShortUrlRedirectRules.tsx
@@ -1,7 +1,7 @@
 import { useDragAndDrop } from '@formkit/drag-and-drop/react';
 import { faPlus } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { Button, Message, Result, SimpleCard,useToggle  } from '@shlinkio/shlink-frontend-kit';
+import { Button, Message, Result, SimpleCard, useToggle } from '@shlinkio/shlink-frontend-kit';
 import type { ShlinkRedirectRuleData, ShlinkShortUrlIdentifier } from '@shlinkio/shlink-js-sdk/api-contract';
 import type { FC, FormEvent } from 'react';
 import { useCallback, useEffect } from 'react';
@@ -13,12 +13,9 @@ import { GoBackButton } from '../utils/components/GoBackButton';
 import { RedirectRuleCard } from './helpers/RedirectRuleCard';
 import { RedirectRuleModal } from './helpers/RedirectRuleModal';
 import type { SetShortUrlRedirectRules, SetShortUrlRedirectRulesInfo } from './reducers/setShortUrlRedirectRules';
-import type { ShortUrlRedirectRules as RedirectRules } from './reducers/shortUrlRedirectRules';
+import { useUrlRedirectRules } from './reducers/shortUrlRedirectRules';
 
-type ShortUrlRedirectRulesProps = {
-  shortUrlRedirectRules: RedirectRules;
-  getShortUrlRedirectRules: (shortUrl: ShlinkShortUrlIdentifier) => void;
-
+export type ShortUrlRedirectRulesProps = {
   shortUrlsDetails: ShortUrlsDetails;
   getShortUrlsDetails: (identifiers: ShlinkShortUrlIdentifier[]) => void;
 
@@ -29,14 +26,13 @@ type ShortUrlRedirectRulesProps = {
 };
 
 export const ShortUrlRedirectRules: FC<ShortUrlRedirectRulesProps> = ({
-  shortUrlRedirectRules,
-  getShortUrlRedirectRules,
   getShortUrlsDetails,
   shortUrlsDetails,
   setShortUrlRedirectRules,
   shortUrlRedirectRulesSaving,
   resetSetRules,
 }) => {
+  const { shortUrlRedirectRules, getShortUrlRedirectRules } = useUrlRedirectRules();
   const loading = shortUrlRedirectRules.status === 'loading';
   const identifier = useShortUrlIdentifier();
   const { shortUrls } = shortUrlsDetails;
@@ -96,7 +92,7 @@ export const ShortUrlRedirectRules: FC<ShortUrlRedirectRulesProps> = ({
 
   const { redirectRules, defaultLongUrl } = shortUrlRedirectRules.status === 'loaded'
     ? shortUrlRedirectRules
-    : { defaultLongUrl: '' };
+    : {};
   useEffect(() => {
     // Initialize rules once loaded
     if (redirectRules) {
@@ -120,9 +116,11 @@ export const ShortUrlRedirectRules: FC<ShortUrlRedirectRulesProps> = ({
           <hr />
           <div>
             <p>Configure dynamic conditions that will be checked at runtime.</p>
-            <p>
-              If no conditions match, visitors will be redirected to: <ExternalLink href={defaultLongUrl} />
-            </p>
+            {defaultLongUrl && (
+              <p>
+                If no conditions match, visitors will be redirected to: <ExternalLink href={defaultLongUrl} />
+              </p>
+            )}
           </div>
         </SimpleCard>
       </header>

--- a/src/redirect-rules/services/provideServices.ts
+++ b/src/redirect-rules/services/provideServices.ts
@@ -1,33 +1,21 @@
 import type Bottle from 'bottlejs';
 import type { ConnectDecorator } from '../../container';
 import { setShortUrlRedirectRules, setShortUrlRedirectRulesReducerCreator } from '../reducers/setShortUrlRedirectRules';
-import {
-  getShortUrlRedirectRules,
-  shortUrlRedirectRulesReducerCreator,
-} from '../reducers/shortUrlRedirectRules';
 import { ShortUrlRedirectRules } from '../ShortUrlRedirectRules';
 
 export const provideServices = (bottle: Bottle, connect: ConnectDecorator) => {
   // Components
   bottle.serviceFactory('ShortUrlRedirectRules', () => ShortUrlRedirectRules);
   bottle.decorator('ShortUrlRedirectRules', connect(
-    ['shortUrlRedirectRules', 'shortUrlsDetails', 'shortUrlRedirectRulesSaving'],
-    ['getShortUrlRedirectRules', 'getShortUrlsDetails', 'setShortUrlRedirectRules', 'resetSetRules'],
+    ['shortUrlsDetails', 'shortUrlRedirectRulesSaving'],
+    ['getShortUrlsDetails', 'setShortUrlRedirectRules', 'resetSetRules'],
   ));
 
   // Actions
-  bottle.serviceFactory('getShortUrlRedirectRules', getShortUrlRedirectRules, 'apiClientFactory');
   bottle.serviceFactory('setShortUrlRedirectRules', setShortUrlRedirectRules, 'apiClientFactory');
   bottle.serviceFactory('resetSetRules', (obj) => obj.resetSetRules, 'setShortUrlRedirectRulesReducerCreator');
 
   // Reducers
-  bottle.serviceFactory(
-    'shortUrlRedirectRulesReducerCreator',
-    shortUrlRedirectRulesReducerCreator,
-    'getShortUrlRedirectRules',
-  );
-  bottle.serviceFactory('shortUrlRedirectRulesReducer', (obj) => obj.reducer, 'shortUrlRedirectRulesReducerCreator');
-
   bottle.serviceFactory(
     'setShortUrlRedirectRulesReducerCreator',
     setShortUrlRedirectRulesReducerCreator,

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -6,6 +6,7 @@ import type { MercureInfo } from '../mercure/reducers/mercureInfo';
 import { mercureInfoReducer } from '../mercure/reducers/mercureInfo';
 import type { SetShortUrlRedirectRules } from '../redirect-rules/reducers/setShortUrlRedirectRules';
 import type { ShortUrlRedirectRules } from '../redirect-rules/reducers/shortUrlRedirectRules';
+import { shortUrlRedirectRulesReducer } from '../redirect-rules/reducers/shortUrlRedirectRules';
 import type { ShortUrlCreation } from '../short-urls/reducers/shortUrlCreation';
 import { shortUrlCreationReducer } from '../short-urls/reducers/shortUrlCreation';
 import type { ShortUrlDeletion } from '../short-urls/reducers/shortUrlDeletion';
@@ -55,7 +56,7 @@ export const setUpStore = (container: IContainer, preloadedState?: any) => confi
     tagEdit: container.tagEditReducer as TagEdition,
     domainsList: container.domainsListReducer as DomainsList,
     visitsOverview: container.visitsOverviewReducer as VisitsOverview,
-    shortUrlRedirectRules: container.shortUrlRedirectRulesReducer as ShortUrlRedirectRules,
+    shortUrlRedirectRules: shortUrlRedirectRulesReducer,
     shortUrlRedirectRulesSaving: container.setShortUrlRedirectRulesReducer as SetShortUrlRedirectRules,
   } as const),
   preloadedState,

--- a/test/redirect-rules/reducers/shortUrlRedirectRules.test.ts
+++ b/test/redirect-rules/reducers/shortUrlRedirectRules.test.ts
@@ -3,17 +3,15 @@ import { fromPartial } from '@total-typescript/shoehorn';
 import type { ShlinkApiClient } from '../../../src/api-contract';
 import { parseApiError } from '../../../src/api-contract/utils';
 import {
-  getShortUrlRedirectRules as getShortUrlRedirectRulesCreator,
-  shortUrlRedirectRulesReducerCreator,
+  getShortUrlRedirectRulesThunk as getShortUrlRedirectRules,
+  shortUrlRedirectRulesReducer as reducer,
 } from '../../../src/redirect-rules/reducers/shortUrlRedirectRules';
 
 describe('shortUrlRedirectRulesReducer', () => {
   const getShortUrlRedirectRulesCall = vi.fn();
-  const buildShlinkApiClient = () => fromPartial<ShlinkApiClient>({
+  const apiClientFactory = () => fromPartial<ShlinkApiClient>({
     getShortUrlRedirectRules: getShortUrlRedirectRulesCall,
   });
-  const getShortUrlRedirectRules = getShortUrlRedirectRulesCreator(buildShlinkApiClient);
-  const { reducer } = shortUrlRedirectRulesReducerCreator(getShortUrlRedirectRules);
 
   describe('reducer', () => {
     it('returns loading on pending', () => {
@@ -52,7 +50,7 @@ describe('shortUrlRedirectRulesReducer', () => {
       ];
 
       getShortUrlRedirectRulesCall.mockResolvedValue(shortUrlRules);
-      await getShortUrlRedirectRules({ shortCode: '' })(dispatch, vi.fn(), {});
+      await getShortUrlRedirectRules({ shortCode: '', apiClientFactory })(dispatch, vi.fn(), {});
 
       expect(getShortUrlRedirectRulesCall).toHaveBeenCalledOnce();
       expect(dispatch).toHaveBeenCalledTimes(2);


### PR DESCRIPTION
Part of https://github.com/shlinkio/shlink-web-component/issues/161

Stop injecting redirect-rules-related redux state and actions, and provide a hook wrapping useDispatch and useSelector instead.