### PR TITLE
Simplify redirection saving reducer type with a status discriminator prop

### DIFF
--- a/src/redirect-rules/ShortUrlRedirectRules.tsx
+++ b/src/redirect-rules/ShortUrlRedirectRules.tsx
@@ -41,8 +41,7 @@ export const ShortUrlRedirectRules: FC<ShortUrlRedirectRulesProps> = ({
     dragHandle: '.drag-n-drop-handler',
     dropZoneClass: 'opacity-25',
   });
-
-  const { saving, saved, errorData } = shortUrlRedirectRulesSaving;
+  const saving = shortUrlRedirectRulesSaving.status === 'saving';
 
   const { flag: isModalOpen, setToFalse: closeModal, setToTrue: openModal } = useToggle();
 
@@ -153,15 +152,17 @@ export const ShortUrlRedirectRules: FC<ShortUrlRedirectRulesProps> = ({
           </Button>
         </div>
       </form>
-      {errorData && (
+      {shortUrlRedirectRulesSaving.status === 'error' && (
         <Result variant="error">
           <ShlinkApiError
-            errorData={errorData}
+            errorData={shortUrlRedirectRulesSaving.error}
             fallbackMessage="An error occurred while saving short URL redirect rules :("
           />
         </Result>
       )}
-      {saved && <Result variant="success">Redirect rules properly saved.</Result>}
+      {shortUrlRedirectRulesSaving.status === 'saved' && (
+        <Result variant="success">Redirect rules properly saved.</Result>
+      )}
       <RedirectRuleModal isOpen={isModalOpen} onClose={closeModal} onSave={pushRule} />
     </div>
   );

--- a/src/redirect-rules/reducers/setShortUrlRedirectRules.ts
+++ b/src/redirect-rules/reducers/setShortUrlRedirectRules.ts
@@ -11,16 +11,14 @@ import { createAsyncThunk } from '../../store/helpers';
 const REDUCER_PREFIX = 'shlink/setShortUrlRedirectRules';
 
 export type SetShortUrlRedirectRules = {
-  saving: boolean;
-  saved: boolean;
-  error: boolean;
-  errorData?: ProblemDetailsError;
+  status: 'idle' | 'saving' | 'saved';
+} | {
+  status: 'error';
+  error?: ProblemDetailsError;
 };
 
 const initialState: SetShortUrlRedirectRules = {
-  saving: false,
-  saved: false,
-  error: false,
+  status: 'idle',
 };
 
 export type SetShortUrlRedirectRulesInfo = {
@@ -41,16 +39,16 @@ export const setShortUrlRedirectRulesReducerCreator = (
 ) => {
   const { reducer, actions } = createSlice({
     name: REDUCER_PREFIX,
-    initialState,
+    initialState: initialState as SetShortUrlRedirectRules,
     reducers: {
       resetSetRules: () => initialState,
     },
     extraReducers: (builder) => {
-      builder.addCase(setShortUrlRedirectRulesThunk.pending, () => ({ saving: true, saved: false, error: false }));
+      builder.addCase(setShortUrlRedirectRulesThunk.pending, () => ({ status: 'saving' }));
       builder.addCase(setShortUrlRedirectRulesThunk.rejected, (_, { error }) => (
-        { saving: false, saved: false, error: true, errorData: parseApiError(error) }
+        { status: 'error', error: parseApiError(error) }
       ));
-      builder.addCase(setShortUrlRedirectRulesThunk.fulfilled, () => ({ saving: false, error: false, saved: true }));
+      builder.addCase(setShortUrlRedirectRulesThunk.fulfilled, () => ({ status: 'saved' }));
     },
   });
 

--- a/src/tags/reducers/tagEdit.ts
+++ b/src/tags/reducers/tagEdit.ts
@@ -1,5 +1,5 @@
 import { createAction, createSlice } from '@reduxjs/toolkit';
-import type { ProblemDetailsError, ShlinkApiClient } from '../../api-contract';
+import type { ProblemDetailsError, ShlinkApiClient, ShlinkRenaming } from '../../api-contract';
 import { parseApiError } from '../../api-contract/utils';
 import { createAsyncThunk } from '../../store/helpers';
 import type { ColorGenerator } from '../../utils/services/ColorGenerator';
@@ -11,17 +11,13 @@ export type TagEdition = {
 } | {
   status: 'error';
   error?: ProblemDetailsError;
-} | {
+} | (ShlinkRenaming & {
   status: 'edited';
-  oldName: string;
-  newName: string;
-};
+});
 
-export interface EditTag {
-  oldName: string;
-  newName: string;
+export type EditTag = ShlinkRenaming & {
   color: string;
-}
+};
 
 const initialState: TagEdition = {
   status: 'idle',

--- a/test/redirect-rules/reducers/setShortUrlRedirectRules.test.ts
+++ b/test/redirect-rules/reducers/setShortUrlRedirectRules.test.ts
@@ -19,7 +19,7 @@ describe('setShortUrlRedirectRulesReducer', () => {
   describe('reducer', () => {
     it('returns saving on pending', () => {
       const result = reducer(undefined, setShortUrlRedirectRules.pending('', fromPartial({}), undefined));
-      expect(result).toEqual({ saving: true, saved: false, error: false });
+      expect(result).toEqual({ status: 'saving' });
     });
 
     it('returns error data on rejected', () => {
@@ -28,7 +28,7 @@ describe('setShortUrlRedirectRulesReducer', () => {
         undefined,
         setShortUrlRedirectRules.rejected(error, '', fromPartial({}), undefined, undefined),
       );
-      expect(result).toEqual({ saving: false, saved: false, error: true, errorData: parseApiError(error) });
+      expect(result).toEqual({ status: 'error', error: parseApiError(error) });
     });
 
     it('returns saved on fulfilled', () => {
@@ -36,12 +36,12 @@ describe('setShortUrlRedirectRulesReducer', () => {
         undefined,
         setShortUrlRedirectRules.fulfilled(fromPartial({}), '', fromPartial({}), undefined),
       );
-      expect(result).toEqual({ saving: false, saved: true, error: false });
+      expect(result).toEqual({ status: 'saved' });
     });
 
     it('resets to initial state on resetSetRules', () => {
       const result = reducer(undefined, resetSetRules());
-      expect(result).toEqual({ saving: false, saved: false, error: false });
+      expect(result).toEqual({ status: 'idle' });
     });
   });
 


### PR DESCRIPTION
Closes https://github.com/shlinkio/shlink-web-component/issues/874

Replace the multiple boolean flags that determine the status of the redirection saving reducers, with a single status discriminator prop that is less error prone and easier to reason about.