### PR TITLE
Create hook for orphan visits deletion reducer module

### DIFF
--- a/src/store/helpers.ts
+++ b/src/store/helpers.ts
@@ -16,7 +16,7 @@ export const createAsyncThunk = <Returned, ThunkArg = void>(
   payloadCreator: ShlinkPayloadCreator<Returned, ThunkArg>,
 ) => baseCreateAsyncThunk(typePrefix, payloadCreator, { serializeError: (e) => e });
 
-export type WithApiClient<T> = T & { apiClientFactory: () => ShlinkApiClient };
+export type WithApiClient<T = unknown> = T & { apiClientFactory: () => ShlinkApiClient };
 
 /**
  * Alias for useDependencies<[() => ShlinkApiClient]>('apiClientFactory')[0], to avoid duplicating this logic in every

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -23,6 +23,7 @@ import { tagEditReducer } from '../tags/reducers/tagEdit';
 import type { TagsList } from '../tags/reducers/tagsList';
 import type { DomainVisits } from '../visits/reducers/domainVisits';
 import type { OrphanVisitsDeletion } from '../visits/reducers/orphanVisitsDeletion';
+import { orphanVisitsDeletionReducer } from '../visits/reducers/orphanVisitsDeletion';
 import type { ShortUrlVisits } from '../visits/reducers/shortUrlVisits';
 import type { ShortUrlVisitsDeletion } from '../visits/reducers/shortUrlVisitsDeletion';
 import type { TagVisits } from '../visits/reducers/tagVisits';
@@ -50,7 +51,7 @@ export const setUpStore = (container: IContainer, preloadedState?: any) => confi
     domainVisits: container.domainVisitsReducer as DomainVisits,
     domainVisitsComparison: container.domainVisitsComparisonReducer as VisitsComparisonInfo,
     orphanVisits: container.orphanVisitsReducer as VisitsInfo,
-    orphanVisitsDeletion: container.orphanVisitsDeletionReducer as OrphanVisitsDeletion,
+    orphanVisitsDeletion: orphanVisitsDeletionReducer,
     nonOrphanVisits: container.nonOrphanVisitsReducer as VisitsInfo,
     tagsList: container.tagsListReducer as TagsList,
     tagDelete: tagDeleteReducer,

--- a/src/visits/OrphanVisits.tsx
+++ b/src/visits/OrphanVisits.tsx
@@ -6,7 +6,7 @@ import { boundToMercureHub } from '../mercure/helpers/boundToMercureHub';
 import { Topics } from '../mercure/helpers/Topics';
 import type { ReportExporter } from '../utils/services/ReportExporter';
 import type { LoadOrphanVisits } from './reducers/orphanVisits';
-import type { OrphanVisitsDeletion } from './reducers/orphanVisitsDeletion';
+import { useOrphanVisitsDeletion } from './reducers/orphanVisitsDeletion';
 import type { GetVisitsOptions, VisitsInfo } from './reducers/types';
 import type { NormalizedVisit, VisitsParams } from './types';
 import { VisitsHeader } from './VisitsHeader';
@@ -14,9 +14,7 @@ import { VisitsStats } from './VisitsStats';
 
 export type OrphanVisitsProps = {
   getOrphanVisits: (params: LoadOrphanVisits) => void;
-  deleteOrphanVisits: () => void;
   orphanVisits: VisitsInfo;
-  orphanVisitsDeletion: OrphanVisitsDeletion;
   cancelGetOrphanVisits: () => void;
   domainsList: DomainsList;
 };
@@ -26,7 +24,7 @@ type OrphanVisitsDeps = {
 };
 
 const OrphanVisits: FCWithDeps<OrphanVisitsProps, OrphanVisitsDeps> = boundToMercureHub((
-  { getOrphanVisits, orphanVisits, cancelGetOrphanVisits, deleteOrphanVisits, orphanVisitsDeletion, domainsList },
+  { getOrphanVisits, orphanVisits, cancelGetOrphanVisits, domainsList },
 ) => {
   const { ReportExporter: reportExporter } = useDependencies(OrphanVisits);
   const exportCsv = useCallback(
@@ -42,6 +40,7 @@ const OrphanVisits: FCWithDeps<OrphanVisitsProps, OrphanVisitsDeps> = boundToMer
     }),
     [getOrphanVisits],
   );
+  const { deleteOrphanVisits, orphanVisitsDeletion } = useOrphanVisitsDeletion();
   const deletion = useMemo(
     () => ({ deleteVisits: deleteOrphanVisits, visitsDeletion: orphanVisitsDeletion }),
     [deleteOrphanVisits, orphanVisitsDeletion],

--- a/src/visits/reducers/orphanVisits.ts
+++ b/src/visits/reducers/orphanVisits.ts
@@ -3,7 +3,7 @@ import type { ShlinkApiClient, ShlinkOrphanVisit, ShlinkOrphanVisitType } from '
 import { isBetween } from '../../utils/dates/helpers/date';
 import { isOrphanVisit } from '../helpers';
 import { createVisitsAsyncThunk, createVisitsReducer, lastVisitLoaderForLoader } from './common';
-import type { deleteOrphanVisits } from './orphanVisitsDeletion';
+import { deleteOrphanVisitsThunk } from './orphanVisitsDeletion';
 import type { LoadWithDomainVisits, VisitsInfo } from './types';
 
 const REDUCER_PREFIX = 'shlink/orphanVisits';
@@ -51,7 +51,6 @@ export const getOrphanVisits = (apiClientFactory: () => ShlinkApiClient) => crea
 
 export const orphanVisitsReducerCreator = (
   asyncThunkCreator: ReturnType<typeof getOrphanVisits>,
-  deleteOrphanVisitsThunk: ReturnType<typeof deleteOrphanVisits>,
 ) => createVisitsReducer({
   name: REDUCER_PREFIX,
   initialState,

--- a/src/visits/services/provideServices.ts
+++ b/src/visits/services/provideServices.ts
@@ -7,7 +7,6 @@ import { OrphanVisitsFactory } from '../OrphanVisits';
 import { domainVisitsReducerCreator, getDomainVisits } from '../reducers/domainVisits';
 import { getNonOrphanVisits, nonOrphanVisitsReducerCreator } from '../reducers/nonOrphanVisits';
 import { getOrphanVisits, orphanVisitsReducerCreator } from '../reducers/orphanVisits';
-import { deleteOrphanVisits, orphanVisitsDeletionReducerCreator } from '../reducers/orphanVisitsDeletion';
 import { getShortUrlVisits, shortUrlVisitsReducerCreator } from '../reducers/shortUrlVisits';
 import { deleteShortUrlVisits, shortUrlVisitsDeletionReducerCreator } from '../reducers/shortUrlVisitsDeletion';
 import { getTagVisits, tagVisitsReducerCreator } from '../reducers/tagVisits';
@@ -77,8 +76,8 @@ export const provideServices = (bottle: Bottle, connect: ConnectDecorator) => {
 
   bottle.factory('OrphanVisits', OrphanVisitsFactory);
   bottle.decorator('OrphanVisits', connect(
-    ['orphanVisits', 'orphanVisitsDeletion', 'domainsList'],
-    ['getOrphanVisits', 'cancelGetOrphanVisits', 'deleteOrphanVisits'],
+    ['orphanVisits', 'domainsList'],
+    ['getOrphanVisits', 'cancelGetOrphanVisits'],
   ));
 
   bottle.factory('NonOrphanVisits', NonOrphanVisitsFactory);
@@ -126,8 +125,6 @@ export const provideServices = (bottle: Bottle, connect: ConnectDecorator) => {
   bottle.serviceFactory('getOrphanVisits', getOrphanVisits, 'apiClientFactory');
   bottle.serviceFactory('cancelGetOrphanVisits', (obj) => obj.cancelGetVisits, 'orphanVisitsReducerCreator');
 
-  bottle.serviceFactory('deleteOrphanVisits', deleteOrphanVisits, 'apiClientFactory');
-
   bottle.serviceFactory('getNonOrphanVisits', getNonOrphanVisits, 'apiClientFactory');
   bottle.serviceFactory('cancelGetNonOrphanVisits', (obj) => obj.cancelGetVisits, 'nonOrphanVisitsReducerCreator');
 
@@ -147,16 +144,8 @@ export const provideServices = (bottle: Bottle, connect: ConnectDecorator) => {
     'orphanVisitsReducerCreator',
     orphanVisitsReducerCreator,
     'getOrphanVisits',
-    'deleteOrphanVisits',
   );
   bottle.serviceFactory('orphanVisitsReducer', (obj) => obj.reducer, 'orphanVisitsReducerCreator');
-
-  bottle.serviceFactory(
-    'orphanVisitsDeletionReducerCreator',
-    orphanVisitsDeletionReducerCreator,
-    'deleteOrphanVisits',
-  );
-  bottle.serviceFactory('orphanVisitsDeletionReducer', (obj) => obj.reducer, 'orphanVisitsDeletionReducerCreator');
 
   bottle.serviceFactory(
     'shortUrlVisitsReducerCreator',

--- a/test/visits/OrphanVisits.test.tsx
+++ b/test/visits/OrphanVisits.test.tsx
@@ -25,8 +25,6 @@ describe('<OrphanVisits />', () => {
             getOrphanVisits={getOrphanVisits}
             orphanVisits={orphanVisits}
             cancelGetOrphanVisits={vi.fn()}
-            deleteOrphanVisits={vi.fn()}
-            orphanVisitsDeletion={fromPartial({})}
             domainsList={fromPartial({ domains: [] })}
           />
         </Card>

--- a/test/visits/reducers/orphanVisits.test.ts
+++ b/test/visits/reducers/orphanVisits.test.ts
@@ -10,6 +10,7 @@ import {
   getOrphanVisits as getOrphanVisitsCreator,
   orphanVisitsReducerCreator,
 } from '../../../src/visits/reducers/orphanVisits';
+import { deleteOrphanVisitsThunk } from '../../../src/visits/reducers/orphanVisitsDeletion';
 import type { VisitsInfo } from '../../../src/visits/reducers/types';
 import { createNewVisits } from '../../../src/visits/reducers/visitCreation';
 import { problemDetailsError } from '../../__mocks__/ProblemDetailsError.mock';
@@ -21,10 +22,7 @@ describe('orphanVisitsReducer', () => {
   const getOrphanVisitsCall = vi.fn();
   const buildShlinkApiClientMock = () => fromPartial<ShlinkApiClient>({ getOrphanVisits: getOrphanVisitsCall });
   const getOrphanVisits = getOrphanVisitsCreator(buildShlinkApiClientMock);
-  const { reducer, cancelGetVisits: cancelGetOrphanVisits } = orphanVisitsReducerCreator(
-    getOrphanVisits,
-    fromPartial({ fulfilled: { type: 'deleteOrphanVisits' } }),
-  );
+  const { reducer, cancelGetVisits: cancelGetOrphanVisits } = orphanVisitsReducerCreator(getOrphanVisits);
 
   describe('reducer', () => {
     const buildState = (data: Partial<VisitsInfo>) => fromPartial<VisitsInfo>(data);
@@ -129,7 +127,7 @@ describe('orphanVisitsReducer', () => {
       const prevState = buildState({
         visits: [fromPartial({}), fromPartial({})],
       });
-      const result = reducer(prevState, { type: 'deleteOrphanVisits', payload: {} });
+      const result = reducer(prevState, deleteOrphanVisitsThunk.fulfilled(fromPartial({}), '', fromPartial({})));
 
       expect(result.visits).toHaveLength(0);
     });


### PR DESCRIPTION
Part of https://github.com/shlinkio/shlink-web-component/issues/161

Stop injecting orphan-visits-deletion-related redux state and actions, and provide a hook wrapping useDispatch and useSelector instead.