### PR TITLE
Simplify urls list rules reducer type with a status discriminator prop

### DIFF
--- a/src/overview/Overview.tsx
+++ b/src/overview/Overview.tsx
@@ -52,7 +52,6 @@ const Overview: FCWithDeps<OverviewProps, OverviewDeps> = boundToMercureHub((
 ) => {
   const { ShortUrlsTable, CreateShortUrl } = useDependencies(Overview);
   const { shortUrlsList, listShortUrls } = useUrlsList();
-  const { loading, shortUrls } = shortUrlsList;
   const loadingTags = tagsList.status === 'loading';
   const { loading: loadingVisits, nonOrphanVisits, orphanVisits } = visitsOverview;
   const routesPrefix = useRoutesPrefix();
@@ -85,7 +84,8 @@ const Overview: FCWithDeps<OverviewProps, OverviewDeps> = boundToMercureHub((
           visitsSummary={orphanVisits}
         />
         <HighlightCard title="Short URLs" link={`${routesPrefix}/list-short-urls/1`}>
-          {loading ? 'Loading...' : formatNumber(shortUrls?.pagination.totalItems ?? 0)}
+          {shortUrlsList.status === 'loading' && 'Loading...'}
+          {shortUrlsList.status === 'loaded' && formatNumber(shortUrlsList.shortUrls.pagination.totalItems)}
         </HighlightCard>
         <HighlightCard title="Tags" link={`${routesPrefix}/manage-tags`}>
           {loadingTags ? 'Loading...' : formatNumber(tagsList.tags.length)}

--- a/src/short-urls/ShortUrlsList.tsx
+++ b/src/short-urls/ShortUrlsList.tsx
@@ -54,7 +54,8 @@ const ShortUrlsList: FCWithDeps<any, ShortUrlsListDeps> = boundToMercureHub(() =
     // This separated state handling is needed to be able to fall back to settings value, but only once when loaded
     orderBy ?? settings.shortUrlsList?.defaultOrdering ?? DEFAULT_SHORT_URLS_ORDERING,
   );
-  const { pagination } = shortUrlsList?.shortUrls ?? {};
+  const urlsAreLoaded = shortUrlsList.status === 'loaded';
+  const { pagination } = urlsAreLoaded ? shortUrlsList.shortUrls : {};
   const doExcludeBots = useMemo(
     () => excludeBots ?? settings.visits?.excludeBots,
     [excludeBots, settings.visits?.excludeBots],
@@ -117,20 +118,20 @@ const ShortUrlsList: FCWithDeps<any, ShortUrlsListDeps> = boundToMercureHub(() =
   return (
     <VisitsComparisonProvider value={visitsComparisonValue}>
       <ShortUrlsFilteringBar
-        shortUrlsAmount={shortUrlsList.shortUrls?.pagination.totalItems}
+        shortUrlsAmount={urlsAreLoaded ? shortUrlsList.shortUrls.pagination.totalItems : undefined}
         order={actualOrderBy}
         handleOrderBy={handleOrderBy}
         className="mb-4"
       />
       <VisitsComparisonCollector type="short-urls" className="mb-4" />
-      <SimpleCard bodyClassName={clsx({ 'pb-0': !shortUrlsList.loading })}>
+      <SimpleCard bodyClassName={clsx({ 'pb-0': urlsAreLoaded })}>
         <ShortUrlsTable
           shortUrlsList={shortUrlsList}
           orderByColumn={orderByColumn}
           renderOrderIcon={renderOrderIcon}
           onTagClick={addTag}
         />
-        {!shortUrlsList.loading && <Paginator paginator={pagination} currentQueryString={location.search} />}
+        {pagination && <Paginator paginator={pagination} currentQueryString={location.search} />}
       </SimpleCard>
     </VisitsComparisonProvider>
 

--- a/src/short-urls/ShortUrlsTable.tsx
+++ b/src/short-urls/ShortUrlsTable.tsx
@@ -30,21 +30,21 @@ const FullRow: FC<PropsWithChildren<{ danger?: boolean }>> = ({ children, danger
 );
 
 const ShortUrlsTableBody: FC<ShortUrlsTableBodyProps> = ({ shortUrlsList, onTagClick, ShortUrlsRow }) => {
-  const { error, loading, shortUrls } = shortUrlsList;
+  const { status } = shortUrlsList;
 
-  if (error) {
+  if (status === 'error') {
     return <FullRow danger>Something went wrong while loading short URLs :(</FullRow>;
   }
 
-  if (loading) {
+  if (status === 'loading') {
     return <FullRow>Loading...</FullRow>;
   }
 
-  if (!shortUrls || shortUrls.data.length === 0) {
+  if (status !== 'loaded' || shortUrlsList.shortUrls.data.length === 0) {
     return <FullRow>No results found</FullRow>;
   }
 
-  return shortUrls?.data.map((shortUrl) => (
+  return shortUrlsList.shortUrls.data.map((shortUrl) => (
     <ShortUrlsRow
       key={shortUrl.shortUrl}
       shortUrl={shortUrl}

--- a/src/short-urls/reducers/shortUrlsDetails.ts
+++ b/src/short-urls/reducers/shortUrlsDetails.ts
@@ -31,7 +31,9 @@ export const shortUrlsDetailsReducerCreator = (apiClientFactory: () => ShlinkApi
       const pairs = await Promise.all(identifiers.map(
         async (identifier): Promise<[ShlinkShortUrlIdentifier, ShlinkShortUrl]> => {
           const { shortCode, domain } = identifier;
-          const alreadyLoaded = shortUrlsList?.shortUrls?.data.find((url) => shortUrlMatches(url, shortCode, domain));
+          const alreadyLoaded = shortUrlsList.status === 'loaded'
+            ? shortUrlsList.shortUrls.data.find((url) => shortUrlMatches(url, shortCode, domain))
+            : undefined;
 
           return [identifier, alreadyLoaded ?? await apiClientFactory().getShortUrl({ shortCode, domain })];
         },

--- a/src/short-urls/reducers/shortUrlsList.ts
+++ b/src/short-urls/reducers/shortUrlsList.ts
@@ -13,15 +13,15 @@ import { editShortUrlThunk } from './shortUrlEdition';
 const REDUCER_PREFIX = 'shlink/shortUrlsList';
 export const ITEMS_IN_OVERVIEW_PAGE = 5;
 
-export interface ShortUrlsList {
-  shortUrls?: ShlinkShortUrlsList;
-  loading: boolean;
-  error: boolean;
-}
+export type ShortUrlsList = {
+  status: 'idle' | 'loading' | 'error';
+} | {
+  status: 'loaded';
+  shortUrls: ShlinkShortUrlsList;
+};
 
 const initialState: ShortUrlsList = {
-  loading: true,
-  error: false,
+  status: 'idle',
 };
 
 export const listShortUrlsThunk = createAsyncThunk(
@@ -33,20 +33,20 @@ export const listShortUrlsThunk = createAsyncThunk(
 
 export const { reducer: shortUrlsListReducer } = createSlice({
   name: REDUCER_PREFIX,
-  initialState,
+  initialState: initialState as ShortUrlsList,
   reducers: {},
   extraReducers: (builder) => {
-    builder.addCase(listShortUrlsThunk.pending, (state) => ({ ...state, loading: true, error: false }));
-    builder.addCase(listShortUrlsThunk.rejected, () => ({ loading: false, error: true }));
+    builder.addCase(listShortUrlsThunk.pending, () => ({ status: 'loading' }));
+    builder.addCase(listShortUrlsThunk.rejected, () => ({ status: 'error' }));
     builder.addCase(
       listShortUrlsThunk.fulfilled,
-      (_, { payload: shortUrls }) => ({ loading: false, error: false, shortUrls }),
+      (_, { payload: shortUrls }) => ({ status: 'loaded', shortUrls }),
     );
 
     builder.addCase(
       createShortUrlThunk.fulfilled,
       (state, { payload }) => {
-        if (!state.shortUrls) {
+        if (state.status !== 'loaded') {
           return;
         }
 
@@ -61,7 +61,7 @@ export const { reducer: shortUrlsListReducer } = createSlice({
     builder.addCase(
       editShortUrlThunk.fulfilled,
       (state, { payload: editedShortUrl }) => {
-        if (!state.shortUrls) {
+        if (state.status !== 'loaded') {
           return;
         }
 
@@ -75,7 +75,7 @@ export const { reducer: shortUrlsListReducer } = createSlice({
     builder.addCase(
       shortUrlDeleted,
       (state, { payload }) => {
-        if (!state.shortUrls) {
+        if (state.status !== 'loaded') {
           return;
         }
 
@@ -89,7 +89,7 @@ export const { reducer: shortUrlsListReducer } = createSlice({
     builder.addCase(
       createNewVisits,
       (state, { payload }) => {
-        if (!state.shortUrls) {
+        if (state.status !== 'loaded') {
           return;
         }
 

--- a/test/short-urls/reducers/shortUrlsDetails.test.ts
+++ b/test/short-urls/reducers/shortUrlsDetails.test.ts
@@ -48,21 +48,22 @@ describe('shortUrlsDetailsReducer', () => {
     const buildGetState = (shortUrlsList?: ShortUrlsList) => () => fromPartial<RootState>({ shortUrlsList });
 
     it.each([
-      [undefined],
-      [fromPartial<ShortUrlsList>({})],
+      [fromPartial<ShortUrlsList>({ status: 'loading' })],
       [
         fromPartial<ShortUrlsList>({
+          status: 'loaded',
           shortUrls: { data: [] },
         }),
       ],
       [
         fromPartial<ShortUrlsList>({
+          status: 'loaded',
           shortUrls: {
             data: [{ shortCode: 'this_will_not_match' }],
           },
         }),
       ],
-    ])('performs API call when short URL is not found in local state', async (shortUrlsList?: ShortUrlsList) => {
+    ])('performs API call when short URL is not found in local state', async (shortUrlsList: ShortUrlsList) => {
       const identifier = { shortCode: 'abc123', domain: '' };
       const resolvedShortUrl = fromPartial<ShlinkShortUrl>({ longUrl: 'foo', shortCode: 'abc123' });
       getShortUrlCall.mockResolvedValue(resolvedShortUrl);
@@ -82,6 +83,7 @@ describe('shortUrlsDetailsReducer', () => {
       await getShortUrlsDetails([foundShortUrl])(
         dispatchMock,
         buildGetState(fromPartial({
+          status: 'loaded',
           shortUrls: {
             data: [foundShortUrl],
           },


### PR DESCRIPTION
Part of https://github.com/shlinkio/shlink-web-component/issues/874

Replace the multiple boolean flags that determine the status of the urls list reducer, with a single status discriminator prop that is less error prone and easier to reason about.