### PR TITLE
Remove all vite optimized deps

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -36,39 +36,6 @@ export default defineConfig({
     },
   },
 
-  // Vitest recommended to add these dependencies here to avoid flaky tests
-  optimizeDeps: {
-    include: [
-      '@formkit/drag-and-drop/react',
-      '@fortawesome/free-regular-svg-icons',
-      '@fortawesome/free-solid-svg-icons',
-      '@fortawesome/react-fontawesome',
-      '@json2csv/plainjs',
-      '@testing-library/react',
-      '@testing-library/user-event',
-      '@shlinkio/data-manipulation',
-      '@shlinkio/shlink-frontend-kit',
-      '@shlinkio/shlink-js-sdk',
-      '@shlinkio/shlink-js-sdk/api-contract',
-      '@shlinkio/shlink-js-sdk/fetch',
-      'axe-core',
-      'bottlejs',
-      'bowser',
-      'clsx',
-      'compare-versions',
-      'date-fns',
-      'history',
-      'leaflet',
-      'qr-code-styling',
-      'react-dom/client',
-      'react-external-link',
-      'react-leaflet',
-      'react-router',
-      'react-swipeable',
-      'recharts',
-    ],
-  },
-
   test: {
     globals: true,
     setupFiles: [


### PR DESCRIPTION
I have lately been seeing a lot of errors when running tests with code coverage, related with the usage of disk space: `Error: ENOSPC: no space left on device, write`.

<img width="494" height="126" alt="image" src="https://github.com/user-attachments/assets/b84afd08-5250-44a7-9d3d-469f8af1debf" />

This error causes tests execution to stop and leave unfinished.

I have read the optimizing of dependencies might be related, so this is an attempt at removing all of them to see the result.