### PR TITLE
Create hook for url visits deletion reducer module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/playwright:v1.56.1-noble
+FROM mcr.microsoft.com/playwright:v1.57.0-noble
 
 ENV NODE_VERSION 24.11
 ENV TINI_VERSION v0.19.0

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -26,6 +26,7 @@ import type { OrphanVisitsDeletion } from '../visits/reducers/orphanVisitsDeleti
 import { orphanVisitsDeletionReducer } from '../visits/reducers/orphanVisitsDeletion';
 import type { ShortUrlVisits } from '../visits/reducers/shortUrlVisits';
 import type { ShortUrlVisitsDeletion } from '../visits/reducers/shortUrlVisitsDeletion';
+import { shortUrlVisitsDeletionReducer } from '../visits/reducers/shortUrlVisitsDeletion';
 import type { TagVisits } from '../visits/reducers/tagVisits';
 import type { VisitsInfo } from '../visits/reducers/types';
 import type { VisitsOverview } from '../visits/reducers/visitsOverview';
@@ -44,7 +45,7 @@ export const setUpStore = (container: IContainer, preloadedState?: any) => confi
     shortUrlEdition: shortUrlEditionReducer,
     shortUrlsDetails: container.shortUrlsDetailsReducer as ShortUrlsDetails,
     shortUrlVisits: container.shortUrlVisitsReducer as ShortUrlVisits,
-    shortUrlVisitsDeletion: container.shortUrlVisitsDeletionReducer as ShortUrlVisitsDeletion,
+    shortUrlVisitsDeletion: shortUrlVisitsDeletionReducer,
     shortUrlVisitsComparison: container.shortUrlVisitsComparisonReducer as VisitsComparisonInfo,
     tagVisits: container.tagVisitsReducer as TagVisits,
     tagVisitsComparison: container.tagVisitsComparisonReducer as VisitsComparisonInfo,

--- a/src/visits/ShortUrlVisits.tsx
+++ b/src/visits/ShortUrlVisits.tsx
@@ -9,7 +9,7 @@ import { useShortUrlIdentifier } from '../short-urls/helpers/hooks';
 import type { ShortUrlsDetails } from '../short-urls/reducers/shortUrlsDetails';
 import type { ReportExporter } from '../utils/services/ReportExporter';
 import type { LoadShortUrlVisits, ShortUrlVisits as ShortUrlVisitsState } from './reducers/shortUrlVisits';
-import type { ShortUrlVisitsDeletion } from './reducers/shortUrlVisitsDeletion';
+import { useUrlVisitsDeletion } from './reducers/shortUrlVisitsDeletion';
 import type { GetVisitsOptions } from './reducers/types';
 import { ShortUrlVisitsHeader } from './ShortUrlVisitsHeader';
 import type { NormalizedVisit, VisitsParams } from './types';
@@ -17,9 +17,7 @@ import { VisitsStats } from './VisitsStats';
 
 export type ShortUrlVisitsProps = {
   shortUrlVisits: ShortUrlVisitsState;
-  shortUrlVisitsDeletion: ShortUrlVisitsDeletion;
   getShortUrlVisits: (params: LoadShortUrlVisits) => void;
-  deleteShortUrlVisits: (shortUrl: ShlinkShortUrlIdentifier) => void;
   getShortUrlsDetails: (identifiers: ShlinkShortUrlIdentifier[]) => void;
   shortUrlsDetails: ShortUrlsDetails;
   cancelGetShortUrlVisits: () => void;
@@ -31,11 +29,9 @@ type ShortUrlVisitsDeps = {
 
 const ShortUrlVisits: FCWithDeps<ShortUrlVisitsProps, ShortUrlVisitsDeps> = boundToMercureHub(({
   shortUrlVisits,
-  shortUrlVisitsDeletion,
   shortUrlsDetails,
   getShortUrlVisits,
   getShortUrlsDetails,
-  deleteShortUrlVisits,
   cancelGetShortUrlVisits,
 }: ShortUrlVisitsProps) => {
   const { ReportExporter: reportExporter } = useDependencies(ShortUrlVisits);
@@ -55,6 +51,8 @@ const ShortUrlVisits: FCWithDeps<ShortUrlVisitsProps, ShortUrlVisitsDeps> = boun
     `short-url_${shortUrl?.shortUrl.replace(/https?:\/\//g, '')}_visits.csv`,
     visits,
   ), [reportExporter, shortUrl?.shortUrl]);
+
+  const { shortUrlVisitsDeletion, deleteShortUrlVisits } = useUrlVisitsDeletion();
   const deletion = useMemo(() => {
     const deleteVisits = () => deleteShortUrlVisits(identifier);
     return { deleteVisits, visitsDeletion: shortUrlVisitsDeletion };

--- a/src/visits/reducers/shortUrlVisits.ts
+++ b/src/visits/reducers/shortUrlVisits.ts
@@ -1,7 +1,7 @@
 import type { ShlinkApiClient, ShlinkShortUrlIdentifier, ShlinkVisitsParams } from '../../api-contract';
 import { filterCreatedVisitsByShortUrl } from '../helpers';
 import { createVisitsAsyncThunk, createVisitsReducer, lastVisitLoaderForLoader } from './common';
-import type { deleteShortUrlVisits } from './shortUrlVisitsDeletion';
+import { deleteShortUrlVisitsThunk } from './shortUrlVisitsDeletion';
 import type { LoadVisits, VisitsInfo } from './types';
 
 const REDUCER_PREFIX = 'shlink/shortUrlVisits';
@@ -38,7 +38,6 @@ export const getShortUrlVisits = (apiClientFactory: () => ShlinkApiClient) => cr
 
 export const shortUrlVisitsReducerCreator = (
   asyncThunkCreator: ReturnType<typeof getShortUrlVisits>,
-  deleteShortUrlVisitsThunk: ReturnType<typeof deleteShortUrlVisits>,
 ) => createVisitsReducer({
   name: REDUCER_PREFIX,
   initialState,

--- a/src/visits/services/provideServices.ts
+++ b/src/visits/services/provideServices.ts
@@ -8,7 +8,6 @@ import { domainVisitsReducerCreator, getDomainVisits } from '../reducers/domainV
 import { getNonOrphanVisits, nonOrphanVisitsReducerCreator } from '../reducers/nonOrphanVisits';
 import { getOrphanVisits, orphanVisitsReducerCreator } from '../reducers/orphanVisits';
 import { getShortUrlVisits, shortUrlVisitsReducerCreator } from '../reducers/shortUrlVisits';
-import { deleteShortUrlVisits, shortUrlVisitsDeletionReducerCreator } from '../reducers/shortUrlVisitsDeletion';
 import { getTagVisits, tagVisitsReducerCreator } from '../reducers/tagVisits';
 import { loadVisitsOverview, visitsOverviewReducerCreator } from '../reducers/visitsOverview';
 import { ShortUrlVisitsFactory } from '../ShortUrlVisits';
@@ -35,16 +34,10 @@ export const provideServices = (bottle: Bottle, connect: ConnectDecorator) => {
   bottle.serviceFactory('MapModal', () => MapModal);
 
   bottle.factory('ShortUrlVisits', ShortUrlVisitsFactory);
-  bottle.decorator('ShortUrlVisits', connect([
-    'shortUrlVisits',
-    'shortUrlVisitsDeletion',
-    'shortUrlsDetails',
-  ], [
-    'getShortUrlVisits',
-    'deleteShortUrlVisits',
-    'getShortUrlsDetails',
-    'cancelGetShortUrlVisits',
-  ]));
+  bottle.decorator('ShortUrlVisits', connect(
+    ['shortUrlVisits', 'shortUrlsDetails'],
+    ['getShortUrlVisits', 'getShortUrlsDetails', 'cancelGetShortUrlVisits'],
+  ));
 
   bottle.factory('TagVisits', TagVisitsFactory);
   bottle.decorator('TagVisits', connect(['tagVisits', 'domainsList'], ['getTagVisits', 'cancelGetTagVisits']));
@@ -64,11 +57,7 @@ export const provideServices = (bottle: Bottle, connect: ConnectDecorator) => {
   bottle.serviceFactory('ShortUrlVisitsComparison', () => ShortUrlVisitsComparison);
   bottle.decorator('ShortUrlVisitsComparison', connect(
     ['shortUrlVisitsComparison', 'shortUrlsDetails'],
-    [
-      'getShortUrlVisitsForComparison',
-      'cancelGetShortUrlVisitsForComparison',
-      'getShortUrlsDetails',
-    ],
+    ['getShortUrlVisitsForComparison', 'cancelGetShortUrlVisitsForComparison', 'getShortUrlsDetails'],
   ));
 
   bottle.factory('DomainVisits', DomainVisitsFactory);
@@ -99,8 +88,6 @@ export const provideServices = (bottle: Bottle, connect: ConnectDecorator) => {
     (obj) => obj.cancelGetVisits,
     'shortUrlVisitsComparisonReducerCreator',
   );
-
-  bottle.serviceFactory('deleteShortUrlVisits', deleteShortUrlVisits, 'apiClientFactory');
 
   bottle.serviceFactory('getTagVisits', getTagVisits, 'apiClientFactory');
   bottle.serviceFactory('cancelGetTagVisits', (obj) => obj.cancelGetVisits, 'tagVisitsReducerCreator');
@@ -151,16 +138,8 @@ export const provideServices = (bottle: Bottle, connect: ConnectDecorator) => {
     'shortUrlVisitsReducerCreator',
     shortUrlVisitsReducerCreator,
     'getShortUrlVisits',
-    'deleteShortUrlVisits',
   );
   bottle.serviceFactory('shortUrlVisitsReducer', (obj) => obj.reducer, 'shortUrlVisitsReducerCreator');
-
-  bottle.serviceFactory(
-    'shortUrlVisitsDeletionReducerCreator',
-    shortUrlVisitsDeletionReducerCreator,
-    'deleteShortUrlVisits',
-  );
-  bottle.serviceFactory('shortUrlVisitsDeletionReducer', (obj) => obj.reducer, 'shortUrlVisitsDeletionReducerCreator');
 
   bottle.serviceFactory('tagVisitsReducerCreator', tagVisitsReducerCreator, 'getTagVisits');
   bottle.serviceFactory('tagVisitsReducer', (obj) => obj.reducer, 'tagVisitsReducerCreator');

--- a/test/visits/ShortUrlVisits.test.tsx
+++ b/test/visits/ShortUrlVisits.test.tsx
@@ -37,8 +37,6 @@ describe('<ShortUrlVisits />', () => {
                 }),
               },
             })}
-            shortUrlVisitsDeletion={fromPartial({})}
-            deleteShortUrlVisits={vi.fn()}
             cancelGetShortUrlVisits={vi.fn()}
           />
         </Card>

--- a/test/visits/reducers/shortUrlVisits.test.ts
+++ b/test/visits/reducers/shortUrlVisits.test.ts
@@ -10,6 +10,7 @@ import {
   getShortUrlVisits as getShortUrlVisitsCreator,
   shortUrlVisitsReducerCreator,
 } from '../../../src/visits/reducers/shortUrlVisits';
+import { deleteShortUrlVisitsThunk } from '../../../src/visits/reducers/shortUrlVisitsDeletion';
 import { createNewVisits } from '../../../src/visits/reducers/visitCreation';
 import { problemDetailsError } from '../../__mocks__/ProblemDetailsError.mock';
 
@@ -20,10 +21,7 @@ describe('shortUrlVisitsReducer', () => {
   const getShortUrlVisitsCall = vi.fn();
   const buildApiClientMock = () => fromPartial<ShlinkApiClient>({ getShortUrlVisits: getShortUrlVisitsCall });
   const getShortUrlVisits = getShortUrlVisitsCreator(buildApiClientMock);
-  const { reducer, cancelGetVisits: cancelGetShortUrlVisits } = shortUrlVisitsReducerCreator(
-    getShortUrlVisits,
-    fromPartial({ fulfilled: { type: 'deleteShortUrlVisits' } }),
-  );
+  const { reducer, cancelGetVisits: cancelGetShortUrlVisits } = shortUrlVisitsReducerCreator(getShortUrlVisits);
 
   describe('reducer', () => {
     const buildState = (data: Partial<ShortUrlVisits>) => fromPartial<ShortUrlVisits>(data);
@@ -159,7 +157,10 @@ describe('shortUrlVisitsReducer', () => {
         shortCode: 'abc123',
         domain: 'domain',
       });
-      const result = reducer(prevState, { type: 'deleteShortUrlVisits', payload: { shortCode, domain } });
+      const result = reducer(
+        prevState,
+        deleteShortUrlVisitsThunk.fulfilled(fromPartial({ shortCode, domain }), '', fromPartial({})),
+      );
 
       expect(result.visits).toHaveLength(expectedVisitsLength);
     });

--- a/test/visits/reducers/shortUrlVisitsDeletion.test.ts
+++ b/test/visits/reducers/shortUrlVisitsDeletion.test.ts
@@ -1,17 +1,13 @@
 import { fromPartial } from '@total-typescript/shoehorn';
 import type { ShlinkApiClient } from '../../../src/api-contract';
 import {
-  deleteShortUrlVisits as deleteShortUrlVisitsCreator,
-  shortUrlVisitsDeletionReducerCreator,
+  deleteShortUrlVisitsThunk as deleteShortUrlVisits,
+  shortUrlVisitsDeletionReducer as reducer,
 } from '../../../src/visits/reducers/shortUrlVisitsDeletion';
 
 describe('shortUrlsVisitsDeletionReducer', () => {
   const deleteShortUrlVisitsCall = vi.fn();
-  const buildShlinkApiClientMock = () => fromPartial<ShlinkApiClient>({
-    deleteShortUrlVisits: deleteShortUrlVisitsCall,
-  });
-  const deleteShortUrlVisits = deleteShortUrlVisitsCreator(buildShlinkApiClientMock);
-  const { reducer } = shortUrlVisitsDeletionReducerCreator(deleteShortUrlVisits);
+  const apiClientFactory = () => fromPartial<ShlinkApiClient>({ deleteShortUrlVisits: deleteShortUrlVisitsCall });
 
   describe('reducer', () => {
     it('returns deleting for pending action', () => {
@@ -39,7 +35,7 @@ describe('shortUrlsVisitsDeletionReducer', () => {
     it('dispatches payload containing short URL info and deleted visits', async () => {
       deleteShortUrlVisitsCall.mockResolvedValue({ deletedVisits: 50 });
 
-      await deleteShortUrlVisits({ shortCode: 'foo' })(dispatch, vi.fn(), {});
+      await deleteShortUrlVisits({ shortCode: 'foo', apiClientFactory })(dispatch, vi.fn(), {});
 
       expect(deleteShortUrlVisitsCall).toHaveBeenCalledOnce();
       expect(dispatch).toHaveBeenCalledTimes(2);


### PR DESCRIPTION
Part of https://github.com/shlinkio/shlink-web-component/issues/161

Stop injecting url-visits-deletion-related redux state and actions, and provide a hook wrapping useDispatch and useSelector instead.