### PR TITLE
Fix incorrect colSpan calculated in visits table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * *Nothing*
 
 ### Fixed
-* *Nothing*
+* [#1024](https://github.com/shlinkio/shlink-web-component/issues/1024) Fix incorrect colSpan calculated in visits table depending on what columns have been enabled.
 
 
 ## [0.19.1] - 2026-06-24

--- a/src/visits/VisitsTable.tsx
+++ b/src/visits/VisitsTable.tsx
@@ -109,8 +109,14 @@ export const VisitsTable = ({ visits, selectedVisits = [], setSelectedVisits }: 
 
     return paginator.visitsGroups.length === 0 || !!paginator.visitsGroups[page - 1]?.[0]?.visitedUrl;
   }, [columns.visitedUrl, page, paginator.visitsGroups]);
-  // TODO Fix this value now that columns can be customized
-  const fullSizeColSpan = 6 + Number(showVisitedUrl) + (columns.userAgent ? 1 : 2);
+  const fullSizeColSpan = useMemo(() => {
+    // Whether visitedUrl is displayed or not is computed separately, so we don't want to count that column here
+    const visibleColumns = Object.entries(columns).filter(
+      ([col, isEnabled]) => col !== ('visitedUrl' satisfies VisitsColumn) && isEnabled,
+    );
+    // Add one, as the first column is always visible
+    return 1 + Number(showVisitedUrl) + visibleColumns.length;
+  }, [columns, showVisitedUrl]);
   const hasVisits = paginator.total > 0;
 
   const orderByColumn = (field: OrderableFields) =>


### PR DESCRIPTION
Closes #1024 

Colspan for full-width elements was incorrectly calculated depending on what columns have been enabled.