### PR TITLE
Simplify url details reducer type with a status discriminator prop

### DIFF
--- a/src/redirect-rules/ShortUrlRedirectRules.tsx
+++ b/src/redirect-rules/ShortUrlRedirectRules.tsx
@@ -35,8 +35,8 @@ export const ShortUrlRedirectRules: FC<ShortUrlRedirectRulesProps> = ({
   const { shortUrlRedirectRules, getShortUrlRedirectRules } = useUrlRedirectRules();
   const loading = shortUrlRedirectRules.status === 'loading';
   const identifier = useShortUrlIdentifier();
-  const { shortUrls } = shortUrlsDetails;
-  const shortUrl = identifier && shortUrls?.get(identifier);
+  const { status } = shortUrlsDetails;
+  const shortUrl = identifier && status === 'loaded' ? shortUrlsDetails.shortUrls.get(identifier) : undefined;
   const [rulesContainerRef, rules, setRules] = useDragAndDrop<HTMLDivElement, ShlinkRedirectRuleData>([], {
     dragHandle: '.drag-n-drop-handler',
     dropZoneClass: 'opacity-25',
@@ -107,8 +107,7 @@ export const ShortUrlRedirectRules: FC<ShortUrlRedirectRulesProps> = ({
           <h2 className="sm:flex justify-between items-center">
             <GoBackButton />
             <div className="text-center grow">
-              {shortUrlsDetails.loading && <>Loading...</>}
-              {!shortUrlsDetails.loading && (
+              {status === 'loading' ? <>Loading...</> : (
                 <small>Redirect rules for <ExternalLink href={shortUrl?.shortUrl ?? ''} /></small>
               )}
             </div>

--- a/src/short-urls/EditShortUrl.tsx
+++ b/src/short-urls/EditShortUrl.tsx
@@ -26,8 +26,8 @@ type EditShortUrlDeps = {
 const EditShortUrl: FCWithDeps<EditShortUrlProps, EditShortUrlDeps> = ({ shortUrlsDetails, getShortUrlsDetails }) => {
   const { ShortUrlForm } = useDependencies(EditShortUrl);
   const identifier = useShortUrlIdentifier();
-  const { loading, error, errorData, shortUrls } = shortUrlsDetails;
-  const shortUrl = identifier && shortUrls?.get(identifier);
+  const { status } = shortUrlsDetails;
+  const shortUrl = identifier && status === 'loaded' ? shortUrlsDetails.shortUrls.get(identifier) : undefined;
 
   const { shortUrlEdition, editShortUrl } = useUrlEdition();
   const { saving, saved, error: savingError, errorData: savingErrorData } = shortUrlEdition;
@@ -39,14 +39,14 @@ const EditShortUrl: FCWithDeps<EditShortUrlProps, EditShortUrlDeps> = ({ shortUr
     }
   }, [getShortUrlsDetails, identifier]);
 
-  if (loading) {
+  if (status === 'loading') {
     return <Message loading />;
   }
 
-  if (error) {
+  if (status === 'error') {
     return (
       <Result variant="error">
-        <ShlinkApiError errorData={errorData} fallbackMessage="An error occurred while loading short URL detail :(" />
+        <ShlinkApiError errorData={shortUrlsDetails.error} fallbackMessage="An error occurred while loading short URL detail :(" />
       </Result>
     );
   }

--- a/src/short-urls/reducers/shortUrlsDetails.ts
+++ b/src/short-urls/reducers/shortUrlsDetails.ts
@@ -7,15 +7,17 @@ import { shortUrlMatches } from '../helpers';
 const REDUCER_PREFIX = 'shlink/shortUrlsDetails';
 
 export type ShortUrlsDetails = {
-  shortUrls?: Map<ShlinkShortUrlIdentifier, ShlinkShortUrl>;
-  loading: boolean;
-  error: boolean;
-  errorData?: ProblemDetailsError;
+  status: 'idle' | 'loading';
+} | {
+  status: 'error';
+  error?: ProblemDetailsError;
+} | {
+  status: 'loaded';
+  shortUrls: Map<ShlinkShortUrlIdentifier, ShlinkShortUrl>;
 };
 
 const initialState: ShortUrlsDetails = {
-  loading: false,
-  error: false,
+  status: 'idle',
 };
 
 export const shortUrlsDetailsReducerCreator = (apiClientFactory: () => ShlinkApiClient) => {
@@ -41,14 +43,14 @@ export const shortUrlsDetailsReducerCreator = (apiClientFactory: () => ShlinkApi
 
   const { reducer } = createSlice({
     name: REDUCER_PREFIX,
-    initialState,
+    initialState: initialState as ShortUrlsDetails,
     reducers: {},
     extraReducers: (builder) => {
-      builder.addCase(getShortUrlsDetails.pending, () => ({ loading: true, error: false }));
+      builder.addCase(getShortUrlsDetails.pending, () => ({ status: 'loading' }));
       builder.addCase(getShortUrlsDetails.rejected, (_, { error }) => (
-        { loading: false, error: true, errorData: parseApiError(error) }
+        { status: 'error', error: parseApiError(error) }
       ));
-      builder.addCase(getShortUrlsDetails.fulfilled, (_, { payload: shortUrls }) => ({ ...initialState, shortUrls }));
+      builder.addCase(getShortUrlsDetails.fulfilled, (_, { payload: shortUrls }) => ({ status: 'loaded', shortUrls }));
     },
   });
 

--- a/src/visits/ShortUrlVisits.tsx
+++ b/src/visits/ShortUrlVisits.tsx
@@ -40,7 +40,8 @@ const ShortUrlVisits: FCWithDeps<ShortUrlVisitsProps, ShortUrlVisitsDeps> = boun
 }: ShortUrlVisitsProps) => {
   const { ReportExporter: reportExporter } = useDependencies(ShortUrlVisits);
   const identifier = useShortUrlIdentifier();
-  const shortUrl = useMemo(() => shortUrlsDetails.shortUrls?.get(identifier), [identifier, shortUrlsDetails.shortUrls]);
+  const shortUrls = shortUrlsDetails.status === 'loaded' ? shortUrlsDetails.shortUrls : undefined;
+  const shortUrl = useMemo(() => shortUrls?.get(identifier), [identifier, shortUrls]);
 
   const loadVisits = useCallback(
     (params: VisitsParams, options: GetVisitsOptions) => getShortUrlVisits({
@@ -71,7 +72,11 @@ const ShortUrlVisits: FCWithDeps<ShortUrlVisitsProps, ShortUrlVisitsDeps> = boun
       exportCsv={exportCsv}
       deletion={deletion}
     >
-      <ShortUrlVisitsHeader shortUrl={shortUrl} loading={shortUrlsDetails.loading} shortUrlVisits={shortUrlVisits} />
+      <ShortUrlVisitsHeader
+        shortUrl={shortUrl}
+        loading={shortUrlsDetails.status === 'loading'}
+        shortUrlVisits={shortUrlVisits}
+      />
     </VisitsStats>
   );
 }, (params) => (params.shortCode ? [Topics.shortUrlVisits(urlDecodeShortCode(params.shortCode))] : []));

--- a/src/visits/visits-comparison/ShortUrlVisitsComparison.tsx
+++ b/src/visits/visits-comparison/ShortUrlVisitsComparison.tsx
@@ -32,7 +32,8 @@ export const ShortUrlVisitsComparison: FC<ShortUrlVisitsComparisonProps> = bound
     [getShortUrlVisitsForComparison, identifiers],
   );
 
-  const loadedShortUrls = useMemo(() => [...shortUrlsDetails.shortUrls?.values() ?? []], [shortUrlsDetails.shortUrls]);
+  const shortUrls = shortUrlsDetails.status === 'loaded' ? shortUrlsDetails.shortUrls : undefined;
+  const loadedShortUrls = useMemo(() => [...shortUrls?.values() ?? []], [shortUrls]);
   const visitsComparisonInfo = useMemo((): VisitsComparisonInfo => {
     const { visitsGroups: baseVisitsGroups, loading, ...rest } = shortUrlVisitsComparison;
     const visitsGroups = loadedShortUrls.reduce<Record<string, ShlinkVisit[]>>(
@@ -43,8 +44,8 @@ export const ShortUrlVisitsComparison: FC<ShortUrlVisitsComparisonProps> = bound
       {},
     );
 
-    return { ...rest, visitsGroups, loading: loading || shortUrlsDetails.loading };
-  }, [shortUrlVisitsComparison, shortUrlsDetails.loading, loadedShortUrls]);
+    return { ...rest, visitsGroups, loading: loading || shortUrlsDetails.status === 'loading' };
+  }, [shortUrlVisitsComparison, shortUrlsDetails.status, loadedShortUrls]);
 
   useEffect(() => {
     if (identifiers.length > 0) {
@@ -56,7 +57,7 @@ export const ShortUrlVisitsComparison: FC<ShortUrlVisitsComparisonProps> = bound
     <VisitsComparison
       title={(
         <span data-testid="title">
-          {shortUrlsDetails.loading
+          {shortUrlsDetails.status === 'loading'
             ? 'Loading...'
             : `Comparing ${loadedShortUrls.length} short URLs`}
         </span>

--- a/test/redirect-rules/ShortUrlRedirectRules.test.tsx
+++ b/test/redirect-rules/ShortUrlRedirectRules.test.tsx
@@ -26,7 +26,8 @@ describe('<ShortUrlRedirectRules />', () => {
         {/* Wrap in Card so that it has the proper background color and passes a11y contrast checks */}
         <Card>
           <ShortUrlRedirectRules
-            shortUrlsDetails={fromPartial(loading ? { loading } : {
+            shortUrlsDetails={fromPartial(loading ? { status: 'loading' } : {
+              status: 'loaded',
               shortUrls: {
                 get: () => fromPartial<ShlinkShortUrl>({ shortUrl: 'https://s.test/123' }),
               },

--- a/test/short-urls/EditShortUrl.test.tsx
+++ b/test/short-urls/EditShortUrl.test.tsx
@@ -19,7 +19,10 @@ describe('<EditShortUrl />', () => {
   const setUp = (detail: Partial<ShortUrlsDetails> = {}, edition: Partial<ShortUrlEdition> = {}) => renderWithStore(
     <MemoryRouterWithParams params={identifier}>
       <SettingsProvider value={{}}>
-        <EditShortUrl shortUrlsDetails={fromPartial(detail)} getShortUrlsDetails={getShortUrlsDetails} />
+        <EditShortUrl
+          shortUrlsDetails={fromPartial({ status: 'loaded', shortUrls: new Map(), ...detail })}
+          getShortUrlsDetails={getShortUrlsDetails}
+        />
       </SettingsProvider>
     </MemoryRouterWithParams>,
     {
@@ -45,14 +48,14 @@ describe('<EditShortUrl />', () => {
   )));
 
   it('renders loading message while loading detail', () => {
-    setUp({ loading: true });
+    setUp({ status: 'loading' });
 
     expect(screen.getByText('Loading...')).toBeInTheDocument();
     expect(screen.queryByText('ShortUrlForm')).not.toBeInTheDocument();
   });
 
   it('renders error when loading detail fails', () => {
-    setUp({ error: true });
+    setUp({ status: 'error' });
 
     expect(screen.getByText('An error occurred while loading short URL detail :(')).toBeInTheDocument();
     expect(screen.queryByText('ShortUrlForm')).not.toBeInTheDocument();

--- a/test/short-urls/reducers/shortUrlsDetails.test.ts
+++ b/test/short-urls/reducers/shortUrlsDetails.test.ts
@@ -11,18 +11,17 @@ describe('shortUrlsDetailsReducer', () => {
 
   describe('reducer', () => {
     it('returns loading on pending', () => {
-      const { loading } = reducer({ loading: false, error: false }, getShortUrlsDetails.pending('', [], undefined));
-      expect(loading).toEqual(true);
+      const { status } = reducer({ status: 'idle' }, getShortUrlsDetails.pending('', [], undefined));
+      expect(status).toEqual('loading');
     });
 
     it('stops loading and returns error on rejected', () => {
-      const { loading, error } = reducer(
-        { loading: true, error: false },
+      const { status } = reducer(
+        { status: 'loading' },
         getShortUrlsDetails.rejected(null, '', [], undefined, undefined),
       );
 
-      expect(loading).toEqual(false);
-      expect(error).toEqual(true);
+      expect(status).toEqual('error');
     });
 
     it('return short URLs on fulfilled', () => {
@@ -31,14 +30,16 @@ describe('shortUrlsDetailsReducer', () => {
         [identifier, fromPartial<ShlinkShortUrl>({ longUrl: 'foo', shortCode: 'bar' })],
       ]);
       const state = reducer(
-        { loading: true, error: false },
+        { status: 'loading' },
         getShortUrlsDetails.fulfilled(actionShortUrls, '', [identifier], undefined),
       );
-      const { loading, error, shortUrls } = state;
+      const { status } = state;
 
-      expect(loading).toEqual(false);
-      expect(error).toEqual(false);
-      expect(shortUrls).toEqual(actionShortUrls);
+      expect(status).toEqual('loaded');
+      // Just making TS happy here
+      if (status === 'loaded') {
+        expect(state.shortUrls).toEqual(actionShortUrls);
+      }
     });
   });
 

--- a/test/visits/ShortUrlVisits.test.tsx
+++ b/test/visits/ShortUrlVisits.test.tsx
@@ -28,6 +28,7 @@ describe('<ShortUrlVisits />', () => {
             getShortUrlVisits={getShortUrlVisitsMock}
             shortUrlVisits={shortUrlVisits}
             shortUrlsDetails={fromPartial({
+              status: 'loaded',
               shortUrls: {
                 get: () => fromPartial<ShlinkShortUrl>({
                   shortUrl: 'https://s.test/123',

--- a/test/visits/visits-comparison/ShortUrlVisitsComparison.test.tsx
+++ b/test/visits/visits-comparison/ShortUrlVisitsComparison.test.tsx
@@ -35,7 +35,7 @@ describe('<ShortUrlVisitsComparison />', () => {
           shortUrls: new Map(shortUrls.map(
             (shortUrl) => [shortUrl, { ...shortUrl, shortUrl: `https://${shortUrlToQuery(shortUrl)}` }],
           )),
-          loading: loadingDetails,
+          status: loadingDetails ? 'loading' : 'loaded',
         })}
       />
     </MemoryRouter>,


### PR DESCRIPTION
Part of https://github.com/shlinkio/shlink-web-component/issues/874

Replace the multiple boolean flags that determine the status of the url details rules reducer, with a single status discriminator prop that is less error prone and easier to reason about.