### PR TITLE
Simplify visits reducers types with a status discriminator prop

### DIFF
--- a/src/visits/DomainVisits.tsx
+++ b/src/visits/DomainVisits.tsx
@@ -38,7 +38,10 @@ const DomainVisitsBase = boundToMercureHub<DomainVisitsProps>(({ ReportExporter:
       visitsInfo={domainVisits}
       exportCsv={exportCsv}
     >
-      <VisitsHeader visits={domainVisits.visits} title={`"${authority}" visits`} />
+      <VisitsHeader
+        visits={domainVisits.status === 'loaded' ? domainVisits.visits : []}
+        title={`"${authority}" visits`}
+      />
     </VisitsStats>
   );
 }, () => [Topics.visits]);

--- a/src/visits/NonOrphanVisits.tsx
+++ b/src/visits/NonOrphanVisits.tsx
@@ -38,7 +38,10 @@ const NonOrphanVisitsBase = boundToMercureHub<NonOrphanVisitsProps>(({ ReportExp
       exportCsv={exportCsv}
       domains={domainsList.domains}
     >
-      <VisitsHeader title="Non-orphan visits" visits={nonOrphanVisits.visits} />
+      <VisitsHeader
+        title="Non-orphan visits"
+        visits={nonOrphanVisits.status === 'loaded' ? nonOrphanVisits.visits : []}
+      />
     </VisitsStats>
   );
 }, () => [Topics.visits]);

--- a/src/visits/OrphanVisits.tsx
+++ b/src/visits/OrphanVisits.tsx
@@ -47,7 +47,7 @@ const OrphanVisitsBase = boundToMercureHub<OrphanVisitsProps>(({ ReportExporter:
       isOrphanVisits
       domains={domainsList.domains}
     >
-      <VisitsHeader title="Orphan visits" visits={orphanVisits.visits} />
+      <VisitsHeader title="Orphan visits" visits={orphanVisits.status === 'loaded' ? orphanVisits.visits : []} />
     </VisitsStats>
   );
 }, () => [Topics.orphanVisits]);

--- a/src/visits/ShortUrlVisitsHeader.tsx
+++ b/src/visits/ShortUrlVisitsHeader.tsx
@@ -31,7 +31,7 @@ const Date = ({ shortUrl }: { shortUrl?: ShlinkShortUrl }) => {
 };
 
 export const ShortUrlVisitsHeader = ({ shortUrl, loading, shortUrlVisits }: ShortUrlVisitsHeaderProps) => {
-  const { visits } = shortUrlVisits;
+  const { visits = [] } = shortUrlVisits.status === 'loaded' ? shortUrlVisits : {};
   const shortLink = shortUrl?.shortUrl ?? '';
   const longLink = shortUrl?.longUrl ?? '';
   const title = shortUrl?.title;

--- a/src/visits/TagVisitsHeader.tsx
+++ b/src/visits/TagVisitsHeader.tsx
@@ -9,11 +9,11 @@ interface TagVisitsHeaderProps {
 }
 
 export const TagVisitsHeader = ({ tagVisits, colorGenerator }: TagVisitsHeaderProps) => {
-  const { visits, tag } = tagVisits;
+  const { tag, visits = [] } = tagVisits.status === 'loaded' ? tagVisits : {};
   const visitsStatsTitle = (
     <span className="flex items-center justify-center">
       <span className="mr-2">Visits for</span>
-      <Tag text={tag} colorGenerator={colorGenerator} />
+      {tag && <Tag text={tag} colorGenerator={colorGenerator} />}
     </span>
   );
 

--- a/src/visits/VisitsStats.tsx
+++ b/src/visits/VisitsStats.tsx
@@ -91,7 +91,9 @@ export const VisitsStats: FC<VisitsStatsProps> = (props) => {
     isOrphanVisits = false,
     domains,
   } = props;
-  const { visits, prevVisits, loading, errorData, fallbackInterval } = visitsInfo;
+  const { status } = visitsInfo;
+  const loading = status === 'loading';
+  const { visits, prevVisits } = status === 'loaded' ? visitsInfo : { visits: [] };
   const [{ dateRange, visitsFilter, loadPrevInterval, domain }, updateQuery] = useVisitsQuery();
   const visitsSettings = useSetting('visits');
   const [activeInterval, setActiveInterval] = useState<DateInterval>();
@@ -107,8 +109,9 @@ export const VisitsStats: FC<VisitsStatsProps> = (props) => {
     },
     [updateQuery],
   );
+  const { fallbackInterval } = status === 'fallback' ? visitsInfo : {};
   const [currentFallbackInterval, setCurrentFallbackInterval] = useState<DateInterval>(
-    fallbackInterval ?? visitsSettings?.defaultInterval ?? 'last30Days',
+    status === 'fallback' ? visitsInfo.fallbackInterval : (visitsSettings?.defaultInterval ?? 'last30Days'),
   );
   const [highlightedVisits, setHighlightedVisits] = useState<NormalizedVisit[]>([]);
   const [highlightedLabel, setHighlightedLabel] = useState<string | undefined>();
@@ -183,7 +186,7 @@ export const VisitsStats: FC<VisitsStatsProps> = (props) => {
     if (fallbackInterval && currentFallbackInterval === (visitsSettings?.defaultInterval ?? 'last30Days')) {
       setCurrentFallbackInterval(fallbackInterval);
     }
-  }, [currentFallbackInterval, fallbackInterval, visitsSettings?.defaultInterval]);
+  }, [currentFallbackInterval, status, fallbackInterval, visitsSettings?.defaultInterval]);
 
   return (
     <div className="flex flex-col gap-y-4">
@@ -240,8 +243,8 @@ export const VisitsStats: FC<VisitsStatsProps> = (props) => {
       </section>
 
       <section className="flex flex-col gap-4">
-        <VisitsLoadingFeedback info={visitsInfo} />
-        {!loading && !errorData && (
+        {status !== 'loaded' && status !== 'fallback' && <VisitsLoadingFeedback info={visitsInfo} />}
+        {!loading && status !== 'error' && (
           <>
             <NavPills fill className="sticky top-(--header-height) z-2">
               {Object.values(sections).map(({ title, icon, subPath, shouldRender }: VisitsNavLinkOptions, index) => (

--- a/src/visits/helpers/VisitsLoadingFeedback.tsx
+++ b/src/visits/helpers/VisitsLoadingFeedback.tsx
@@ -29,21 +29,24 @@ const ProgressBar: FC<ProgressBarProps> = ({ className, value, ...rest }) => {
 };
 
 export const VisitsLoadingFeedback: FC<VisitsLoadingFeedbackProps> = ({ info }) => {
-  const { loading, errorData, progress } = info;
-  return (
-    <>
-      {loading && progress === null && <Message loading />}
-      {loading && progress !== null && (
-        <Message loading>
-          This is going to take a while... :S
-          <ProgressBar value={progress} className="mt-4" />
-        </Message>
-      )}
-      {errorData && (
-        <Result variant="error">
-          <ShlinkApiError errorData={errorData} fallbackMessage="An error occurred while loading visits :(" />
-        </Result>
-      )}
-    </>
-  );
+  const { status } = info;
+
+  if (status === 'error') {
+    return (
+      <Result variant="error">
+        <ShlinkApiError errorData={info.error} fallbackMessage="An error occurred while loading visits :(" />
+      </Result>
+    );
+  }
+
+  if (status === 'loading') {
+    return info.progress === null ? <Message loading /> : (
+      <Message loading>
+        This is going to take a while... :S
+        <ProgressBar value={info.progress} className="mt-4" />
+      </Message>
+    );
+  }
+
+  return null;
 };

--- a/src/visits/reducers/types/index.ts
+++ b/src/visits/reducers/types/index.ts
@@ -23,15 +23,23 @@ export type VisitsLoaded = {
 };
 
 export type VisitsLoadingInfo = {
-  loading: boolean;
-  cancelLoad: boolean;
-  errorData: ProblemDetailsError | null;
+  status: 'idle' | 'canceled';
+} | {
+  status: 'loading';
   progress: number | null;
+} | {
+  status: 'error';
+  error?: ProblemDetailsError;
 };
 
-export type VisitsInfo = VisitsLoadingInfo & VisitsLoaded & {
-  fallbackInterval?: DateInterval;
-};
+export type VisitsInfo<T = unknown> = VisitsLoadingInfo | {
+  // When trying to load visits on default interval results in 0 visits, but more visits exist if going back in time
+  status: 'fallback';
+  fallbackInterval: DateInterval;
+} | (T & VisitsLoaded & {
+  // When visits have been loaded, either in the first try, or after falling back to a wider interval
+  status: 'loaded';
+});
 
 export type VisitsDeletion<Result = unknown> = {
   status: 'idle' | 'deleting';

--- a/src/visits/visits-comparison/ShortUrlVisitsComparison.tsx
+++ b/src/visits/visits-comparison/ShortUrlVisitsComparison.tsx
@@ -26,7 +26,18 @@ export const ShortUrlVisitsComparison = boundToMercureHub(() => {
   const shortUrls = shortUrlsDetails.status === 'loaded' ? shortUrlsDetails.shortUrls : undefined;
   const loadedShortUrls = useMemo(() => [...shortUrls?.values() ?? []], [shortUrls]);
   const visitsComparisonInfo = useMemo((): VisitsComparisonInfo => {
-    const { visitsGroups: baseVisitsGroups, loading, ...rest } = shortUrlVisitsComparison;
+    const { status } = shortUrlVisitsComparison;
+
+    if (shortUrlsDetails.status === 'loading') {
+      const progress = status === 'loading' ? shortUrlVisitsComparison.progress : null;
+      return { status: 'loading', progress };
+    }
+
+    if (status !== 'loaded') {
+      return shortUrlVisitsComparison;
+    }
+
+    const { visitsGroups: baseVisitsGroups, ...rest } = shortUrlVisitsComparison;
     const visitsGroups = loadedShortUrls.reduce<Record<string, ShlinkVisit[]>>(
       (acc, shortUrl) => {
         acc[shortUrl.shortUrl] = baseVisitsGroups[shortUrlToQuery(shortUrl)] ?? [];
@@ -35,7 +46,7 @@ export const ShortUrlVisitsComparison = boundToMercureHub(() => {
       {},
     );
 
-    return { ...rest, visitsGroups, loading: loading || shortUrlsDetails.status === 'loading' };
+    return { ...rest, visitsGroups };
   }, [shortUrlVisitsComparison, shortUrlsDetails.status, loadedShortUrls]);
 
   useEffect(() => {

--- a/src/visits/visits-comparison/TagVisitsComparison.tsx
+++ b/src/visits/visits-comparison/TagVisitsComparison.tsx
@@ -20,7 +20,8 @@ const TagVisitsComparisonBase = boundToMercureHub<TagVisitsComparisonProps>(({ C
     (params: LoadVisitsForComparison) => getTagVisitsForComparison({ ...params, tags }),
     [getTagVisitsForComparison, tags],
   );
-  const { visitsGroups } = tagVisitsComparison;
+  const { status } = tagVisitsComparison;
+  const { visitsGroups } = status === 'loaded' ? tagVisitsComparison : { visitsGroups: {} };
   const colors = useMemo(
     () => Object.keys(visitsGroups).reduce<Record<string, string>>((acc, key) => {
       acc[key] = colorGenerator.getColorForKey(key);

--- a/src/visits/visits-comparison/VisitsComparison.tsx
+++ b/src/visits/visits-comparison/VisitsComparison.tsx
@@ -31,7 +31,9 @@ export const VisitsComparison: FC<VisitsComparisonProps> = ({
   visitsComparisonInfo,
   cancelGetVisitsComparison,
 }) => {
-  const { loading, visitsGroups } = visitsComparisonInfo;
+  const { status } = visitsComparisonInfo;
+  const loading = status === 'loading';
+  const { visitsGroups = {} } = status === 'loaded' ? visitsComparisonInfo : {};
   const visitsSettings = useSetting('visits');
   const normalizedVisitsGroups = useMemo(
     () => Object.keys(visitsGroups).reduce<Record<string, VisitsList>>((acc, key, index) => {
@@ -102,7 +104,7 @@ export const VisitsComparison: FC<VisitsComparisonProps> = ({
         <div className="hidden lg:block lg:flex-2 xl:flex-3" />
       </div>
 
-      <VisitsLoadingFeedback info={visitsComparisonInfo} />
+      {status !== 'loaded' && <VisitsLoadingFeedback info={visitsComparisonInfo} />}
       {!loading && (
         <VisitsSectionWithFallback showFallback={showFallback}>
           <LineChartCard visitsGroups={normalizedVisitsGroups} onDateRangeChange={setDates} />

--- a/src/visits/visits-comparison/reducers/common/createVisitsComparisonReducer.ts
+++ b/src/visits/visits-comparison/reducers/common/createVisitsComparisonReducer.ts
@@ -1,44 +1,48 @@
 import { createSlice } from '@reduxjs/toolkit';
 import { parseApiError } from '../../../../api-contract/utils';
 import { createNewVisits } from '../../../reducers/visitCreation';
-import type { CreateVisit } from '../../../types';
-import type { VisitsComparisonInfo } from '../types';
+import type { CreateVisit, VisitsParams } from '../../../types';
+import type { LoadVisitsForComparison, VisitsComparisonInfo } from '../types';
 import type { createVisitsComparisonAsyncThunk } from './createVisitsComparisonAsyncThunk';
 
-type VisitsReducerOptions<AT extends ReturnType<typeof createVisitsComparisonAsyncThunk>> = {
+type VisitsReducerOptions<T extends LoadVisitsForComparison> = {
   name: string;
-  asyncThunk: AT;
+  asyncThunk: ReturnType<typeof createVisitsComparisonAsyncThunk<T>>;
   initialState: VisitsComparisonInfo;
   filterCreatedVisitsForGroup: (
-    state: Omit<VisitsComparisonInfo, 'visitsGroups'> & { groupKey: string },
+    state: { groupKey: string; params?: VisitsParams },
     createdVisits: CreateVisit[],
   ) => CreateVisit[];
 };
 
-export const createVisitsComparisonReducer = <AT extends ReturnType<typeof createVisitsComparisonAsyncThunk>>(
-  { name, asyncThunk, initialState, filterCreatedVisitsForGroup }: VisitsReducerOptions<AT>,
+export const createVisitsComparisonReducer = <T extends LoadVisitsForComparison>(
+  { name, asyncThunk, initialState, filterCreatedVisitsForGroup }: VisitsReducerOptions<T>,
 ) => {
   const { pending, rejected, fulfilled, progressChanged } = asyncThunk;
   const { reducer, actions } = createSlice({
     name,
     initialState,
     reducers: {
-      cancelGetVisits: (state) => ({ ...state, cancelLoad: true }),
+      cancelGetVisits: () => ({ status: 'canceled' as const }),
     },
     extraReducers: (builder) => {
-      builder.addCase(pending, () => ({ ...initialState, loading: true }));
-      builder.addCase(rejected, (_, { error }) => ({ ...initialState, errorData: parseApiError(error) ?? null }));
-      builder.addCase(fulfilled, (state, { payload }) => (
-        { ...state, ...payload, loading: false, progress: null, errorData: null }
+      builder.addCase(pending, () => ({ status: 'loading', progress: null }));
+      builder.addCase(progressChanged, (state, { payload: progress }) => (
+        // Update progress only if already loading
+        state.status !== 'loading' ? state : { status: 'loading', progress }
       ));
-
-      builder.addCase(progressChanged, (state, { payload: progress }) => ({ ...state, progress }));
+      builder.addCase(rejected, (_, { error }) => ({ status: 'error', error: parseApiError(error) }));
+      builder.addCase(fulfilled, (state, { payload }) => ({ ...state, ...payload, status: 'loaded' }));
 
       builder.addCase(createNewVisits, (state, { payload }) => {
-        const { visitsGroups, ...rest } = state;
+        if (state.status !== 'loaded') {
+          return state;
+        }
+
+        const { visitsGroups, params, ...rest } = state;
         const newVisitGroupsPairs = Object.keys(visitsGroups).map((groupKey) => {
           const newVisits = filterCreatedVisitsForGroup(
-            { ...rest, groupKey },
+            { params, groupKey },
             payload.createdVisits,
           ).map(({ visit }) => visit);
 
@@ -46,7 +50,7 @@ export const createVisitsComparisonReducer = <AT extends ReturnType<typeof creat
         });
         const enhancedVisitsGroups = Object.fromEntries(newVisitGroupsPairs);
 
-        return { ...rest, visitsGroups: enhancedVisitsGroups };
+        return { ...rest, params, visitsGroups: enhancedVisitsGroups };
       });
     },
   });

--- a/src/visits/visits-comparison/reducers/domainVisitsComparison.ts
+++ b/src/visits/visits-comparison/reducers/domainVisitsComparison.ts
@@ -13,11 +13,7 @@ const REDUCER_PREFIX = 'shlink/domainVisitsComparison';
 export type LoadDomainVisitsForComparison = LoadVisitsForComparison & { domains: string[]; };
 
 const initialState: VisitsComparisonInfo = {
-  visitsGroups: {},
-  loading: false,
-  cancelLoad: false,
-  errorData: null,
-  progress: null,
+  status: 'idle',
 };
 
 export const getDomainVisitsForComparisonThunk = createVisitsComparisonAsyncThunk({
@@ -31,7 +27,7 @@ export const getDomainVisitsForComparisonThunk = createVisitsComparisonAsyncThun
 
     return Object.fromEntries(loaderEntries);
   },
-  shouldCancel: (getState) => getState().domainVisitsComparison.cancelLoad,
+  shouldCancel: (getState) => getState().domainVisitsComparison.status === 'canceled',
 });
 
 export const {
@@ -39,8 +35,7 @@ export const {
   cancelGetVisits: cancelGetDomainVisitsForComparison,
 } = createVisitsComparisonReducer({
   name: REDUCER_PREFIX,
-  initialState,
-  // @ts-expect-error TODO Fix type inference
+  initialState: initialState as VisitsComparisonInfo,
   asyncThunk: getDomainVisitsForComparisonThunk,
   filterCreatedVisitsForGroup: ({ groupKey: domain, params }, createdVisits) => filterCreatedVisitsByDomain(
     createdVisits,

--- a/src/visits/visits-comparison/reducers/shortUrlVisitsComparison.ts
+++ b/src/visits/visits-comparison/reducers/shortUrlVisitsComparison.ts
@@ -14,11 +14,7 @@ const REDUCER_PREFIX = 'shlink/shortUrlVisitsComparison';
 export type LoadShortUrlVisitsForComparison = LoadVisitsForComparison & { shortUrls: ShlinkShortUrlIdentifier[]; };
 
 const initialState: VisitsComparisonInfo = {
-  visitsGroups: {},
-  loading: false,
-  cancelLoad: false,
-  errorData: null,
-  progress: null,
+  status: 'idle',
 };
 
 export const getShortUrlVisitsForComparisonThunk = createVisitsComparisonAsyncThunk({
@@ -32,7 +28,7 @@ export const getShortUrlVisitsForComparisonThunk = createVisitsComparisonAsyncTh
 
     return Object.fromEntries(loaderEntries);
   },
-  shouldCancel: (getState) => getState().shortUrlVisitsComparison.cancelLoad,
+  shouldCancel: (getState) => getState().shortUrlVisitsComparison.status === 'canceled',
 });
 
 export const {
@@ -40,8 +36,7 @@ export const {
   cancelGetVisits: cancelGetShortUrlVisitsComparison,
 } = createVisitsComparisonReducer({
   name: REDUCER_PREFIX,
-  initialState,
-  // @ts-expect-error TODO Fix type inference
+  initialState: initialState as VisitsComparisonInfo,
   asyncThunk: getShortUrlVisitsForComparisonThunk,
   filterCreatedVisitsForGroup: ({ groupKey, params }, createdVisits) => filterCreatedVisitsByShortUrl(
     createdVisits,

--- a/src/visits/visits-comparison/reducers/tagVisitsComparison.ts
+++ b/src/visits/visits-comparison/reducers/tagVisitsComparison.ts
@@ -13,11 +13,7 @@ const REDUCER_PREFIX = 'shlink/tagVisitsComparison';
 export type LoadTagVisitsForComparison = LoadVisitsForComparison & { tags: string[]; };
 
 const initialState: VisitsComparisonInfo = {
-  visitsGroups: {},
-  loading: false,
-  cancelLoad: false,
-  errorData: null,
-  progress: null,
+  status: 'idle',
 };
 
 export const getTagVisitsForComparisonThunk = createVisitsComparisonAsyncThunk({
@@ -31,7 +27,7 @@ export const getTagVisitsForComparisonThunk = createVisitsComparisonAsyncThunk({
 
     return Object.fromEntries(loaderEntries);
   },
-  shouldCancel: (getState) => getState().tagVisitsComparison.cancelLoad,
+  shouldCancel: (getState) => getState().tagVisitsComparison.status === 'canceled',
 });
 
 export const {
@@ -39,8 +35,7 @@ export const {
   cancelGetVisits: cancelGetTagVisitsForComparison,
 } = createVisitsComparisonReducer({
   name: REDUCER_PREFIX,
-  initialState,
-  // @ts-expect-error TODO Fix type inference
+  initialState: initialState as VisitsComparisonInfo,
   asyncThunk: getTagVisitsForComparisonThunk,
   filterCreatedVisitsForGroup: ({ groupKey: tag, params }, createdVisits) => filterCreatedVisitsByTag(
     createdVisits,

--- a/src/visits/visits-comparison/reducers/types.ts
+++ b/src/visits/visits-comparison/reducers/types.ts
@@ -11,4 +11,6 @@ export type VisitsForComparisonLoaded = {
   params?: VisitsParams;
 };
 
-export type VisitsComparisonInfo = VisitsLoadingInfo & VisitsForComparisonLoaded;
+export type VisitsComparisonInfo = VisitsLoadingInfo | (VisitsForComparisonLoaded & {
+  status: 'loaded';
+});

--- a/test/visits/TagVisitsHeader.test.tsx
+++ b/test/visits/TagVisitsHeader.test.tsx
@@ -7,7 +7,8 @@ import { checkAccessibility } from '../__helpers__/accessibility';
 import { colorGeneratorMock } from '../utils/services/__mocks__/ColorGenerator.mock';
 
 describe('<TagVisitsHeader />', () => {
-  const tagVisits = fromPartial<TagVisits>({
+  const tagVisits = fromPartial<Extract<TagVisits, { status: 'loaded' }>>({
+    status: 'loaded',
     tag: 'foo',
     visits: [{}, {}, {}, {}],
   });

--- a/test/visits/VisitsStats.test.tsx
+++ b/test/visits/VisitsStats.test.tsx
@@ -49,9 +49,7 @@ describe('<VisitsStats />', () => {
                 <VisitsStats
                   getVisits={getVisitsMock}
                   visitsInfo={fromPartial({
-                    loading: false,
-                    errorData: null,
-                    progress: null,
+                    status: 'loaded',
                     visits: [],
                     ...visitsInfo,
                   })}
@@ -72,7 +70,7 @@ describe('<VisitsStats />', () => {
 
   it('renders a preloader when visits are loading', () => {
     setUp({
-      visitsInfo: { loading: true, progress: null },
+      visitsInfo: { status: 'loading', progress: null },
     });
 
     expect(screen.getByText('Loading...')).toBeInTheDocument();
@@ -81,7 +79,7 @@ describe('<VisitsStats />', () => {
 
   it('renders a warning and progress bar when loading large amounts of visits', () => {
     setUp({
-      visitsInfo: { loading: true, progress: 25 },
+      visitsInfo: { status: 'loading', progress: 25 },
     });
 
     expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
@@ -91,7 +89,7 @@ describe('<VisitsStats />', () => {
 
   it('renders an error message when visits could not be loaded', () => {
     setUp({
-      visitsInfo: { errorData: fromPartial({ }) },
+      visitsInfo: { status: 'error', error: fromPartial({}) },
     });
     expect(screen.getByText('An error occurred while loading visits :(')).toBeInTheDocument();
   });

--- a/test/visits/visits-comparison/DomainVisitsComparison.test.tsx
+++ b/test/visits/visits-comparison/DomainVisitsComparison.test.tsx
@@ -39,7 +39,7 @@ describe('<DomainVisitsComparison />', () => {
 
   it('cancels loading visits when unmounted', async () => {
     const { store } = await setUp();
-    const isCanceled = () => store.getState().domainVisitsComparison.cancelLoad;
+    const isCanceled = () => store.getState().domainVisitsComparison.status === 'canceled';
 
     expect(isCanceled()).toBe(false);
     cleanup();

--- a/test/visits/visits-comparison/ShortUrlVisitsComparison.test.tsx
+++ b/test/visits/visits-comparison/ShortUrlVisitsComparison.test.tsx
@@ -51,7 +51,7 @@ describe('<ShortUrlVisitsComparison />', () => {
 
   it('cancels loading visits when unmounted', async () => {
     const { store } = await setUp();
-    const isCanceled = () => store.getState().shortUrlVisitsComparison.cancelLoad;
+    const isCanceled = () => store.getState().shortUrlVisitsComparison.status === 'canceled';
 
     expect(isCanceled()).toBe(false);
     cleanup();

--- a/test/visits/visits-comparison/TagVisitsComparison.test.tsx
+++ b/test/visits/visits-comparison/TagVisitsComparison.test.tsx
@@ -40,7 +40,7 @@ describe('<TagVisitsComparison />', () => {
 
   it('cancels loading visits when unmounted', async () => {
     const { store } = await setUp();
-    const isCanceled = () => store.getState().tagVisitsComparison.cancelLoad;
+    const isCanceled = () => store.getState().tagVisitsComparison.status === 'canceled';
 
     expect(isCanceled()).toBe(false);
     cleanup();

--- a/test/visits/visits-comparison/VisitsComparison.test.tsx
+++ b/test/visits/visits-comparison/VisitsComparison.test.tsx
@@ -24,7 +24,7 @@ describe('<VisitsComparison />', () => {
         title="Comparing visits"
         getVisitsForComparison={getVisitsForComparison}
         cancelGetVisitsComparison={cancelGetVisitsComparison}
-        visitsComparisonInfo={fromPartial({ loading, visitsGroups, progress: null })}
+        visitsComparisonInfo={loading ? { status: 'loading', progress: null } : { status: 'loaded', visitsGroups }}
       />
     </MemoryRouter>,
   );


### PR DESCRIPTION
Part of https://github.com/shlinkio/shlink-web-component/issues/874

Replace the multiple boolean flags that determine the status of the visits and visits comparison reducers, with a single status discriminator prop that is less error prone and easier to reason about.

### TODO

- [x] Fix cancelling visits loading.
    **EDIT**: This stopped working because of a race condition in which status is set to canceled, but in-flight requests end up setting it back to loading. Previously, loading and canceled statuses were handled by two different flags, which incidentally worked around this race condition.