### PR TITLE
Create hook for tag visits comparison reducer module

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -44,6 +44,7 @@ import type { VisitsInfo } from '../visits/reducers/types';
 import type { VisitsOverview } from '../visits/reducers/visitsOverview';
 import { visitsOverviewReducer } from '../visits/reducers/visitsOverview';
 import { shortUrlVisitsComparisonReducer } from '../visits/visits-comparison/reducers/shortUrlVisitsComparison';
+import { tagVisitsComparisonReducer } from '../visits/visits-comparison/reducers/tagVisitsComparison';
 import type { VisitsComparisonInfo } from '../visits/visits-comparison/reducers/types';
 
 // @ts-expect-error process is actually available in vite
@@ -62,7 +63,7 @@ export const setUpStore = (container: IContainer, preloadedState?: any) => confi
     shortUrlVisitsDeletion: shortUrlVisitsDeletionReducer,
     shortUrlVisitsComparison: shortUrlVisitsComparisonReducer,
     tagVisits: tagVisitsReducer,
-    tagVisitsComparison: container.tagVisitsComparisonReducer as VisitsComparisonInfo,
+    tagVisitsComparison: tagVisitsComparisonReducer,
     domainVisits: domainVisitsReducer,
     domainVisitsComparison: container.domainVisitsComparisonReducer as VisitsComparisonInfo,
     orphanVisits: orphanVisitsReducer,

--- a/src/visits/services/provideServices.ts
+++ b/src/visits/services/provideServices.ts
@@ -11,10 +11,6 @@ import {
   domainVisitsComparisonReducerCreator,
   getDomainVisitsForComparison,
 } from '../visits-comparison/reducers/domainVisitsComparison';
-import {
-  getTagVisitsForComparison,
-  tagVisitsComparisonReducerCreator,
-} from '../visits-comparison/reducers/tagVisitsComparison';
 import { TagVisitsComparisonFactory } from '../visits-comparison/TagVisitsComparison';
 import * as visitsParser from './VisitsParser';
 
@@ -23,14 +19,8 @@ export const provideServices = (bottle: Bottle, connect: ConnectDecorator) => {
   bottle.serviceFactory('MapModal', () => MapModal);
 
   bottle.factory('ShortUrlVisits', ShortUrlVisitsFactory);
-
   bottle.factory('TagVisits', TagVisitsFactory);
-
   bottle.factory('TagVisitsComparison', TagVisitsComparisonFactory);
-  bottle.decorator('TagVisitsComparison', connect(
-    ['tagVisitsComparison'],
-    ['getTagVisitsForComparison', 'cancelGetTagVisitsForComparison'],
-  ));
 
   bottle.serviceFactory('DomainVisitsComparison', () => DomainVisitsComparison);
   bottle.decorator('DomainVisitsComparison', connect(
@@ -46,13 +36,6 @@ export const provideServices = (bottle: Bottle, connect: ConnectDecorator) => {
   bottle.serviceFactory('VisitsParser', () => visitsParser);
 
   // Actions
-  bottle.serviceFactory('getTagVisitsForComparison', getTagVisitsForComparison, 'apiClientFactory');
-  bottle.serviceFactory(
-    'cancelGetTagVisitsForComparison',
-    (obj) => obj.cancelGetVisits,
-    'tagVisitsComparisonReducerCreator',
-  );
-
   bottle.serviceFactory('getDomainVisitsForComparison', getDomainVisitsForComparison, 'apiClientFactory');
   bottle.serviceFactory(
     'cancelGetDomainVisitsForComparison',
@@ -61,13 +44,6 @@ export const provideServices = (bottle: Bottle, connect: ConnectDecorator) => {
   );
 
   // Reducers
-  bottle.serviceFactory(
-    'tagVisitsComparisonReducerCreator',
-    tagVisitsComparisonReducerCreator,
-    'getTagVisitsForComparison',
-  );
-  bottle.serviceFactory('tagVisitsComparisonReducer', (obj) => obj.reducer, 'tagVisitsComparisonReducerCreator');
-
   bottle.serviceFactory(
     'domainVisitsComparisonReducerCreator',
     domainVisitsComparisonReducerCreator,

--- a/src/visits/visits-comparison/TagVisitsComparison.tsx
+++ b/src/visits/visits-comparison/TagVisitsComparison.tsx
@@ -6,25 +6,18 @@ import { Topics } from '../../mercure/helpers/Topics';
 import { Tag } from '../../tags/helpers/Tag';
 import { useArrayQueryParam } from '../../utils/helpers/hooks';
 import type { ColorGenerator } from '../../utils/services/ColorGenerator';
-import type { LoadTagVisitsForComparison } from './reducers/tagVisitsComparison';
-import type { LoadVisitsForComparison, VisitsComparisonInfo } from './reducers/types';
+import { useTagVisitsComparison } from './reducers/tagVisitsComparison';
+import type { LoadVisitsForComparison } from './reducers/types';
 import { VisitsComparison } from './VisitsComparison';
-
-type TagVisitsComparisonProps = {
-  getTagVisitsForComparison: (params: LoadTagVisitsForComparison) => void;
-  tagVisitsComparison: VisitsComparisonInfo;
-  cancelGetTagVisitsComparison: () => void;
-};
 
 type TagVisitsComparisonDeps = {
   ColorGenerator: ColorGenerator;
 };
 
-const TagVisitsComparison: FCWithDeps<TagVisitsComparisonProps, TagVisitsComparisonDeps> = boundToMercureHub((
-  { getTagVisitsForComparison, tagVisitsComparison, cancelGetTagVisitsComparison },
-) => {
+const TagVisitsComparison: FCWithDeps<any, TagVisitsComparisonDeps> = boundToMercureHub(() => {
   const { ColorGenerator: colorGenerator } = useDependencies(TagVisitsComparison);
   const tags = useArrayQueryParam('tags');
+  const { getTagVisitsForComparison, tagVisitsComparison, cancelGetTagVisitsForComparison } = useTagVisitsComparison();
   const getVisitsForComparison = useCallback(
     (params: LoadVisitsForComparison) => getTagVisitsForComparison({ ...params, tags }),
     [getTagVisitsForComparison, tags],
@@ -43,7 +36,7 @@ const TagVisitsComparison: FCWithDeps<TagVisitsComparisonProps, TagVisitsCompari
       title={<>Comparing {tags.map((tag) => <Tag key={tag} colorGenerator={colorGenerator} text={tag} />)}</>}
       getVisitsForComparison={getVisitsForComparison}
       visitsComparisonInfo={tagVisitsComparison}
-      cancelGetVisitsComparison={cancelGetTagVisitsComparison}
+      cancelGetVisitsComparison={cancelGetTagVisitsForComparison}
       colors={colors}
     />
   );

--- a/src/visits/visits-comparison/VisitsComparison.tsx
+++ b/src/visits/visits-comparison/VisitsComparison.tsx
@@ -19,6 +19,7 @@ type VisitsComparisonProps = {
   title: ReactNode;
   getVisitsForComparison: (params: LoadVisitsForComparison) => void;
   visitsComparisonInfo: VisitsComparisonInfo;
+  // TODO Rename to onCancelGetVisitsComparison
   cancelGetVisitsComparison: () => void;
   colors?: Record<string, string>;
 };

--- a/test/visits/visits-comparison/TagVisitsComparison.test.tsx
+++ b/test/visits/visits-comparison/TagVisitsComparison.test.tsx
@@ -1,4 +1,5 @@
-import { cleanup, screen } from '@testing-library/react';
+import type { ShlinkVisitsList } from '@shlinkio/shlink-js-sdk/api-contract';
+import { cleanup, screen, waitFor } from '@testing-library/react';
 import { fromPartial } from '@total-typescript/shoehorn';
 import { MemoryRouter } from 'react-router';
 import { TagVisitsComparisonFactory } from '../../../src/visits/visits-comparison/TagVisitsComparison';
@@ -10,19 +11,24 @@ describe('<TagVisitsComparison />', () => {
   const TagVisitsComparison = TagVisitsComparisonFactory(fromPartial({
     ColorGenerator: colorGeneratorMock,
   }));
-  const getTagVisitsForComparison = vi.fn();
-  const cancelGetTagVisitsComparison = vi.fn();
-  const setUp = (tags = ['foo', 'bar', 'baz']) => renderWithStore(
-    <MemoryRouter initialEntries={[{ search: `?tags=${tags.join(',')}` }]}>
-      <TagVisitsComparison
-        getTagVisitsForComparison={getTagVisitsForComparison}
-        cancelGetTagVisitsComparison={cancelGetTagVisitsComparison}
-        tagVisitsComparison={fromPartial({
-          visitsGroups: Object.fromEntries(tags.map((tag) => [tag, []])),
-        })}
-      />
-    </MemoryRouter>,
-  );
+  const getTagVisits = vi.fn().mockResolvedValue(fromPartial<ShlinkVisitsList>({
+    data: [],
+    pagination: { currentPage: 1, pagesCount: 1, totalItems: 0 },
+  }));
+  const setUp = async (tags = ['foo', 'bar', 'baz']) => {
+    const renderResult = renderWithStore(
+      <MemoryRouter initialEntries={[{ search: `?tags=${tags.join(',')}` }]}>
+        <TagVisitsComparison />
+      </MemoryRouter>,
+      {
+        apiClientFactory: () => fromPartial({ getTagVisits }),
+      },
+    );
+
+    await waitFor(() => expect(screen.queryByText('Loading...')).not.toBeInTheDocument());
+
+    return renderResult;
+  };
 
   it('passes a11y checks', () => checkAccessibility(setUp()));
 
@@ -30,32 +36,31 @@ describe('<TagVisitsComparison />', () => {
     [['foo']],
     [['foo', 'bar']],
     [['baz', 'something', 'whatever']],
-  ])('loads tags on mount', (tags) => {
-    setUp(tags);
-    expect(getTagVisitsForComparison).toHaveBeenLastCalledWith(expect.objectContaining({ tags }));
+  ])('loads tags on mount', async (tags) => {
+    await setUp(tags);
+    expect(getTagVisits).toHaveBeenCalledTimes(tags.length);
   });
 
-  it('cancels loading visits when unmounted', () => {
-    setUp();
+  it('cancels loading visits when unmounted', async () => {
+    const { store } = await setUp();
+    const isCanceled = () => store.getState().tagVisitsComparison.cancelLoad;
 
-    expect(cancelGetTagVisitsComparison).not.toHaveBeenCalled();
+    expect(isCanceled()).toBe(false);
     cleanup();
-    expect(cancelGetTagVisitsComparison).toHaveBeenCalledOnce();
+    expect(isCanceled()).toBe(true);
   });
 
   it.each([
     [['foo']],
     [['foo', 'bar']],
     [['baz', 'something', 'whatever']],
-  ])('renders tags in title', (tags) => {
-    setUp(tags);
-
-    expect.assertions(tags.length);
+  ])('renders tags in title', async (tags) => {
+    await setUp(tags);
     tags.forEach((tag) => expect(screen.getByText(tag)).toBeInTheDocument());
   });
 
-  it('loads colors for tags', () => {
-    setUp();
+  it('loads colors for tags', async () => {
+    await setUp();
     expect(getColorForKey).toHaveBeenCalledTimes(3);
     expect(getColorForKey).toHaveBeenNthCalledWith(1, 'foo');
     expect(getColorForKey).toHaveBeenNthCalledWith(2, 'bar');

--- a/test/visits/visits-comparison/reducers/tagVisitsComparison.test.ts
+++ b/test/visits/visits-comparison/reducers/tagVisitsComparison.test.ts
@@ -5,8 +5,9 @@ import { formatIsoDate } from '../../../../src/utils/dates/helpers/date';
 import { rangeOf } from '../../../../src/utils/helpers';
 import { createNewVisits } from '../../../../src/visits/reducers/visitCreation';
 import {
-  getTagVisitsForComparison as getTagVisitsForComparisonCreator,
-  tagVisitsComparisonReducerCreator,
+  cancelGetTagVisitsForComparison,
+  getTagVisitsForComparisonThunk as getTagVisitsForComparison,
+  tagVisitsComparisonReducer as reducer,
 } from '../../../../src/visits/visits-comparison/reducers/tagVisitsComparison';
 import { problemDetailsError } from '../../../__mocks__/ProblemDetailsError.mock';
 
@@ -14,15 +15,11 @@ describe('tagVisitsComparisonReducer', () => {
   const now = new Date();
   const visitsMocks = rangeOf(2, () => fromPartial<ShlinkVisit>({}));
   const getTagVisitsCall = vi.fn();
-  const buildShlinkApiClientMock = () => fromPartial<ShlinkApiClient>({ getTagVisits: getTagVisitsCall });
-  const getTagVisitsForComparison = getTagVisitsForComparisonCreator(buildShlinkApiClientMock);
-  const { reducer, cancelGetVisits: cancelGetTagVisitsForComparison } = tagVisitsComparisonReducerCreator(
-    getTagVisitsForComparison,
-  );
+  const apiClientFactory = () => fromPartial<ShlinkApiClient>({ getTagVisits: getTagVisitsCall });
 
   describe('reducer', () => {
     it('returns loading when pending', () => {
-      const action = getTagVisitsForComparison.pending('', fromPartial({ tags: [] }), undefined);
+      const action = getTagVisitsForComparison.pending('', fromPartial({ tags: [] }));
       const { loading } = reducer(fromPartial({ loading: false }), action);
 
       expect(loading).toEqual(true);
@@ -36,7 +33,7 @@ describe('tagVisitsComparisonReducer', () => {
     it('stops loading and returns error when rejected', () => {
       const { loading, errorData } = reducer(
         fromPartial({ loading: true, errorData: null }),
-        getTagVisitsForComparison.rejected(problemDetailsError, '', fromPartial({ tags: [] }), undefined, undefined),
+        getTagVisitsForComparison.rejected(problemDetailsError, '', fromPartial({ tags: [] })),
       );
 
       expect(loading).toEqual(false);
@@ -136,7 +133,7 @@ describe('tagVisitsComparisonReducer', () => {
         baz: visitsMocks,
       };
       const tags = Object.keys(visitsGroups);
-      const getVisitsComparisonParam = { tags, params: {} };
+      const getVisitsComparisonParam = { tags, params: {}, apiClientFactory };
 
       getTagVisitsCall.mockResolvedValue({
         data: visitsMocks,


### PR DESCRIPTION
Part of https://github.com/shlinkio/shlink-web-component/issues/161

Stop injecting tag-visits-comparison-related redux state and actions, and provide a hook wrapping useDispatch and useSelector instead.