### PR TITLE
Simplify visits deletion reducers type with a status discriminator prop

### DIFF
--- a/src/visits/helpers/VisitsStatsOptions.tsx
+++ b/src/visits/helpers/VisitsStatsOptions.tsx
@@ -9,7 +9,7 @@ export type VisitsStatsOptionsProps = {
 };
 
 export const VisitsStatsOptions: FC<VisitsStatsOptionsProps> = ({ visitsDeletion, deleteVisits }) => {
-  const { deleting } = visitsDeletion;
+  const deleting = visitsDeletion.status === 'deleting';
   const { flag: doubleConfirmed, setToTrue: setDoubleConfirmed } = useToggle();
 
   return (

--- a/src/visits/reducers/orphanVisitsDeletion.ts
+++ b/src/visits/reducers/orphanVisitsDeletion.ts
@@ -6,12 +6,10 @@ import type { VisitsDeletion } from './types';
 
 const REDUCER_PREFIX = 'shlink/orphanVisitsDeletion';
 
-export type OrphanVisitsDeletion = VisitsDeletion & ShlinkDeleteVisitsResult;
+export type OrphanVisitsDeletion = VisitsDeletion<ShlinkDeleteVisitsResult>;
 
 const initialState: OrphanVisitsDeletion = {
-  deletedVisits: 0,
-  deleting: false,
-  error: false,
+  status: 'idle',
 };
 
 export const deleteOrphanVisits = (apiClientFactory: () => ShlinkApiClient) => createAsyncThunk(
@@ -23,16 +21,16 @@ export const orphanVisitsDeletionReducerCreator = (
   deleteOrphanVisitsThunk: ReturnType<typeof deleteOrphanVisits>,
 ) => createSlice({
   name: REDUCER_PREFIX,
-  initialState,
+  initialState: initialState as OrphanVisitsDeletion,
   reducers: {},
   extraReducers: (builder) => {
-    builder.addCase(deleteOrphanVisitsThunk.pending, (state) => ({ ...state, deleting: true, error: false }));
-    builder.addCase(deleteOrphanVisitsThunk.rejected, (state, { error }) => (
-      { ...state, deleting: false, error: true, errorData: parseApiError(error) }
+    builder.addCase(deleteOrphanVisitsThunk.pending, () => ({ status: 'deleting' }));
+    builder.addCase(deleteOrphanVisitsThunk.rejected, (_, { error }) => (
+      { status: 'error', error: parseApiError(error) }
     ));
     builder.addCase(deleteOrphanVisitsThunk.fulfilled, (_, { payload }) => {
       const { deletedVisits } = payload;
-      return { ...initialState, deletedVisits };
+      return { status: 'deleted', deletedVisits };
     });
   },
 });

--- a/src/visits/reducers/shortUrlVisitsDeletion.ts
+++ b/src/visits/reducers/shortUrlVisitsDeletion.ts
@@ -8,13 +8,10 @@ const REDUCER_PREFIX = 'shlink/shortUrlVisitsDeletion';
 
 type DeleteVisitsResult = ShlinkDeleteVisitsResult & ShlinkShortUrlIdentifier;
 
-export type ShortUrlVisitsDeletion = VisitsDeletion & DeleteVisitsResult;
+export type ShortUrlVisitsDeletion = VisitsDeletion<DeleteVisitsResult>;
 
 const initialState: ShortUrlVisitsDeletion = {
-  shortCode: '',
-  deletedVisits: 0,
-  deleting: false,
-  error: false,
+  status: 'idle',
 };
 
 export const deleteShortUrlVisits = (apiClientFactory: () => ShlinkApiClient) => createAsyncThunk(
@@ -29,16 +26,16 @@ export const shortUrlVisitsDeletionReducerCreator = (
   deleteShortUrlVisitsThunk: ReturnType<typeof deleteShortUrlVisits>,
 ) => createSlice({
   name: REDUCER_PREFIX,
-  initialState,
+  initialState: initialState as ShortUrlVisitsDeletion,
   reducers: {},
   extraReducers: (builder) => {
-    builder.addCase(deleteShortUrlVisitsThunk.pending, (state) => ({ ...state, deleting: true, error: false }));
-    builder.addCase(deleteShortUrlVisitsThunk.rejected, (state, { error }) => (
-      { ...state, deleting: false, error: true, errorData: parseApiError(error) }
+    builder.addCase(deleteShortUrlVisitsThunk.pending, () => ({ status: 'deleting' }));
+    builder.addCase(deleteShortUrlVisitsThunk.rejected, (_, { error }) => (
+      { status: 'error', error: parseApiError(error) }
     ));
     builder.addCase(deleteShortUrlVisitsThunk.fulfilled, (_, { payload }) => {
       const { shortCode, domain, deletedVisits } = payload;
-      return { ...initialState, shortCode, domain, deletedVisits };
+      return { status: 'deleted', shortCode, domain, deletedVisits };
     });
   },
 });

--- a/src/visits/reducers/types/index.ts
+++ b/src/visits/reducers/types/index.ts
@@ -33,8 +33,11 @@ export type VisitsInfo = VisitsLoadingInfo & VisitsLoaded & {
   fallbackInterval?: DateInterval;
 };
 
-export type VisitsDeletion = {
-  deleting: boolean;
-  error: boolean,
-  errorData?: ProblemDetailsError;
-};
+export type VisitsDeletion<Result = unknown> = {
+  status: 'idle' | 'deleting';
+} | {
+  status: 'error';
+  error?: ProblemDetailsError;
+} | (Result & {
+  status: 'deleted';
+});

--- a/test/visits/helpers/VisitsStatsOptions.test.tsx
+++ b/test/visits/helpers/VisitsStatsOptions.test.tsx
@@ -7,7 +7,10 @@ import { renderWithEvents } from '../../__helpers__/setUpTest';
 describe('<VisitsStatsOptions />', () => {
   const deleteVisits = vi.fn();
   const setUp = (deleting = false) => renderWithEvents(
-    <VisitsStatsOptions deleteVisits={deleteVisits} visitsDeletion={fromPartial({ deleting })} />,
+    <VisitsStatsOptions
+      deleteVisits={deleteVisits}
+      visitsDeletion={fromPartial({ status: deleting ? 'deleting' : 'idle' })}
+    />,
   );
 
   it('passes a11y checks', () => checkAccessibility(setUp()));

--- a/test/visits/reducers/orphanVisitsDeletion.test.ts
+++ b/test/visits/reducers/orphanVisitsDeletion.test.ts
@@ -16,21 +16,21 @@ describe('orphanVisitsDeletionReducer', () => {
   describe('reducer', () => {
     it('returns deleting for pending action', () => {
       const result = reducer(fromPartial({}), deleteOrphanVisits.pending(''));
-      expect(result).toEqual(expect.objectContaining({ deleting: true, error: false }));
+      expect(result).toEqual(expect.objectContaining({ status: 'deleting' }));
     });
 
     it('returns error for rejected action', () => {
       const error = { type: 'INTERNAL_SERVER_ERROR', status: 500 } as unknown as Error;
       const result = reducer(fromPartial({}), deleteOrphanVisits.rejected(error, ''));
 
-      expect(result).toEqual(expect.objectContaining({ deleting: false, error: true }));
+      expect(result).toEqual(expect.objectContaining({ status: 'error' }));
     });
 
     it('returns success on fulfilled rejected', () => {
       const deletionResult = { deletedVisits: 10 };
       const result = reducer(fromPartial({}), deleteOrphanVisits.fulfilled(deletionResult, ''));
 
-      expect(result).toEqual(expect.objectContaining({ deleting: false, error: false, ...deletionResult }));
+      expect(result).toEqual(expect.objectContaining({ status: 'deleted', ...deletionResult }));
     });
   });
 

--- a/test/visits/reducers/shortUrlVisitsDeletion.test.ts
+++ b/test/visits/reducers/shortUrlVisitsDeletion.test.ts
@@ -16,21 +16,21 @@ describe('shortUrlsVisitsDeletionReducer', () => {
   describe('reducer', () => {
     it('returns deleting for pending action', () => {
       const result = reducer(fromPartial({}), deleteShortUrlVisits.pending('', fromPartial({})));
-      expect(result).toEqual(expect.objectContaining({ deleting: true, error: false }));
+      expect(result).toEqual(expect.objectContaining({ status: 'deleting' }));
     });
 
     it('returns error for rejected action', () => {
       const error = { type: 'NOT_FOUND', status: 404 } as unknown as Error;
       const result = reducer(fromPartial({}), deleteShortUrlVisits.rejected(error, '', fromPartial({})));
 
-      expect(result).toEqual(expect.objectContaining({ deleting: false, error: true }));
+      expect(result).toEqual(expect.objectContaining({ status: 'error' }));
     });
 
     it('returns success on fulfilled rejected', () => {
       const shortUrl = { shortCode: 'shortCode', domain: 'domain', deletedVisits: 10 };
       const result = reducer(fromPartial({}), deleteShortUrlVisits.fulfilled(shortUrl, '', fromPartial({})));
 
-      expect(result).toEqual(expect.objectContaining({ deleting: false, error: false, ...shortUrl }));
+      expect(result).toEqual(expect.objectContaining({ status: 'deleted', ...shortUrl }));
     });
   });
 


### PR DESCRIPTION
Closes https://github.com/shlinkio/shlink-web-component/issues/874

Replace the multiple boolean flags that determine the status of the visits deletion reducers, with a single status discriminator prop that is less error prone and easier to reason about.