### PR TITLE
Create hook for tag edition reducer module

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -19,6 +19,7 @@ import { shortUrlsListReducer } from '../short-urls/reducers/shortUrlsList';
 import type { TagDeletion } from '../tags/reducers/tagDelete';
 import { tagDeleteReducer } from '../tags/reducers/tagDelete';
 import type { TagEdition } from '../tags/reducers/tagEdit';
+import { tagEditReducer } from '../tags/reducers/tagEdit';
 import type { TagsList } from '../tags/reducers/tagsList';
 import type { DomainVisits } from '../visits/reducers/domainVisits';
 import type { OrphanVisitsDeletion } from '../visits/reducers/orphanVisitsDeletion';
@@ -53,7 +54,7 @@ export const setUpStore = (container: IContainer, preloadedState?: any) => confi
     nonOrphanVisits: container.nonOrphanVisitsReducer as VisitsInfo,
     tagsList: container.tagsListReducer as TagsList,
     tagDelete: tagDeleteReducer,
-    tagEdit: container.tagEditReducer as TagEdition,
+    tagEdit: tagEditReducer,
     domainsList: container.domainsListReducer as DomainsList,
     visitsOverview: container.visitsOverviewReducer as VisitsOverview,
     shortUrlRedirectRules: shortUrlRedirectRulesReducer,

--- a/src/tags/helpers/EditTagModal.tsx
+++ b/src/tags/helpers/EditTagModal.tsx
@@ -6,21 +6,14 @@ import { componentFactory, useDependencies } from '../../container/utils';
 import { ColorPicker } from '../../utils/components/ColorPicker';
 import type { ColorGenerator } from '../../utils/services/ColorGenerator';
 import type { TagModalProps } from '../data';
-import type { EditTag, TagEdition } from '../reducers/tagEdit';
-
-interface EditTagModalProps extends TagModalProps {
-  tagEdit: TagEdition;
-  editTag: (editTag: EditTag) => Promise<void>;
-  tagEdited: (tagEdited: EditTag) => void;
-}
+import { useTagEdit } from '../reducers/tagEdit';
 
 type EditTagModalDeps = {
   ColorGenerator: ColorGenerator;
 };
 
-const EditTagModal: FCWithDeps<EditTagModalProps, EditTagModalDeps> = (
-  { tag, editTag, onClose, tagEdited, isOpen, tagEdit },
-) => {
+const EditTagModal: FCWithDeps<TagModalProps, EditTagModalDeps> = ({ tag, onClose, isOpen }) => {
+  const { editTag, tagEdited, tagEdit } = useTagEdit();
   const { ColorGenerator: colorGenerator } = useDependencies(EditTagModal);
   const [newTagName, setNewTagName] = useState(tag);
   const [color, setColor] = useState(colorGenerator.getColorForKey(tag));

--- a/src/tags/reducers/tagEdit.ts
+++ b/src/tags/reducers/tagEdit.ts
@@ -1,6 +1,11 @@
 import { createAction, createSlice } from '@reduxjs/toolkit';
-import type { ProblemDetailsError, ShlinkApiClient, ShlinkRenaming } from '../../api-contract';
+import type { ShlinkApiClient } from '@shlinkio/shlink-js-sdk';
+import { useCallback } from 'react';
+import type { ProblemDetailsError, ShlinkRenaming } from '../../api-contract';
 import { parseApiError } from '../../api-contract/utils';
+import { useDependencies } from '../../container/context';
+import { useAppDispatch, useAppSelector } from '../../store';
+import type { WithApiClient } from '../../store/helpers';
 import { createAsyncThunk } from '../../store/helpers';
 import type { ColorGenerator } from '../../utils/services/ColorGenerator';
 
@@ -25,12 +30,13 @@ const initialState: TagEdition = {
 
 export const tagEdited = createAction<EditTag>(`${REDUCER_PREFIX}/tagEdited`);
 
-export const editTag = (
-  apiClientFactory: () => ShlinkApiClient,
-  colorGenerator: ColorGenerator,
-) => createAsyncThunk(
+type EditTagOptions = WithApiClient<EditTag> & {
+  colorGenerator: ColorGenerator;
+};
+
+export const editTagThunk = createAsyncThunk(
   `${REDUCER_PREFIX}/editTag`,
-  async ({ oldName, newName, color }: EditTag): Promise<EditTag> => {
+  async ({ oldName, newName, color, apiClientFactory, colorGenerator }: EditTagOptions): Promise<EditTag> => {
     await apiClientFactory().editTag({ oldName, newName });
     colorGenerator.setColorForKey(newName, color);
 
@@ -38,7 +44,7 @@ export const editTag = (
   },
 );
 
-export const tagEditReducerCreator = (editTagThunk: ReturnType<typeof editTag>) => createSlice({
+export const { reducer: tagEditReducer } = createSlice({
   name: REDUCER_PREFIX,
   initialState: initialState as TagEdition,
   reducers: {},
@@ -51,3 +57,19 @@ export const tagEditReducerCreator = (editTagThunk: ReturnType<typeof editTag>) 
     });
   },
 });
+
+export const useTagEdit = () => {
+  const dispatch = useAppDispatch();
+  const [apiClientFactory, colorGenerator] = useDependencies<[() => ShlinkApiClient, ColorGenerator]>(
+    'apiClientFactory',
+    'ColorGenerator',
+  );
+  const editTag = useCallback(
+    (data: EditTag) => dispatch(editTagThunk({ ...data, apiClientFactory, colorGenerator })),
+    [apiClientFactory, colorGenerator, dispatch],
+  );
+  const dispatchTagEdited = useCallback((data: EditTag) => dispatch(tagEdited(data)), [dispatch]);
+  const tagEdit = useAppSelector((state) => state.tagEdit);
+
+  return { tagEdit, editTag, tagEdited: dispatchTagEdited };
+};

--- a/src/tags/services/provideServices.ts
+++ b/src/tags/services/provideServices.ts
@@ -3,7 +3,6 @@ import type { ConnectDecorator } from '../../container';
 import { EditTagModalFactory } from '../helpers/EditTagModal';
 import { TagsSearchDropdownFactory } from '../helpers/TagsSearchDropdown';
 import { TagsSelectorFactory } from '../helpers/TagsSelector';
-import { editTag, tagEdited, tagEditReducerCreator } from '../reducers/tagEdit';
 import { filterTags, listTags, tagsListReducerCreator } from '../reducers/tagsList';
 import { TagsListFactory } from '../TagsList';
 import { TagsTableFactory } from '../TagsTable';
@@ -15,7 +14,6 @@ export const provideServices = (bottle: Bottle, connect: ConnectDecorator) => {
   bottle.factory('TagsSearchDropdown', TagsSearchDropdownFactory);
 
   bottle.factory('EditTagModal', EditTagModalFactory);
-  bottle.decorator('EditTagModal', connect(['tagEdit'], ['editTag', 'tagEdited']));
 
   bottle.factory('TagsTableRow', TagsTableRowFactory);
   bottle.factory('TagsTable', TagsTableFactory);
@@ -24,16 +22,10 @@ export const provideServices = (bottle: Bottle, connect: ConnectDecorator) => {
   bottle.decorator('TagsList', connect(['tagsList'], ['filterTags']));
 
   // Reducers
-  bottle.serviceFactory('tagEditReducerCreator', tagEditReducerCreator, 'editTag');
-  bottle.serviceFactory('tagEditReducer', (obj) => obj.reducer, 'tagEditReducerCreator');
-
   bottle.serviceFactory('tagsListReducerCreator', tagsListReducerCreator, 'listTags');
   bottle.serviceFactory('tagsListReducer', (obj) => obj.reducer, 'tagsListReducerCreator');
 
   // Actions
   bottle.serviceFactory('listTags', listTags, 'apiClientFactory');
   bottle.serviceFactory('filterTags', () => filterTags);
-
-  bottle.serviceFactory('editTag', editTag, 'apiClientFactory', 'ColorGenerator');
-  bottle.serviceFactory('tagEdited', () => tagEdited);
 };

--- a/test/tags/helpers/EditTagModal.test.tsx
+++ b/test/tags/helpers/EditTagModal.test.tsx
@@ -1,9 +1,11 @@
 import { screen } from '@testing-library/react';
 import { fromPartial } from '@total-typescript/shoehorn';
+import { ContainerProvider } from '../../../src/container/context';
 import { EditTagModalFactory } from '../../../src/tags/helpers/EditTagModal';
 import type { TagEdition } from '../../../src/tags/reducers/tagEdit';
 import { checkAccessibility } from '../../__helpers__/accessibility';
-import { renderWithEvents } from '../../__helpers__/setUpTest';
+import { renderWithStore } from '../../__helpers__/setUpTest';
+import { colorGeneratorMock } from '../../utils/services/__mocks__/ColorGenerator.mock';
 
 describe('<EditTagModal />', () => {
   const EditTagModal = EditTagModalFactory(fromPartial({
@@ -11,12 +13,19 @@ describe('<EditTagModal />', () => {
   }));
   const editTag = vi.fn().mockReturnValue(Promise.resolve());
   const onClose = vi.fn();
-  const setUp = (tagEdit: Partial<TagEdition> = {}) => {
-    const edition = fromPartial<TagEdition>(tagEdit);
-    return renderWithEvents(
-      <EditTagModal isOpen tag="foo" tagEdit={edition} editTag={editTag} tagEdited={vi.fn()} onClose={onClose} />,
-    );
-  };
+  const setUp = (tagEdit: Partial<TagEdition> = {}) => renderWithStore(
+    <ContainerProvider
+      value={fromPartial({
+        apiClientFactory: () => fromPartial({ editTag }),
+        ColorGenerator: colorGeneratorMock,
+      })}
+    >
+      <EditTagModal tag="foo" isOpen onClose={onClose} />
+    </ContainerProvider>,
+    {
+      initialState: { tagEdit: fromPartial<TagEdition>(tagEdit) },
+    },
+  );
 
   it('passes a11y checks', () => checkAccessibility(setUp()));
 

--- a/test/tags/reducers/tagEdit.test.ts
+++ b/test/tags/reducers/tagEdit.test.ts
@@ -1,6 +1,6 @@
 import { fromPartial } from '@total-typescript/shoehorn';
 import type { ShlinkApiClient } from '../../../src/api-contract';
-import { editTag as editTagCreator, tagEdited, tagEditReducerCreator } from '../../../src/tags/reducers/tagEdit';
+import { editTagThunk as editTag, tagEdited, tagEditReducer as reducer } from '../../../src/tags/reducers/tagEdit';
 import type { ColorGenerator } from '../../../src/utils/services/ColorGenerator';
 
 describe('tagEditReducer', () => {
@@ -8,10 +8,8 @@ describe('tagEditReducer', () => {
   const newName = 'bar';
   const color = '#ff0000';
   const editTagCall = vi.fn();
-  const buildShlinkApiClient = () => fromPartial<ShlinkApiClient>({ editTag: editTagCall });
+  const apiClientFactory = () => fromPartial<ShlinkApiClient>({ editTag: editTagCall });
   const colorGenerator = fromPartial<ColorGenerator>({ setColorForKey: vi.fn() });
-  const editTag = editTagCreator(buildShlinkApiClient, colorGenerator);
-  const { reducer } = tagEditReducerCreator(editTag);
 
   describe('reducer', () => {
     it('returns loading on EDIT_TAG_START', () => {
@@ -44,7 +42,7 @@ describe('tagEditReducer', () => {
     it('calls API on success', async () => {
       editTagCall.mockResolvedValue(undefined);
 
-      await editTag({ oldName, newName, color })(dispatch, vi.fn(), {});
+      await editTag({ oldName, newName, color, apiClientFactory, colorGenerator })(dispatch, vi.fn(), {});
 
       expect(editTagCall).toHaveBeenCalledOnce();
       expect(editTagCall).toHaveBeenCalledWith({ oldName, newName });


### PR DESCRIPTION
Part of https://github.com/shlinkio/shlink-web-component/issues/161

Stop injecting tag-edition-related redux state and actions, and provide a hook wrapping useDispatch and useSelector instead.