### PR TITLE
Create hook for redirects saving reducer module

### DIFF
--- a/src/redirect-rules/ShortUrlRedirectRules.tsx
+++ b/src/redirect-rules/ShortUrlRedirectRules.tsx
@@ -12,27 +12,17 @@ import type { ShortUrlsDetails } from '../short-urls/reducers/shortUrlsDetails';
 import { GoBackButton } from '../utils/components/GoBackButton';
 import { RedirectRuleCard } from './helpers/RedirectRuleCard';
 import { RedirectRuleModal } from './helpers/RedirectRuleModal';
-import type { SetShortUrlRedirectRules, SetShortUrlRedirectRulesInfo } from './reducers/setShortUrlRedirectRules';
+import { useUrlRedirectRulesSaving } from './reducers/setShortUrlRedirectRules';
 import { useUrlRedirectRules } from './reducers/shortUrlRedirectRules';
 
 export type ShortUrlRedirectRulesProps = {
   shortUrlsDetails: ShortUrlsDetails;
   getShortUrlsDetails: (identifiers: ShlinkShortUrlIdentifier[]) => void;
-
-  shortUrlRedirectRulesSaving: SetShortUrlRedirectRules;
-  setShortUrlRedirectRules: (info: SetShortUrlRedirectRulesInfo) => void;
-
-  resetSetRules: () => void;
 };
 
-export const ShortUrlRedirectRules: FC<ShortUrlRedirectRulesProps> = ({
-  getShortUrlsDetails,
-  shortUrlsDetails,
-  setShortUrlRedirectRules,
-  shortUrlRedirectRulesSaving,
-  resetSetRules,
-}) => {
+export const ShortUrlRedirectRules: FC<ShortUrlRedirectRulesProps> = ({ getShortUrlsDetails, shortUrlsDetails }) => {
   const { shortUrlRedirectRules, getShortUrlRedirectRules } = useUrlRedirectRules();
+  const { setShortUrlRedirectRules, shortUrlRedirectRulesSaving, resetSetRules } = useUrlRedirectRulesSaving();
   const loading = shortUrlRedirectRules.status === 'loading';
   const identifier = useShortUrlIdentifier();
   const { status } = shortUrlsDetails;
@@ -86,7 +76,9 @@ export const ShortUrlRedirectRules: FC<ShortUrlRedirectRulesProps> = ({
     getShortUrlRedirectRules(identifier);
     getShortUrlsDetails([identifier]);
 
-    return resetSetRules;
+    return () => {
+      resetSetRules();
+    };
   }, [getShortUrlRedirectRules, getShortUrlsDetails, identifier, resetSetRules]);
 
   const { redirectRules, defaultLongUrl } = shortUrlRedirectRules.status === 'loaded'

--- a/src/redirect-rules/reducers/setShortUrlRedirectRules.ts
+++ b/src/redirect-rules/reducers/setShortUrlRedirectRules.ts
@@ -1,12 +1,10 @@
 import { createSlice } from '@reduxjs/toolkit';
-import type {
-  ProblemDetailsError,
-  ShlinkApiClient,
-  ShlinkSetRedirectRulesData,
-  ShlinkShortUrlIdentifier,
-} from '../../api-contract';
+import { useCallback } from 'react';
+import type { ProblemDetailsError, ShlinkSetRedirectRulesData, ShlinkShortUrlIdentifier } from '../../api-contract';
 import { parseApiError } from '../../api-contract/utils';
-import { createAsyncThunk } from '../../store/helpers';
+import { useAppDispatch, useAppSelector } from '../../store';
+import type { WithApiClient } from '../../store/helpers';
+import { createAsyncThunk,useApiClientFactory  } from '../../store/helpers';
 
 const REDUCER_PREFIX = 'shlink/setShortUrlRedirectRules';
 
@@ -26,33 +24,42 @@ export type SetShortUrlRedirectRulesInfo = {
   data: ShlinkSetRedirectRulesData;
 };
 
-export const setShortUrlRedirectRules = (apiClientFactory: () => ShlinkApiClient) => createAsyncThunk(
+export const setShortUrlRedirectRulesThunk = createAsyncThunk(
   `${REDUCER_PREFIX}/setShortUrlRedirectRules`,
-  ({ shortUrl, data }: SetShortUrlRedirectRulesInfo) => {
+  ({ shortUrl, data, apiClientFactory }: WithApiClient<SetShortUrlRedirectRulesInfo>) => {
     const { shortCode, domain } = shortUrl;
     return apiClientFactory().setShortUrlRedirectRules({ shortCode, domain }, data);
   },
 );
 
-export const setShortUrlRedirectRulesReducerCreator = (
-  setShortUrlRedirectRulesThunk: ReturnType<typeof setShortUrlRedirectRules>,
-) => {
-  const { reducer, actions } = createSlice({
-    name: REDUCER_PREFIX,
-    initialState: initialState as SetShortUrlRedirectRules,
-    reducers: {
-      resetSetRules: () => initialState,
-    },
-    extraReducers: (builder) => {
-      builder.addCase(setShortUrlRedirectRulesThunk.pending, () => ({ status: 'saving' }));
-      builder.addCase(setShortUrlRedirectRulesThunk.rejected, (_, { error }) => (
-        { status: 'error', error: parseApiError(error) }
-      ));
-      builder.addCase(setShortUrlRedirectRulesThunk.fulfilled, () => ({ status: 'saved' }));
-    },
-  });
+const { reducer, actions } = createSlice({
+  name: REDUCER_PREFIX,
+  initialState: initialState as SetShortUrlRedirectRules,
+  reducers: {
+    resetSetRules: () => initialState,
+  },
+  extraReducers: (builder) => {
+    builder.addCase(setShortUrlRedirectRulesThunk.pending, () => ({ status: 'saving' }));
+    builder.addCase(setShortUrlRedirectRulesThunk.rejected, (_, { error }) => (
+      { status: 'error', error: parseApiError(error) }
+    ));
+    builder.addCase(setShortUrlRedirectRulesThunk.fulfilled, () => ({ status: 'saved' }));
+  },
+});
 
-  const { resetSetRules } = actions;
+export const { resetSetRules } = actions;
 
-  return { reducer, resetSetRules };
+export const shortUrlRedirectRulesSavingReducer = reducer;
+
+export const useUrlRedirectRulesSaving = () => {
+  const dispatch = useAppDispatch();
+  const apiClientFactory = useApiClientFactory();
+  const setShortUrlRedirectRules = useCallback(
+    (info: SetShortUrlRedirectRulesInfo) => dispatch(setShortUrlRedirectRulesThunk({ ...info, apiClientFactory })),
+    [apiClientFactory, dispatch],
+  );
+  const resetSetRules = useCallback(() => dispatch(actions.resetSetRules()), [dispatch]);
+  const shortUrlRedirectRulesSaving = useAppSelector((state) => state.shortUrlRedirectRulesSaving);
+
+  return { shortUrlRedirectRulesSaving, resetSetRules, setShortUrlRedirectRules };
 };

--- a/src/redirect-rules/services/provideServices.ts
+++ b/src/redirect-rules/services/provideServices.ts
@@ -1,29 +1,9 @@
 import type Bottle from 'bottlejs';
 import type { ConnectDecorator } from '../../container';
-import { setShortUrlRedirectRules, setShortUrlRedirectRulesReducerCreator } from '../reducers/setShortUrlRedirectRules';
 import { ShortUrlRedirectRules } from '../ShortUrlRedirectRules';
 
 export const provideServices = (bottle: Bottle, connect: ConnectDecorator) => {
   // Components
   bottle.serviceFactory('ShortUrlRedirectRules', () => ShortUrlRedirectRules);
-  bottle.decorator('ShortUrlRedirectRules', connect(
-    ['shortUrlsDetails', 'shortUrlRedirectRulesSaving'],
-    ['getShortUrlsDetails', 'setShortUrlRedirectRules', 'resetSetRules'],
-  ));
-
-  // Actions
-  bottle.serviceFactory('setShortUrlRedirectRules', setShortUrlRedirectRules, 'apiClientFactory');
-  bottle.serviceFactory('resetSetRules', (obj) => obj.resetSetRules, 'setShortUrlRedirectRulesReducerCreator');
-
-  // Reducers
-  bottle.serviceFactory(
-    'setShortUrlRedirectRulesReducerCreator',
-    setShortUrlRedirectRulesReducerCreator,
-    'setShortUrlRedirectRules',
-  );
-  bottle.serviceFactory(
-    'setShortUrlRedirectRulesReducer',
-    (obj) => obj.reducer,
-    'setShortUrlRedirectRulesReducerCreator',
-  );
+  bottle.decorator('ShortUrlRedirectRules', connect(['shortUrlsDetails'], ['getShortUrlsDetails']));
 };

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -4,7 +4,11 @@ import { useDispatch, useSelector } from 'react-redux';
 import type { DomainsList } from '../domains/reducers/domainsList';
 import type { MercureInfo } from '../mercure/reducers/mercureInfo';
 import { mercureInfoReducer } from '../mercure/reducers/mercureInfo';
-import type { SetShortUrlRedirectRules } from '../redirect-rules/reducers/setShortUrlRedirectRules';
+import type {
+  SetShortUrlRedirectRules } from '../redirect-rules/reducers/setShortUrlRedirectRules';
+import {
+  shortUrlRedirectRulesSavingReducer,
+} from '../redirect-rules/reducers/setShortUrlRedirectRules';
 import type { ShortUrlRedirectRules } from '../redirect-rules/reducers/shortUrlRedirectRules';
 import { shortUrlRedirectRulesReducer } from '../redirect-rules/reducers/shortUrlRedirectRules';
 import type { ShortUrlCreation } from '../short-urls/reducers/shortUrlCreation';
@@ -62,7 +66,7 @@ export const setUpStore = (container: IContainer, preloadedState?: any) => confi
     domainsList: container.domainsListReducer as DomainsList,
     visitsOverview: visitsOverviewReducer,
     shortUrlRedirectRules: shortUrlRedirectRulesReducer,
-    shortUrlRedirectRulesSaving: container.setShortUrlRedirectRulesReducer as SetShortUrlRedirectRules,
+    shortUrlRedirectRulesSaving: shortUrlRedirectRulesSavingReducer,
   } as const),
   preloadedState,
   middleware: (defaultMiddlewaresIncludingReduxThunk) => defaultMiddlewaresIncludingReduxThunk({


### PR DESCRIPTION
Part of https://github.com/shlinkio/shlink-web-component/issues/161

Stop injecting redirection-saving-related redux state and actions, and provide a hook wrapping useDispatch and useSelector instead.