### PR TITLE
Simplify visits overview reducer type with a status discriminator prop

### DIFF
--- a/src/overview/Overview.tsx
+++ b/src/overview/Overview.tsx
@@ -2,6 +2,7 @@ import { Card, formatNumber } from '@shlinkio/shlink-frontend-kit';
 import type { FC, ReactNode } from 'react';
 import { useEffect } from 'react';
 import { Link, useNavigate } from 'react-router';
+import type { ShlinkVisitsSummary } from '../api-contract';
 import type { FCWithDeps } from '../container/utils';
 import { componentFactory, useDependencies } from '../container/utils';
 import { boundToMercureHub } from '../mercure/helpers/boundToMercureHub';
@@ -47,13 +48,19 @@ type OverviewDeps = {
   CreateShortUrl: FC<CreateShortUrlProps>;
 };
 
+const visitsSummaryFallback: ShlinkVisitsSummary = { total: 0, bots: 0, nonBots: 0 };
+
 const Overview: FCWithDeps<OverviewProps, OverviewDeps> = boundToMercureHub((
   { tagsList, loadVisitsOverview, visitsOverview },
 ) => {
   const { ShortUrlsTable, CreateShortUrl } = useDependencies(Overview);
   const { shortUrlsList, listShortUrls } = useUrlsList();
   const loadingTags = tagsList.status === 'loading';
-  const { loading: loadingVisits, nonOrphanVisits, orphanVisits } = visitsOverview;
+  const loadingVisits = visitsOverview.status === 'loading';
+  const { orphanVisits, nonOrphanVisits } = visitsOverview.status === 'loaded' ? visitsOverview : {
+    orphanVisits: visitsSummaryFallback,
+    nonOrphanVisits: visitsSummaryFallback,
+  };
   const routesPrefix = useRoutesPrefix();
   const navigate = useNavigate();
   const visits = useSetting('visits');

--- a/src/overview/helpers/VisitsHighlightCard.tsx
+++ b/src/overview/helpers/VisitsHighlightCard.tsx
@@ -1,13 +1,13 @@
 import { formatNumber } from '@shlinkio/shlink-frontend-kit';
 import type { FC } from 'react';
-import type { PartialVisitsSummary } from '../../visits/reducers/visitsOverview';
+import type { ShlinkVisitsSummary } from '../../api-contract';
 import type { HighlightCardProps } from './HighlightCard';
 import { HighlightCard } from './HighlightCard';
 
 export type VisitsHighlightCardProps = Omit<HighlightCardProps, 'tooltip' | 'children'> & {
   loading: boolean;
   excludeBots: boolean;
-  visitsSummary: PartialVisitsSummary;
+  visitsSummary: ShlinkVisitsSummary;
 };
 
 export const VisitsHighlightCard: FC<VisitsHighlightCardProps> = ({ loading, excludeBots, visitsSummary, ...rest }) => (

--- a/test/overview/Overview.test.tsx
+++ b/test/overview/Overview.test.tsx
@@ -28,7 +28,7 @@ describe('<Overview />', () => {
               loadVisitsOverview={loadVisitsOverview}
               tagsList={fromPartial({ status: 'idle', tags: ['foo', 'bar', 'baz'] })}
               visitsOverview={fromPartial({
-                loading: false,
+                status: 'loaded',
                 nonOrphanVisits: { total: 3456, bots: 1000, nonBots: 2456 },
                 orphanVisits: { total: 28, bots: 15, nonBots: 13 },
               })}

--- a/test/overview/helpers/VisitsHighlightCard.test.tsx
+++ b/test/overview/helpers/VisitsHighlightCard.test.tsx
@@ -10,7 +10,7 @@ describe('<VisitsHighlightCard />', () => {
     <MemoryRouter>
       <VisitsHighlightCard
         loading={false}
-        visitsSummary={{ total: 0 }}
+        visitsSummary={{ total: 0, bots: 0, nonBots: 0 }}
         excludeBots={false}
         title="title"
         link=""
@@ -39,7 +39,7 @@ describe('<VisitsHighlightCard />', () => {
   it('renders tooltip when summary has bots', async () => {
     const { user } = setUp({
       title: 'Foo',
-      visitsSummary: { total: 50, bots: 1000 },
+      visitsSummary: { total: 50, bots: 1000, nonBots: 0 },
     });
 
     await user.hover(screen.getByText('Foo'));
@@ -56,22 +56,14 @@ describe('<VisitsHighlightCard />', () => {
       expect(screen.getByText('0')).toBeInTheDocument();
       expect(screen.queryByText('50')).not.toBeInTheDocument();
     }],
-    [true, undefined, () => {
-      expect(screen.getByText('50')).toBeInTheDocument();
-      expect(screen.queryByText('20')).not.toBeInTheDocument();
-    }],
     [false, 20, () => {
-      expect(screen.getByText('50')).toBeInTheDocument();
-      expect(screen.queryByText('20')).not.toBeInTheDocument();
-    }],
-    [false, undefined, () => {
       expect(screen.getByText('50')).toBeInTheDocument();
       expect(screen.queryByText('20')).not.toBeInTheDocument();
     }],
   ])('displays non-bots when present and bots are excluded', (excludeBots, nonBots, assert) => {
     setUp({
       excludeBots,
-      visitsSummary: { total: 50, nonBots },
+      visitsSummary: { total: 50, bots: 0, nonBots },
     });
     assert();
   });


### PR DESCRIPTION
Part of https://github.com/shlinkio/shlink-web-component/issues/874

Replace the multiple boolean flags that determine the status of the visits overview reducer, with a single status discriminator prop that is less error prone and easier to reason about.