### PR TITLE
Simplify tag edition reducer type with a status discriminator prop

### DIFF
--- a/src/tags/helpers/EditTagModal.tsx
+++ b/src/tags/helpers/EditTagModal.tsx
@@ -24,14 +24,15 @@ const EditTagModal: FCWithDeps<EditTagModalProps, EditTagModalDeps> = (
   const { ColorGenerator: colorGenerator } = useDependencies(EditTagModal);
   const [newTagName, setNewTagName] = useState(tag);
   const [color, setColor] = useState(colorGenerator.getColorForKey(tag));
-  const { editing, error, edited, errorData } = tagEdit;
+  const { status } = tagEdit;
+  const editing = status === 'editing';
   const saveTag = useCallback(async () => {
     await editTag({ oldName: tag, newName: newTagName, color });
     onClose();
   }, [color, editTag, newTagName, onClose, tag]);
   const onClosed = useCallback(
-    () => edited && tagEdited({ oldName: tag, newName: newTagName, color }),
-    [color, edited, newTagName, tag, tagEdited],
+    () => status === 'edited' && tagEdited({ oldName: tag, newName: newTagName, color }),
+    [color, status, newTagName, tag, tagEdited],
   );
 
   return (
@@ -55,9 +56,9 @@ const EditTagModal: FCWithDeps<EditTagModalProps, EditTagModalDeps> = (
         />
       </div>
 
-      {error && (
+      {status === 'error' && (
         <Result variant="error" size="sm" className="mt-2">
-          <ShlinkApiError errorData={errorData} fallbackMessage="Something went wrong while editing the tag :(" />
+          <ShlinkApiError errorData={tagEdit.error} fallbackMessage="Something went wrong while editing the tag :(" />
         </Result>
       )}
     </CardModal>

--- a/test/tags/helpers/EditTagModal.test.tsx
+++ b/test/tags/helpers/EditTagModal.test.tsx
@@ -36,16 +36,13 @@ describe('<EditTagModal />', () => {
     [true, 'Saving...'],
     [false, 'Save'],
   ])('renders submit button in expected state', (editing, name) => {
-    setUp({ editing });
+    setUp({ status: editing ? 'editing' : 'idle' });
     expect(screen.getByRole('button', { name })).toBeInTheDocument();
   });
 
-  it.each([
-    [true, 1],
-    [false, 0],
-  ])('displays error result in case of error', (error, expectedResultCount) => {
-    setUp({ error, errorData: fromPartial({}) });
-    expect(screen.queryAllByText('Something went wrong while editing the tag :(')).toHaveLength(expectedResultCount);
+  it('displays error result in case of error', () => {
+    setUp({ status: 'error', error: fromPartial({}) });
+    expect(screen.getByText('Something went wrong while editing the tag :(')).toBeInTheDocument();
   });
 
   it('updates tag value when text changes', async () => {

--- a/test/tags/reducers/tagEdit.test.ts
+++ b/test/tags/reducers/tagEdit.test.ts
@@ -15,26 +15,16 @@ describe('tagEditReducer', () => {
 
   describe('reducer', () => {
     it('returns loading on EDIT_TAG_START', () => {
-      expect(reducer(undefined, editTag.pending('', fromPartial({})))).toEqual({
-        editing: true,
-        edited: false,
-        error: false,
-      });
+      expect(reducer(undefined, editTag.pending('', fromPartial({})))).toEqual({ status: 'editing' });
     });
 
     it('returns error on EDIT_TAG_ERROR', () => {
-      expect(reducer(undefined, editTag.rejected(null, '', fromPartial({})))).toEqual({
-        editing: false,
-        edited: false,
-        error: true,
-      });
+      expect(reducer(undefined, editTag.rejected(null, '', fromPartial({})))).toEqual({ status: 'error' });
     });
 
     it('returns tag names on EDIT_TAG', () => {
       expect(reducer(undefined, editTag.fulfilled({ oldName, newName, color }, '', fromPartial({})))).toEqual({
-        editing: false,
-        edited: true,
-        error: false,
+        status: 'edited',
         oldName: 'foo',
         newName: 'bar',
       });


### PR DESCRIPTION
Closes https://github.com/shlinkio/shlink-web-component/issues/874

Replace the multiple boolean flags that determine the status of the tag edition reducer, with a single status discriminator prop that is less error prone and easier to reason about.