### PR TITLE
Replace event-spurce-polyfill with native EventSource

### DIFF
--- a/event-source-polyfill.d.ts
+++ b/event-source-polyfill.d.ts
@@ -1,8 +1,0 @@
-declare module 'event-source-polyfill' {
-  export class EventSourcePolyfill {
-    public onmessage?: ({ data }: { data: string }) => void;
-    public onerror?: ({ status }: { status: number }) => void;
-    public close: () => void;
-    public constructor(hubUrl: URL, options?: any);
-  }
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "clsx": "^2.1.1",
         "compare-versions": "^6.1.1",
         "date-fns": "^4.1.0",
-        "event-source-polyfill": "^1.0.31",
         "leaflet": "^1.9.4",
         "qr-code-styling": "^1.9.2",
         "react-external-link": "^2.6.1",
@@ -5179,12 +5178,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/event-source-polyfill": {
-      "version": "1.0.31",
-      "resolved": "https://registry.npmjs.org/event-source-polyfill/-/event-source-polyfill-1.0.31.tgz",
-      "integrity": "sha512-4IJSItgS/41IxN5UVAVuAyczwZF7ZIEsM1XAoUzIHA6A+xzusEZUutdXz2Nr+MQPLxfTiCvqE79/C8HT8fKFvA==",
-      "license": "MIT"
     },
     "node_modules/eventemitter3": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "clsx": "^2.1.1",
     "compare-versions": "^6.1.1",
     "date-fns": "^4.1.0",
-    "event-source-polyfill": "^1.0.31",
     "leaflet": "^1.9.4",
     "qr-code-styling": "^1.9.2",
     "react-external-link": "^2.6.1",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -57,7 +57,6 @@ export default defineConfig({
       'clsx',
       'compare-versions',
       'date-fns',
-      'event-source-polyfill',
       'history',
       'leaflet',
       'qr-code-styling',


### PR DESCRIPTION
The `event-spurce-polyfill` package is mostly unmaintained, and I notice it has a message in cyrillic which basically recommends not using it at all.

The only reason it was used is because the native `EventSource` object does not allow providing extra headers, which are required for the mercure authentication, via `Authentication` header.

However, the docs now indicate it is possible to provide authentication via query params, so this PR moves to that approach and finally removes the polyfill.