### PR TITLE
Create hook for visits overview reducer module

### DIFF
--- a/src/overview/Overview.tsx
+++ b/src/overview/Overview.tsx
@@ -13,7 +13,7 @@ import { ITEMS_IN_OVERVIEW_PAGE, useUrlsList } from '../short-urls/reducers/shor
 import type { ShortUrlsTableType } from '../short-urls/ShortUrlsTable';
 import type { TagsList } from '../tags/reducers/tagsList';
 import { useRoutesPrefix } from '../utils/routesPrefix';
-import type { VisitsOverview } from '../visits/reducers/visitsOverview';
+import { useVisitsOverview } from '../visits/reducers/visitsOverview';
 import { HighlightCard } from './helpers/HighlightCard';
 import { VisitsHighlightCard } from './helpers/VisitsHighlightCard';
 
@@ -37,10 +37,8 @@ const OverviewCard: FC<OverviewCardProps> = ({ children, titleLinkText, titleLin
   </Card>
 );
 
-type OverviewProps = {
+export type OverviewProps = {
   tagsList: TagsList;
-  visitsOverview: VisitsOverview;
-  loadVisitsOverview: () => void;
 };
 
 type OverviewDeps = {
@@ -50,17 +48,16 @@ type OverviewDeps = {
 
 const visitsSummaryFallback: ShlinkVisitsSummary = { total: 0, bots: 0, nonBots: 0 };
 
-const Overview: FCWithDeps<OverviewProps, OverviewDeps> = boundToMercureHub((
-  { tagsList, loadVisitsOverview, visitsOverview },
-) => {
+const Overview: FCWithDeps<OverviewProps, OverviewDeps> = boundToMercureHub(({ tagsList }) => {
   const { ShortUrlsTable, CreateShortUrl } = useDependencies(Overview);
   const { shortUrlsList, listShortUrls } = useUrlsList();
-  const loadingTags = tagsList.status === 'loading';
+  const { loadVisitsOverview, visitsOverview } = useVisitsOverview();
   const loadingVisits = visitsOverview.status === 'loading';
   const { orphanVisits, nonOrphanVisits } = visitsOverview.status === 'loaded' ? visitsOverview : {
     orphanVisits: visitsSummaryFallback,
     nonOrphanVisits: visitsSummaryFallback,
   };
+  const loadingTags = tagsList.status === 'loading';
   const routesPrefix = useRoutesPrefix();
   const navigate = useNavigate();
   const visits = useSetting('visits');

--- a/src/overview/services/provideServices.ts
+++ b/src/overview/services/provideServices.ts
@@ -4,5 +4,5 @@ import { OverviewFactory } from '../Overview';
 
 export function provideServices(bottle: Bottle, connect: ConnectDecorator) {
   bottle.factory('Overview', OverviewFactory);
-  bottle.decorator('Overview', connect(['tagsList', 'visitsOverview'], ['loadVisitsOverview']));
+  bottle.decorator('Overview', connect(['tagsList']));
 }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -30,6 +30,7 @@ import { shortUrlVisitsDeletionReducer } from '../visits/reducers/shortUrlVisits
 import type { TagVisits } from '../visits/reducers/tagVisits';
 import type { VisitsInfo } from '../visits/reducers/types';
 import type { VisitsOverview } from '../visits/reducers/visitsOverview';
+import { visitsOverviewReducer } from '../visits/reducers/visitsOverview';
 import type { VisitsComparisonInfo } from '../visits/visits-comparison/reducers/types';
 
 // @ts-expect-error process is actually available in vite
@@ -58,7 +59,7 @@ export const setUpStore = (container: IContainer, preloadedState?: any) => confi
     tagDelete: tagDeleteReducer,
     tagEdit: tagEditReducer,
     domainsList: container.domainsListReducer as DomainsList,
-    visitsOverview: container.visitsOverviewReducer as VisitsOverview,
+    visitsOverview: visitsOverviewReducer,
     shortUrlRedirectRules: shortUrlRedirectRulesReducer,
     shortUrlRedirectRulesSaving: container.setShortUrlRedirectRulesReducer as SetShortUrlRedirectRules,
   } as const),
@@ -73,8 +74,8 @@ export const setUpStore = (container: IContainer, preloadedState?: any) => confi
 export type StoreType = ReturnType<typeof setUpStore>;
 export type AppDispatch = StoreType['dispatch'];
 
-// FIXME Replace with `export type RootState = ReturnType<StoreType['getState']>` When reducers are no longer pulled
-//       from container
+// FIXME Replace with `export type RootState = ReturnType<StoreType['getState']>` when reducers are no longer pulled
+//       from the container
 export type RootState = {
   mercureInfo: MercureInfo;
   shortUrlsList: ShortUrlsList;

--- a/src/visits/services/provideServices.ts
+++ b/src/visits/services/provideServices.ts
@@ -9,7 +9,6 @@ import { getNonOrphanVisits, nonOrphanVisitsReducerCreator } from '../reducers/n
 import { getOrphanVisits, orphanVisitsReducerCreator } from '../reducers/orphanVisits';
 import { getShortUrlVisits, shortUrlVisitsReducerCreator } from '../reducers/shortUrlVisits';
 import { getTagVisits, tagVisitsReducerCreator } from '../reducers/tagVisits';
-import { loadVisitsOverview, visitsOverviewReducerCreator } from '../reducers/visitsOverview';
 import { ShortUrlVisitsFactory } from '../ShortUrlVisits';
 import { TagVisitsFactory } from '../TagVisits';
 import { DomainVisitsComparison } from '../visits-comparison/DomainVisitsComparison';
@@ -115,12 +114,7 @@ export const provideServices = (bottle: Bottle, connect: ConnectDecorator) => {
   bottle.serviceFactory('getNonOrphanVisits', getNonOrphanVisits, 'apiClientFactory');
   bottle.serviceFactory('cancelGetNonOrphanVisits', (obj) => obj.cancelGetVisits, 'nonOrphanVisitsReducerCreator');
 
-  bottle.serviceFactory('loadVisitsOverview', loadVisitsOverview, 'apiClientFactory');
-
   // Reducers
-  bottle.serviceFactory('visitsOverviewReducerCreator', visitsOverviewReducerCreator, 'loadVisitsOverview');
-  bottle.serviceFactory('visitsOverviewReducer', (obj) => obj.reducer, 'visitsOverviewReducerCreator');
-
   bottle.serviceFactory('domainVisitsReducerCreator', domainVisitsReducerCreator, 'getDomainVisits');
   bottle.serviceFactory('domainVisitsReducer', (obj) => obj.reducer, 'domainVisitsReducerCreator');
 

--- a/test/overview/Overview.test.tsx
+++ b/test/overview/Overview.test.tsx
@@ -12,7 +12,6 @@ import { renderWithStore } from '../__helpers__/setUpTest';
 describe('<Overview />', () => {
   const ShortUrlsTable = () => <>ShortUrlsTable</>;
   const CreateShortUrl = () => <>CreateShortUrl</>;
-  const loadVisitsOverview = vi.fn();
   const Overview = OverviewFactory(fromPartial({ ShortUrlsTable, CreateShortUrl }));
   const shortUrls = {
     pagination: { totalItems: 83710 },
@@ -24,21 +23,18 @@ describe('<Overview />', () => {
       <MemoryRouter>
         <SettingsProvider value={fromPartial({ visits })}>
           <RoutesPrefixProvider value={routesPrefix}>
-            <Overview
-              loadVisitsOverview={loadVisitsOverview}
-              tagsList={fromPartial({ status: 'idle', tags: ['foo', 'bar', 'baz'] })}
-              visitsOverview={fromPartial({
-                status: 'loaded',
-                nonOrphanVisits: { total: 3456, bots: 1000, nonBots: 2456 },
-                orphanVisits: { total: 28, bots: 15, nonBots: 13 },
-              })}
-            />
+            <Overview tagsList={fromPartial({ status: 'idle', tags: ['foo', 'bar', 'baz'] })} />
           </RoutesPrefixProvider>
         </SettingsProvider>
       </MemoryRouter>,
       {
         apiClientFactory: vi.fn().mockReturnValue(fromPartial<ShlinkApiClient>({
           listShortUrls: vi.fn().mockResolvedValue(shortUrls),
+          getVisitsOverview: vi.fn().mockResolvedValue(fromPartial({
+            status: 'loaded',
+            nonOrphanVisits: { total: 3456, bots: 1000, nonBots: 2456 },
+            orphanVisits: { total: 28, bots: 15, nonBots: 13 },
+          })),
         })),
       },
     );
@@ -53,7 +49,7 @@ describe('<Overview />', () => {
 
   it('displays loading messages when still loading', async () => {
     const setUpPromise = setUp();
-    expect(screen.getByText('Loading...')).toBeInTheDocument();
+    expect(screen.getAllByText('Loading...')).toHaveLength(3);
 
     await setUpPromise;
     expect(screen.queryByText('Loading...')).not.toBeInTheDocument();


### PR DESCRIPTION
Part of https://github.com/shlinkio/shlink-web-component/issues/161

Stop injecting visits-overview-related redux state and actions, and provide a hook wrapping useDispatch and useSelector instead.